### PR TITLE
Replace np.matrix with np.ndarray (fixes #46)

### DIFF
--- a/src/qfit/backbone.py
+++ b/src/qfit/backbone.py
@@ -139,12 +139,6 @@ def compute_jacobian(bb_coor):
     return jacobian.T
 
 
-def project_on_null_space(null_space, gradients):
-    null_space = np.asmatrix(null_space)
-    projection = null_space * null_space.T
-    return projection * gradients
-
-
 class AtomMoveFunctional:
 
     """Functional for obtaining energy and gradient to move a CB atom"""

--- a/src/qfit/backbone.py
+++ b/src/qfit/backbone.py
@@ -33,13 +33,13 @@ def adp_ellipsoid_axes(U_ij):
     """Calculate principal axes of ADP ellipsoid.
 
     Args:
-        U_ij (np.ndarray[np.float32]): square symmetric matrix of anisotropic
+        U_ij (np.ndarray[float]): square symmetric matrix of anisotropic
             displacement parameters (ADPs) in cartesian coordinates.
             In a PDB, ANISOU cards contain the parameters
                 [u_11, u_22, u_33, u_12, u_13, u_23] / 1e-4 Å^2.
 
     Returns:
-        List[np.ndarray[np.float32]]: principal axes of the anisotropic
+        List[np.ndarray[float]]: principal axes of the anisotropic
             displacement ellipsoid, from largest to smallest.
     """
     # Unscale ADP parameters to Å^2

--- a/src/qfit/backbone.py
+++ b/src/qfit/backbone.py
@@ -83,14 +83,12 @@ def compute_jacobian5d(bb_coor):
     r /= norm(r, axis=1).reshape(-1, 1)
     jacobian[::2, :3] = np.cross(r, fh_fa - N_coor)
     # Orientation constraints
-    f = np.asmatrix(fa - fh)
     dfh_dq = np.cross(r, fh - N_coor)
     dfd_dq = np.cross(r, fd - N_coor)
-    jacobian[::2, 3] = f * np.asmatrix(dfh_dq - dfd_dq).T
+    jacobian[::2, 3] = (fa - fh) @ (dfh_dq - dfd_dq).T
 
-    f = np.asmatrix(fa - faa)
     dfa_dq = np.cross(r, fa - N_coor)
-    jacobian[::2, 4] = f * np.asmatrix(dfh_dq - dfa_dq).T
+    jacobian[::2, 4] = (fa - faa) @ (dfh_dq - dfa_dq).T
 
     # C -> CA rotations
     # Relative distance constraints
@@ -98,14 +96,12 @@ def compute_jacobian5d(bb_coor):
     r /= norm(r, axis=1).reshape(-1, 1)
     jacobian[1::2, :3] = np.cross(r, fh_fa - C_coor)
     # Orientation constraints
-    f = np.asmatrix(fa - fh)
     dfh_dq = np.cross(r, fh - CA_coor)
     dfd_dq = np.cross(r, fd - CA_coor)
-    jacobian[1::2, 3] = f * np.asmatrix(dfh_dq - dfd_dq).T
+    jacobian[1::2, 3] = (fa - fh) @ (dfh_dq - dfd_dq).T
 
-    f = np.asmatrix(fa - faa)
     dfa_dq = np.cross(r, fa - CA_coor)
-    jacobian[1::2, 4] = f * np.asmatrix(dfh_dq - dfa_dq).T
+    jacobian[1::2, 4] = (fa - faa) @ (dfh_dq - dfa_dq).T
 
     return jacobian.T
 

--- a/src/qfit/backbone.py
+++ b/src/qfit/backbone.py
@@ -258,8 +258,7 @@ class NullSpaceOptimizer:
         bb_coor = self.segment._coor[self._bb_selection]
         jacobian = compute_jacobian(bb_coor)
         null_space = sp.linalg.null_space(jacobian)
-        null_space = np.asmatrix(null_space)
-        projector = np.asarray(null_space * null_space.T)
+        projector = null_space @ null_space.T
         null_space_gradients = np.dot(projector, gradients)
         self.segment.coor = self._starting_coor
         return target, null_space_gradients

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -408,18 +408,6 @@ class ZAxisAligner:
         self.forward_rotation = np.asmatrix(self._Rz) * np.asmatrix(self._Ry)
 
 
-def aa_to_rotmat(axis, angle):
-    """Axis angle to rotation matrix."""
-
-    kx, ky, kz = axis
-    K = np.asmatrix([[0, -kz, ky],
-                     [kz, 0, -kx],
-                     [-ky, kx, 0]])
-    K2 = K * K
-    R = np.identity(3) + np.sin(angle) * K + (1 - np.cos(angle)) * K2
-    return R
-
-
 class RotationSets:
 
     LOCAL = (('local_5_10.npy', 10, 5.00),

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -28,7 +28,7 @@ import os.path
 import numpy as np
 import copy
 
-from .structure.math import Rz
+from .structure.math import Rz, Ry
 
 
 class BackboneRotator:
@@ -406,15 +406,6 @@ class ZAxisAligner:
             raise ValueError("Axis is not aligned to z-axis.")
         self.backward_rotation = np.asmatrix(self._Ry).T * np.asmatrix(self._Rz).T
         self.forward_rotation = np.asmatrix(self._Rz) * np.asmatrix(self._Ry)
-
-
-def Ry(theta):
-    """Rotate along y-axis."""
-    cos_theta = np.cos(theta)
-    sin_theta = np.sin(theta)
-    return np.asarray([[ cos_theta, 0, sin_theta],
-                       [         0, 1,         0],
-                       [-sin_theta, 0, cos_theta]])
 
 
 def aa_to_rotmat(axis, angle):

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -28,7 +28,7 @@ import os.path
 import numpy as np
 import copy
 
-from .structure.math import Rz, Ry
+from .structure.math import Rz, Ry, gram_schmidt_orthonormal_zx
 
 
 class BackboneRotator:
@@ -244,19 +244,14 @@ class ChiRotator:
                     break
         selection = new_selection
 
-        # Build a coordinate frame around it using Gram-Schmidt orthogonalization
+        # Translate coordinates to center on coor[1]
         norm = np.linalg.norm
         coor = self.residue._coor[selection]
         self._origin = coor[1].copy()
         coor -= self._origin
-        zaxis = coor[2] / norm(coor[2])
-        yaxis = coor[0] - np.inner(coor[0], zaxis) * zaxis
-        yaxis /= norm(yaxis)
-        xaxis = np.cross(yaxis, zaxis)
-        self._backward = np.zeros((3, 3), float)
-        self._backward[0] = xaxis
-        self._backward[1] = yaxis
-        self._backward[2] = zaxis
+
+        # Make an orthogonal axis system based on 3 atoms
+        self._backward = gram_schmidt_orthonormal_zx(coor)
         self._forward = self._backward.T.copy()
 
         # Save the coordinates aligned along the Z-axis for fast future rotation

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -28,6 +28,8 @@ import os.path
 import numpy as np
 import copy
 
+from .structure.math import Rz
+
 
 class BackboneRotator:
 
@@ -404,15 +406,6 @@ class ZAxisAligner:
             raise ValueError("Axis is not aligned to z-axis.")
         self.backward_rotation = np.asmatrix(self._Ry).T * np.asmatrix(self._Rz).T
         self.forward_rotation = np.asmatrix(self._Rz) * np.asmatrix(self._Ry)
-
-
-def Rz(theta):
-    """Rotate along z-axis."""
-    cos_theta = np.cos(theta)
-    sin_theta = np.sin(theta)
-    return np.asarray([[cos_theta, -sin_theta, 0],
-                       [sin_theta,  cos_theta, 0],
-                       [        0,          0, 1]])
 
 
 def Ry(theta):

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -253,11 +253,11 @@ class ChiRotator:
         yaxis = coor[0] - np.inner(coor[0], zaxis) * zaxis
         yaxis /= norm(yaxis)
         xaxis = np.cross(yaxis, zaxis)
-        self._backward = np.asmatrix(np.zeros((3, 3), float))
+        self._backward = np.zeros((3, 3), float)
         self._backward[0] = xaxis
         self._backward[1] = yaxis
         self._backward[2] = zaxis
-        self._forward= self._backward.T.copy()
+        self._forward = self._backward.T.copy()
 
         # Save the coordinates aligned along the Z-axis for fast future rotation
         atoms_to_rotate = self.residue._rotamers['chi-rotate'][chi_index]
@@ -275,7 +275,7 @@ class ChiRotator:
         self._tmp = np.zeros_like(self._coor_to_rotate)
 
     def __call__(self, angle):
-        R = self._forward * Rz(np.deg2rad(angle))
+        R = self._forward @ Rz(np.deg2rad(angle))
         np.dot(self._coor_to_rotate, R.T, self._tmp)
         self._tmp += self._origin
         self.residue._coor[self._atom_selection] = self._tmp

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -250,8 +250,7 @@ class ChiRotator:
         coor = self.residue._coor[selection]
         self._origin = coor[1].copy()
         coor -= self._origin
-        zaxis = coor[2]
-        zaxis /= norm(zaxis)
+        zaxis = coor[2] / norm(coor[2])
         yaxis = coor[0] - np.inner(coor[0], zaxis) * zaxis
         yaxis /= norm(yaxis)
         xaxis = np.cross(yaxis, zaxis)

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -142,7 +142,7 @@ class GlobalRotator:
         ligand_coor = self.ligand.coor
         if self._center is None:
             self._center = ligand_coor.mean(axis=0)
-        self._coor_to_rotate = np.asmatrix(ligand_coor - self._center)
+        self._coor_to_rotate = ligand_coor - self._center
         self._intermediate = np.zeros_like(ligand_coor)
 
     def __call__(self, rotmat):

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -381,31 +381,32 @@ class BondRotator:
 
 
 class ZAxisAligner:
-
     """Find the rotation that aligns a vector to the Z-axis."""
-
     def __init__(self, axis):
         # Find angle between rotation axis and x-axis
         axis = axis / np.linalg.norm(axis[:-1])
         xaxis_angle = np.arccos(axis[0])
         if axis[1] < 0:
             xaxis_angle *= -1
+
         # Rotate around Z-axis
         self._Rz = Rz(xaxis_angle)
         axis = np.dot(self._Rz.T, axis.reshape(3, -1)).ravel()
+
         # Find angle between rotation axis and z-axis
         zaxis_angle = np.arccos(axis[2] / np.linalg.norm(axis))
         if axis[0] < 0:
             zaxis_angle *= -1
         self._Ry = Ry(zaxis_angle)
+
         # Check whether the transformation is correct.
         # Rotate around the Y-axis to align to the Z-axis.
         axis = np.dot(self._Ry.T, axis.reshape(3, -1)).ravel() / np.linalg.norm(axis)
         if not np.allclose(axis, [0, 0, 1]):
-            print(axis)
-            raise ValueError("Axis is not aligned to z-axis.")
-        self.backward_rotation = np.asmatrix(self._Ry).T * np.asmatrix(self._Rz).T
-        self.forward_rotation = np.asmatrix(self._Rz) * np.asmatrix(self._Ry)
+            raise ValueError(f"Axis {axis} is not aligned to z-axis.")
+
+        self.backward_rotation = self._Ry.T @ self._Rz.T
+        self.forward_rotation = self._Rz @ self._Ry
 
 
 class RotationSets:

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -37,11 +37,10 @@ def Rz(theta):
 
 def Rv(vector, theta):
     """Rotate along a vector."""
-    vector = vector / np.linalg.norm(vector)
-    x, y, z = vector
-    K = np.asmatrix([[ 0, -z,  y],
-                     [ z,  0, -x],
-                     [-y,  x,  0]])
+    (x, y, z) = vector / np.linalg.norm(vector)
+    K = np.array([[ 0, -z,  y],
+                  [ z,  0, -x],
+                  [-y,  x,  0]])
     rot = np.cos(theta) * np.identity(3) + np.sin(theta) * K + (1 - np.cos(theta)) * np.outer(vector, vector)
     return rot
 

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -25,31 +25,33 @@ IN THE SOFTWARE.
 
 import numpy as np
 
+
 def Rz(theta):
     """Rotate along z-axis."""
     cos_theta = np.cos(theta)
     sin_theta = np.sin(theta)
-    return np.asarray([[cos_theta, -sin_theta, 0],
-                       [sin_theta,  cos_theta, 0],
-                       [        0,          0, 1]])
+    return np.array([[cos_theta, -sin_theta, 0],
+                     [sin_theta,  cos_theta, 0],
+                     [        0,          0, 1]])
 
-def Rv(vector,theta):
-      """Rotate along a vector."""
-      vector = vector/np.linalg.norm(vector)
-      x, y, z = vector
-      K = np.asmatrix([[0, -z, y],
-                       [z, 0, -x],
-                       [-y, x, 0]])
-      rot = np.cos(theta) * np.identity(3) + np.sin(theta) * K + (1 - np.cos(theta))* np.outer(vector,vector)
-      return rot
+
+def Rv(vector, theta):
+    """Rotate along a vector."""
+    vector = vector / np.linalg.norm(vector)
+    x, y, z = vector
+    K = np.asmatrix([[ 0, -z,  y],
+                     [ z,  0, -x],
+                     [-y,  x,  0]])
+    rot = np.cos(theta) * np.identity(3) + np.sin(theta) * K + (1 - np.cos(theta)) * np.outer(vector, vector)
+    return rot
 
 
 def aa_to_rotmat(axis, angle):
     """Axis angle to rotation matrix."""
     kx, ky, kz = axis
-    K = np.asmatrix([[0, -kz, ky],
-                     [kz, 0, -kx],
-                     [-ky, kx, 0]])
+    K = np.asmatrix([[  0, -kz,  ky],
+                     [ kz,   0, -kx],
+                     [-ky,  kx,   0]])
     K2 = K * K
     R = np.identity(3) + np.sin(angle) * K + (1 - np.cos(angle)) * K2
     return R
@@ -57,7 +59,6 @@ def aa_to_rotmat(axis, angle):
 
 def dihedral_angle(coor):
     """Calculate dihedral angle starting from four points."""
-
     b1 = coor[0] - coor[1]
     b2 = coor[3] - coor[2]
     b3 = coor[2] - coor[1]
@@ -70,6 +71,7 @@ def dihedral_angle(coor):
     sinv = norm(m1) / normfactor
     cosv = np.inner(n1, n2) / normfactor
     angle = np.rad2deg(np.arctan2(sinv, cosv))
+
     # Check sign of angle
     u = np.cross(n1, n2)
     if np.inner(u, b3) < 0:

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -35,6 +35,15 @@ def Rz(theta):
                      [        0,          0, 1]])
 
 
