### PR TITLE
Automatically select an appropriate QP solver when needed

### DIFF
--- a/qfit/qfit.py
+++ b/qfit/qfit.py
@@ -38,7 +38,7 @@ from .clash import ClashDetector
 from .samplers import ChiRotator, CBAngleRotator, BondRotator
 from .samplers import CovalentBondRotator, GlobalRotator
 from .samplers import RotationSets, Translator
-from .solvers import QPSolver, MIQPSolver, QPSolver2, MIQPSolver2
+from .solvers import QPSolver, MIQPSolver
 from .structure import Structure, _Segment
 from .structure.residue import residue_type
 from .structure.ligand import BondOrder
@@ -276,18 +276,12 @@ class _BaseQFit:
                loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2]):
         do_qp = cardinality is threshold is None
         if do_qp:
-            if self.options.cplex:
-                solver = QPSolver(self._target, self._models)
-            else:
-                solver = QPSolver2(self._target, self._models)
+            solver = QPSolver(self._target, self._models, use_cplex=self.options.cplex)
             solver()
             if self.options.bic_threshold:
                 self._occupancies = solver.weights
         else:
-            if self.options.cplex:
-                solver = MIQPSolver(self._target, self._models)
-            else:
-                solver = MIQPSolver2(self._target, self._models)
+            solver = MIQPSolver(self._target, self._models, use_cplex=self.options.cplex)
 
             # Treshold Selection by BIC:
             if self.options.bic_threshold:

--- a/qfit/qfit.py
+++ b/qfit/qfit.py
@@ -222,10 +222,7 @@ class _BaseQFit:
 
 
     def _convert(self):
-        """Convert structures to densities and extract rnp.maximum(self._subtransformer.xmap.array,
-                   self.options.bulk_solvent_level,
-                   out=self._subtransformer.xmap.array)elevant values for
-           (MI)QP."""
+        """Convert structures to densities and extract relevant values for (MI)QP."""
         logger.info("Converting")
         logger.debug("Masking")
         self._transformer.reset(full=True)

--- a/qfit/qfit_ppiDesign.py
+++ b/qfit/qfit_ppiDesign.py
@@ -16,7 +16,6 @@ from .clash import ClashDetector
 from .samplers import ChiRotator, CBAngleRotator, BondRotator
 from .samplers import CovalentBondRotator, GlobalRotator
 from .samplers import RotationSets, Translator
-from .solvers import QPSolver, MIQPSolver, QPSolver2, MIQPSolver2
 from .structure import Structure
 from .structure.ligand import BondOrder
 from .transformer import Transformer


### PR DESCRIPTION
QPSolver, QPSolver2 and MIQPSolver, MIQPSolver2 classes present the same interface.
71b4f8d implements a pseudoclass that chooses an appropriate solver given available packages.

Without an installed pair from {CPLEX/cvxopt; osqp/miosqp}, the --help function is still able to run. This closes #27 .
The package will now fall back on an available solver if the requested solver is not available (e.g. through `--miosqp` flag).