### PR TITLE
Improve logging infrastructure

### DIFF
--- a/src/qfit/__init__.py
+++ b/src/qfit/__init__.py
@@ -23,6 +23,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 '''
 
+import logging
+
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitCovalentLigand, QFitCovalentLigandOptions
 from .qfit import QFitLigand, QFitLigandOptions
@@ -33,3 +35,6 @@ from .transformer import Transformer
 from .volume import EMMap, XMap
 from .ElecDenRadii import ElectronDensityRadiusTable, ResolutionBins
 from .BondLengths import BondLengthTable
+
+
+LOGGER = logging.getLogger(__name__)

--- a/src/qfit/b_factor.py
+++ b/src/qfit/b_factor.py
@@ -11,7 +11,6 @@ b_factor $pdb.mtz $pdb.pdb --pdb $pdb
 import pkg_resources  # part of setuptools
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitSegment, QFitSegmentOptions
-from .qfit import print_run_info
 from .qfit_protein import QFitProteinOptions, QFitProtein
 import os.path
 import os

--- a/src/qfit/logtools.py
+++ b/src/qfit/logtools.py
@@ -88,3 +88,69 @@ def log_run_info(options, logger):
     for key in vars(options).keys():
         logger.info(f"{key}: {getattr(options, key)}")
     logger.info(f"============================\n")
+
+
+def poolworker_setup_logging(logqueue):
+    """Attaches a QueueHandler to the RootLogger of a subprocess.
+
+    The MainProcess of qFit should handle all the logging. In particular, we
+    attach a ConsoleHandler and FileHandler to the `qfit` module logger (see
+    `setup_logging` above).
+
+    However, subprocesses (i.e. PoolWorkers) do not have any access to the
+    logger objects in MainProcess, and so their logs are never handled and
+    aren't presented to the user.
+
+    Each PoolWorker process has an independent RootLogger.
+    This function attaches a QueueHandler to a PoolWorker's RootLogger, which
+    handles all log records within the PoolWorker by putting them into
+    the multiprocessing.Queue `logqueue`.
+
+    Ideally, there'll be a QueueListener on MainProcess that will shuffle this
+    Queue into the MainProcess logging system.
+
+    Args:
+        logqueue (multiprocessing.Queue): A queue to log messages to.
+    """
+    # Only if we are in a PoolWorker
+    if mp.current_process().name != 'MainProcess':
+        # Get the RootLogger of this Process
+        process_ROOTLOGGER = logging.getLogger()
+        process_ROOTLOGGER.level = logging.NOTSET
+        # If we haven't already set it up, attach a QueueHandler
+        if len(process_ROOTLOGGER.handlers) == 0:
+            queue_handler = logging.handlers.QueueHandler(logqueue)
+            process_ROOTLOGGER.addHandler(queue_handler)
+
+
+class QueueListener(threading.Thread):
+    """A Thread that handles LogRecords from a Queue.
+
+    Independent subprocesses (e.g. PoolWorkers) will place LogRecords onto a
+    Queue. This QueueListener will process these LogRecords, and handle them
+    in MainProcess. This way, we provide a way for subprocesses to access the
+    logging Handlers in MainProcess.
+
+    Run QueueListener.stop() to finish the process before QueueListener.join().
+
+    Args:
+        queue (multiprocessing.Queue): The queue that should be listened to.
+            Contains log messages from other Processes which are to be
+            'handled' here in MainProcess.
+    """
+    def __init__(self, queue, **kwargs):
+        super().__init__(**kwargs)
+        self._queue = queue
+        self._terminator = threading.Event()
+
+    def stop(self):
+        self._terminator.set()
+
+    def run(self):
+        """Processes messages in queue via logging."""
+        while not self._terminator.is_set():
+            while not self._queue.empty():
+                record = self._queue.get()
+                logger = logging.getLogger(record.name)
+                logger.handle(record)
+            time.sleep(0.5)

--- a/src/qfit/logtools.py
+++ b/src/qfit/logtools.py
@@ -1,0 +1,90 @@
+'''
+Excited States software: qFit 3.0
+
+Contributors: Saulo H. P. de Oliveira, Gydo van Zundert, and Henry van den Bedem.
+Contact: vdbedem@stanford.edu
+
+Copyright (C) 2009-2019 Stanford University
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+This entire text, including the above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+'''
+
+import sys
+import os
+import pkg_resources
+import time
+import logging
+import logging.handlers
+import multiprocessing as mp
+import threading
+
+from . import LOGGER as MODULELOGGER
+
+
+def setup_logging(options, filename="qfit.log"):
+    """Attaches logging handlers to module logger with appropriate loglevels.
+
+    Args:
+        options (_BaseQFitOptions): A QFitOptions object.
+    """
+    # Determine logger levels for handlers
+    if options.debug:
+        file_log_level = logging.DEBUG
+        console_log_level = logging.DEBUG
+    elif options.verbose:
+        file_log_level = logging.INFO
+        console_log_level = logging.INFO
+    else:
+        file_log_level = logging.INFO
+        console_log_level = logging.WARNING
+
+    # Create formatter
+    log_formatter = logging.Formatter('%(asctime)s [%(levelname)-8s] %(processName)-10s %(name)s : %(message)s')
+
+    # Create & attach console loghandler
+    console_loghandler = logging.StreamHandler(stream=sys.stdout)
+    console_loghandler.setLevel(console_log_level)
+    console_loghandler.setFormatter(log_formatter)
+    MODULELOGGER.addHandler(console_loghandler)
+
+    # Create & attach file loghandler
+    logging_fname = os.path.join(options.directory, filename)
+    file_loghandler = logging.FileHandler(filename=logging_fname, mode='a')
+    file_loghandler.setLevel(file_log_level)
+    file_loghandler.setFormatter(log_formatter)
+    MODULELOGGER.addHandler(file_loghandler)
+
+    # Drop level of the modulelogger, so things get passed to handlers?
+    MODULELOGGER.setLevel(min(file_log_level, console_log_level))
+
+
+def log_run_info(options, logger):
+    """Prints run info to a logger object.
+
+    Args:
+        options (_BaseQFitOptions): A QFitOptions object for this run.
+        logger (logging.Logger): The logger that will log the messages.
+    """
+    version = pkg_resources.require("qfit")[0].version
+    cmd = " ".join(sys.argv)
+    logger.info(f"===== qFit version: {version} =====")
+    logger.info(time.strftime("%c %Z"))
+    logger.info(f"{cmd}")
+    logger.info(f"===== qFit parameters: =====")
+    for key in vars(options).keys():
+        logger.info(f"{key}: {getattr(options, key)}")
+    logger.info(f"============================\n")

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -31,7 +31,6 @@ import copy
 from string import ascii_uppercase
 import subprocess
 import numpy as np
-import pkg_resources  # part of setuptools
 
 from .backbone import NullSpaceOptimizer, adp_ellipsoid_axes
 from .clash import ClashDetector
@@ -2022,13 +2021,10 @@ class QFitCovalentLigand(_BaseQFit):
 
 
 def print_run_info(args):
-    runinfo_fname = os.path.join(args.directory, 'qfit_run_info.log')
-    with open(runinfo_fname, 'w') as f:
-        version = pkg_resources.require("qfit")[0].version
-        f.write(f'===== qFit version: {version} =====\n\n')
-        cmd = ' '.join(argv)
-        f.write(f'{cmd}\n\n')
-        f.write(f'===== qFit parameters: =====\n\n')
-        for arg in vars(args):
-            f.write(f'{arg[0].upper()}{arg[1:]}: {getattr(args, arg)}\n')
-        f.close()
+    """TO BE DELETED.
+
+    Used to print sys.argv and other parameters (from args) to a file.
+    No longer needed, since this has been moved to
+        `logtools.log_run_info(options, logger)`.
+    """
+    pass

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -2018,13 +2018,3 @@ class QFitCovalentLigand(_BaseQFit):
             conformer.b = b
             conformers.append(conformer)
         return conformers
-
-
-def print_run_info(args):
-    """TO BE DELETED.
-
-    Used to print sys.argv and other parameters (from args) to a file.
-    No longer needed, since this has been moved to
-        `logtools.log_run_info(options, logger)`.
-    """
-    pass

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -57,6 +57,7 @@ class _BaseQFitOptions:
     def __init__(self):
         # General options
         self.directory = '.'
+        self.verbose = False
         self.debug = False
         self.label = None
         self.map = None

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -33,9 +33,9 @@ import sys
 import time
 import numpy as np
 from string import ascii_uppercase
-from .qfit import print_run_info
 from . import MapScaler, Structure, XMap, _Ligand
 from . import QFitLigand, QFitLigandOptions
+from .logtools import setup_logging, log_run_info
 
 logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -232,27 +232,17 @@ def main():
         pdb_id = args.pdb + '_'
     else:
        pdb_id = ''
-    print_run_info(args)
     time0 = time.time()
 
-    # Setup logger
-    logging_fname = os.path.join(args.directory, 'qfit_ligand.log') #combine this with qfit log file
-    if args.debug:
-        level = logging.DEBUG
-    else:
-        level = logging.INFO
-    logging.basicConfig(filename=logging_fname, level=level)
-    logger.info(' '.join(sys.argv))
-    logger.info(time.strftime("%c %Z"))
-    if args.verbose:
-        console_out = logging.StreamHandler(stream=sys.stdout)
-        console_out.setLevel(level)
-        logging.getLogger('').addHandler(console_out)
-
+    # Apply the arguments to options
     options = QFitLigandOptions()
     options.apply_command_args(args)
     print(args.selection)
     print(options.selection)
+
+    # Setup logger
+    setup_logging(options=options, filename="qfit_ligand.log")
+    log_run_info(options, logger)
 
     qfit_ligand = prepare_qfit_ligand(options)
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -339,9 +339,6 @@ class QFitProtein:
             parent=residue.parent,
         )
 
-        # We don't want this subprocess to be verbose
-        options.verbose = False
-
         # Build the residue results directory
         chainid = residue.chain[0]
         resi, icode = residue.id

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -26,7 +26,6 @@ import gc
 import pkg_resources  # part of setuptools
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitSegment, QFitSegmentOptions
-from .qfit import print_run_info
 import multiprocessing as mp
 from tqdm import tqdm
 import os.path
@@ -35,10 +34,14 @@ import sys
 import time
 import copy
 import argparse
+import logging
+from .logtools import setup_logging, log_run_info
 from math import ceil
 from . import MapScaler, Structure, XMap
 from .structure.rotamers import ROTAMERS
 
+
+logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
 
 
@@ -446,12 +449,17 @@ def main():
         os.mkdir(args.directory)
     except OSError:
         pass
-    print_run_info(args)
+
+    # Apply the arguments to options
     options = QFitProteinOptions()
     options.apply_command_args(args)
 
+    # Setup logger
+    setup_logging(options=options)
+    log_run_info(options, logger)
+
     # Build a QFitProtein job
-    qfit = prepare_qfit_protein(options)
+    qfit = prepare_qfit_protein(options=options)
 
     # Run the QFitProtein job
     time0 = time.time()

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -33,7 +33,7 @@ import sys
 import time
 import numpy as np
 from string import ascii_uppercase
-from .qfit import print_run_info
+from .logtools import setup_logging, log_run_info
 from . import MapScaler, Structure, XMap
 from . import QFitRotamericResidue, QFitRotamericResidueOptions
 from .structure import residue_type
@@ -149,9 +149,16 @@ def main():
         os.makedirs(args.directory)
     except OSError:
         pass
-    print_run_info(args)
     time0 = time.time()
-    
+
+    # Apply the arguments to options
+    options = QFitRotamericResidueOptions()
+    options.apply_command_args(args)
+
+    # Setup logger
+    setup_logging(options=options)
+    log_run_info(options, logger)
+
     #Skip over if everything is completed
     #try:
     print(args.directory)
@@ -234,8 +241,6 @@ def main():
     residue_name = residue.resn[0]
     logger.info(f"Residue: {residue_name} {chainid}_{resi}{icode}")
 
-    options = QFitRotamericResidueOptions()
-    options.apply_command_args(args)
     xmap = XMap.fromfile(args.map, resolution=args.resolution, label=args.label)
     xmap = xmap.canonical_unit_cell()
     if args.scale:

--- a/src/qfit/qfit_segment.py
+++ b/src/qfit/qfit_segment.py
@@ -26,12 +26,15 @@ IN THE SOFTWARE.
 import os.path
 import os
 import time
+import logger
 from argparse import ArgumentParser
 
 from . import MapScaler, Structure, XMap
 from .qfit import QFitSegment, QFitSegmentOptions
-from .qfit import print_run_info
+from .logtools import setup_logging, log_run_info
 
+
+logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
 
 
@@ -109,12 +112,16 @@ def main():
         os.makedirs(args.directory)
     except OSError:
         pass
-    print_run_info(args)
 
     time0 = time.time()
 
+    # Apply the arguments to options
     options = QFitSegmentOptions()
     options = options.apply_command_args(args)
+
+    # Setup logger
+    setup_logging(options=options)
+    log_run_info(options, logger)
 
     structure = Structure.fromfile(args.structure)#.reorder()
     if not args.hydro:

--- a/src/qfit/subset_structure_AH.py
+++ b/src/qfit/subset_structure_AH.py
@@ -10,7 +10,6 @@ Contact: vdbedem@stanford.edu
 import pkg_resources  # part of setuptools
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitSegment, QFitSegmentOptions
-from .qfit import print_run_info
 from .qfit_protein import QFitProteinOptions, QFitProtein
 import multiprocessing as mp
 import os.path

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -52,6 +52,7 @@ class TestQFitLigand:
         # Apply the arguments to options
         options = QFitLigandOptions()
         options.apply_command_args(args)
+        options.debug = True  # For debugging in tests
 
         # Setup logger
         setup_logging(options=options, filename="qfit_ligand.log")

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -1,13 +1,20 @@
 import pytest
 import os
 import multiprocessing as mp
+import logging
 
 from qfit.qfit_ligand import (
     QFitLigandOptions,
     prepare_qfit_ligand,
     build_argparser,
-    print_run_info
 )
+from qfit.logtools import (
+    setup_logging,
+    log_run_info,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 def setup_module(module):
@@ -42,9 +49,13 @@ class TestQFitLigand:
         except OSError:
             pass
 
-        print_run_info(args)
+        # Apply the arguments to options
         options = QFitLigandOptions()
         options.apply_command_args(args)
+
+        # Setup logger
+        setup_logging(options=options, filename="qfit_ligand.log")
+        log_run_info(options, logger)
 
         # Build a QFitLigand job
         qfit_ligand = prepare_qfit_ligand(options)

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -1,13 +1,20 @@
 import pytest
 import os
+import logging
 import multiprocessing as mp
 
 from qfit.qfit_protein import (
     QFitProteinOptions,
     build_argparser,
     prepare_qfit_protein,
-    print_run_info,
 )
+from qfit.logtools import (
+    setup_logging,
+    log_run_info,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 def setup_module(module):
@@ -44,9 +51,14 @@ class TestQFitProtein:
             os.mkdir(args.directory)
         except OSError:
             pass
-        print_run_info(args)
+
+        # Apply the arguments to options
         options = QFitProteinOptions()
         options.apply_command_args(args)
+
+        # Setup logger
+        setup_logging(options=options)
+        log_run_info(options, logger)
 
         # Build a QFitProtein job
         qfit = prepare_qfit_protein(options)

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -55,6 +55,7 @@ class TestQFitProtein:
         # Apply the arguments to options
         options = QFitProteinOptions()
         options.apply_command_args(args)
+        options.debug = True  # For debugging in tests
 
         # Setup logger
         setup_logging(options=options)


### PR DESCRIPTION
This PR implements a unified logging infrastructure across the qFit packages.
Logging to the main logfile is now possible from Pool subprocesses, without race conditions.

This PR paves the way for all print() calls to be replaced with logger.debug() calls.