+def Ry(theta):
+    """Rotate along y-axis."""
+    cos_theta = np.cos(theta)
+    sin_theta = np.sin(theta)
+    return np.array([[ cos_theta, 0, sin_theta],
+                     [         0, 1,         0],
+                     [-sin_theta, 0, cos_theta]])
+
+
 def Rv(vector, theta):
     """Rotate along a vector."""
     (x, y, z) = vector / np.linalg.norm(vector)

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -49,10 +49,10 @@ def Rv(vector, theta):
 def aa_to_rotmat(axis, angle):
     """Axis angle to rotation matrix."""
     kx, ky, kz = axis
-    K = np.asmatrix([[  0, -kz,  ky],
-                     [ kz,   0, -kx],
-                     [-ky,  kx,   0]])
-    K2 = K * K
+    K = np.array([[  0, -kz,  ky],
+                  [ kz,   0, -kx],
+                  [-ky,  kx,   0]])
+    K2 = K @ K
     R = np.identity(3) + np.sin(angle) * K + (1 - np.cos(angle)) * K2
     return R
 

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -26,6 +26,27 @@ IN THE SOFTWARE.
 import numpy as np
 
 
+def gram_schmidt_orthonormal_zx(coords):
+    """Create an orthonormal basis from atom vectors z & x.
+
+    This function preserves the direction of the z atom-vector.
+    This is based off the Gram-Schmidt process.
+
+    Args:
+        coords (np.ndarray[float]): A nx3 matrix of row-vectors,
+            with each row containing the position of an atom.
+
+    Returns:
+        np.ndarray[float]: A 3x3 orthonormal set of row-vectors,
+            where the z-axis is parallel to the input z-atom vector.
+    """
+    zaxis = coords[2] / np.linalg.norm(coords[2])
+    yaxis = coords[0] - np.inner(coords[0], zaxis) * zaxis
+    yaxis /= np.linalg.norm(yaxis)
+    xaxis = np.cross(yaxis, zaxis)
+    return np.vstack((xaxis, yaxis, zaxis))
+
+
 def Rz(theta):
     """Create a rotation matrix for rotating about z-axis.
 

--- a/src/qfit/structure/math.py
+++ b/src/qfit/structure/math.py
@@ -27,7 +27,14 @@ import numpy as np
 
 
 def Rz(theta):
-    """Rotate along z-axis."""
+    """Create a rotation matrix for rotating about z-axis.
+
+    Args:
+        theta (float): Angle of rotation in radians.
+
+    Returns:
+         np.ndarray[float]: A 3x3 rotation matrix for rotation about z.
+    """
     cos_theta = np.cos(theta)
     sin_theta = np.sin(theta)
     return np.array([[cos_theta, -sin_theta, 0],
@@ -36,7 +43,14 @@ def Rz(theta):
 
 
 def Ry(theta):
-    """Rotate along y-axis."""
+    """Create a rotation matrix for rotating about y-axis.
+
+    Args:
+        theta (float): Angle of rotation in radians.
+
+    Returns:
+         np.ndarray[float]: A 3x3 rotation matrix for rotation about y.
+    """
     cos_theta = np.cos(theta)
     sin_theta = np.sin(theta)
     return np.array([[ cos_theta, 0, sin_theta],
@@ -45,7 +59,15 @@ def Ry(theta):
 
 
 def Rv(vector, theta):
-    """Rotate along a vector."""
+    """Create a rotation matrix for rotating about a vector.
+
+    Args:
+        vector (np.ndarray[np.float]): A (3,) vector about which to rotate.
+        theta (float): Angle of rotation in radians.
+
+    Returns:
+         np.ndarray[float]: A 3x3 rotation matrix for rotation about z.
+    """
     (x, y, z) = vector / np.linalg.norm(vector)
     K = np.array([[ 0, -z,  y],
                   [ z,  0, -x],
@@ -55,7 +77,15 @@ def Rv(vector, theta):
 
 
 def aa_to_rotmat(axis, angle):
-    """Axis angle to rotation matrix."""
+    """Create a rotation matrix for a given Euler axis, angle rotation.
+
+    Args:
+        axis (np.ndarray[np.float]): A (3,) vector about which to rotate.
+        theta (float): Angle of rotation in radians.
+
+    Returns:
+         np.ndarray[float]: A 3x3 rotation matrix for rotation about axis.
+    """
     kx, ky, kz = axis
     K = np.array([[  0, -kz,  ky],
                   [ kz,   0, -kx],

--- a/src/qfit/structure/residue.py
+++ b/src/qfit/structure/residue.py
@@ -183,8 +183,7 @@ class _RotamerResidue(_BaseResidue):
         coor -= origin
 
         # Make an orthogonal axis system based on 3 atoms
-        zaxis = coor[2]
-        zaxis /= np.linalg.norm(zaxis)
+        zaxis = coor[2] / np.linalg.norm(coor[2])
         yaxis = coor[0] - np.inner(coor[0], zaxis) * zaxis
         yaxis /= np.linalg.norm(yaxis)
         xaxis = np.cross(yaxis, zaxis)

--- a/src/qfit/structure/residue.py
+++ b/src/qfit/structure/residue.py
@@ -204,12 +204,11 @@ class _RotamerResidue(_BaseResidue):
         # Create transformation matrix
         angle = np.deg2rad(value - self.get_chi(chi_index))
         rotation = Rz(angle)
-        R = forward @ rotation
+        R = forward @ rotation @ backward
 
         # Apply transformation
         coor_to_rotate = self._coor[selection]
         coor_to_rotate -= origin
-        coor_to_rotate = np.dot(coor_to_rotate, forward)
         coor_to_rotate = np.dot(coor_to_rotate, R.T)
         coor_to_rotate += origin
         self._coor[selection] = coor_to_rotate

--- a/src/qfit/structure/residue.py
+++ b/src/qfit/structure/residue.py
@@ -178,16 +178,14 @@ class _RotamerResidue(_BaseResidue):
     def set_chi(self, chi_index, value, covalent=None, length=None):
         atoms = self._rotamers['chi'][chi_index]
         selection = self.select('name', atoms)
+
+        # Translate coordinates to center on coor[1]
         coor = self._coor[selection]
         origin = coor[1].copy()
         coor -= origin
 
         # Make an orthogonal axis system based on 3 atoms
-        zaxis = coor[2] / np.linalg.norm(coor[2])
-        yaxis = coor[0] - np.inner(coor[0], zaxis) * zaxis
-        yaxis /= np.linalg.norm(yaxis)
-        xaxis = np.cross(yaxis, zaxis)
-        backward = np.vstack((xaxis, yaxis, zaxis))
+        backward = gram_schmidt_orthonormal_zx(coor)
         forward = backward.T
 
         # Complete selection to be rotated

--- a/src/qfit/structure/residue.py
+++ b/src/qfit/structure/residue.py
@@ -200,11 +200,19 @@ class _RotamerResidue(_BaseResidue):
             atoms_to_rotate2 = self.name[length:]
             selection2 = self.select('name', atoms_to_rotate2)
             selection = np.array(list(selection) + list(selection2), dtype=int)
-        coor_to_rotate = np.dot(self._coor[selection] - origin, backward.T)
-        rotation = Rz(np.deg2rad(value - self.get_chi(chi_index)))
 
+        # Create transformation matrix
+        angle = np.deg2rad(value - self.get_chi(chi_index))
+        rotation = Rz(angle)
         R = forward @ rotation
-        self._coor[selection] = coor_to_rotate.dot(R.T) + origin
+
+        # Apply transformation
+        coor_to_rotate = self._coor[selection]
+        coor_to_rotate -= origin
+        coor_to_rotate = np.dot(coor_to_rotate, forward)
+        coor_to_rotate = np.dot(coor_to_rotate, R.T)
+        coor_to_rotate += origin
+        self._coor[selection] = coor_to_rotate
 
     def print_residue(self):
         for atom, coor, element, b, q in zip(

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -839,10 +839,12 @@ class _Segment(_BaseStructure):
         selection = np.concatenate(selection)
 
         # Make an orthogonal axis system based on 3 atoms
+        # TODO: Use .math.gram_schmidt_orthonormal_zx (or something similar)
+        #       Note that here, the axes are 1→2, 2→1, 0=1×2.
+        origin = system_coor[0].copy()
         CA = residue.extract('name', 'CA').coor[0]
         C = residue.extract('name', 'C').coor[0]
         O = residue.extract('name', 'O').coor[0]
-        origin = system_coor[0].copy()
         system_coor = np.vstack((CA, C, O))
         system_coor -= origin
         zaxis = system_coor[1] / np.linalg.norm(system_coor[1])

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -845,8 +845,7 @@ class _Segment(_BaseStructure):
         origin = system_coor[0].copy()
         system_coor = np.vstack((CA, C, O))
         system_coor -= origin
-        zaxis = system_coor[1]
-        zaxis /= np.linalg.norm(zaxis)
+        zaxis = system_coor[1] / np.linalg.norm(system_coor[1])
         yaxis = system_coor[2] - np.inner(system_coor[2], zaxis) * zaxis
         yaxis /= np.linalg.norm(yaxis)
         xaxis = np.cross(yaxis, zaxis)


### PR DESCRIPTION
numpy has deprecated the np.matrix class.

The most significant advantage of np.matrix is easy access to matrix multiplication.
As of py3.5, the matmul infix operator (@) has been available to do this with np.ndarrays.

We are getting DeprecationWarnings bubbling up from np.matrix.
This is because we do rotations a lot (and so matrix-multiply by rotation matrices), and because we use matrix operations in the 5D Jacobian calculations.

This PR will eliminate sources of the deprecated np.matrix type in qfit, using the 
It also chases down all locations where matmul was 'implied' through one of the objects being a np.matrix type, and makes this matmul operation explicit.