### PR TITLE
Fix a few typos, shorten lines, move towards PEP8

### DIFF
--- a/src/qfit/b_factor.py
+++ b/src/qfit/b_factor.py
@@ -87,7 +87,7 @@ class B_factor():
             B_factor.loc[n,'AA'] = resn_name[1]
             B_factor.loc[n,'Chain'] = resn_name[2]
             B_factor.loc[n,'Max_Bfactor'] = np.amax(b_factor)
-            B_factor.loc[n, 'Averaage_Bfactor'] = np.average(b_factor)
+            B_factor.loc[n, 'Average_Bfactor'] = np.average(b_factor)
             n+=1
         B_factor.to_csv(self.pdb + '_B_factors.csv', index=False)
 

--- a/src/qfit/helpers.py
+++ b/src/qfit/helpers.py
@@ -26,6 +26,7 @@ IN THE SOFTWARE.
 import os
 import errno
 
+
 def mkdir_p(path):
     try:
         os.makedirs(path)
@@ -37,9 +38,7 @@ def mkdir_p(path):
 
 
 class DJoiner(object):
-
     """Join filenames with a set directory."""
-
     def __init__(self, directory):
         self.directory = directory
 

--- a/src/qfit/logtools.py
+++ b/src/qfit/logtools.py
@@ -53,7 +53,8 @@ def setup_logging(options, filename="qfit.log"):
         console_log_level = logging.WARNING
 
     # Create formatter
-    log_formatter = logging.Formatter('%(asctime)s [%(levelname)-8s] %(processName)-10s %(name)s : %(message)s')
+    log_formatter = logging.Formatter('%(asctime)s [%(levelname)-8s] '
+                                      '%(processName)-10s %(name)s : %(message)s')
 
     # Create & attach console loghandler
     console_loghandler = logging.StreamHandler(stream=sys.stdout)

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -146,11 +146,13 @@ class _BaseQFit:
         self._smax = None
         self._simple = True
         self._rmask = 1.5
+
         reso = None
         if self.xmap.resolution.high is not None:
             reso = self.xmap.resolution.high
         elif options.resolution is not None:
             reso = options.resolution
+
         if reso is not None:
             self._smax = 1 / (2 * reso)
             self._simple = False
@@ -342,6 +344,7 @@ class _BaseQFit:
             ext = 'ccp4'
         else:
             ext = 'mrc'
+
         # Create maps
         # for q, coor in zip(self._occupancies, self._coor_set):
         #    self.conformer.q = q
@@ -430,6 +433,7 @@ class QFitRotamericResidue(_BaseQFit):
             # Generate CIF file of unknown ligands for refinement:
             subprocess.run(["phenix.elbow", "--do_all",
                             f"{out_root}_modified_H.pdb"])
+
             # Run the refinement protocol:
             if os.path.isfile(f'elbow.{out_root}_modified_H_pdb.all.001.cif'):
                 elbow = f'elbow.{out_root}_modified_H_pdb.all.001.cif'
@@ -448,6 +452,7 @@ class QFitRotamericResidue(_BaseQFit):
                                 "--overwrite",
                                 f'chain_{self.chain}_res_{self.resi}_adp.params',
                                 f'refinement.input.xray_data.labels=F-obs'])
+
             # Reload structure and xmap as omit map:
             structure = Structure.fromfile(f'{out_root}_modified_H_refine_001.pdb').reorder()
             if not options.hydro:
@@ -584,8 +589,10 @@ class QFitRotamericResidue(_BaseQFit):
     def run(self):
         if self.options.sample_backbone:
             self._sample_backbone()
+
         if self.options.sample_angle and self.residue.resn[0] != 'PRO' and self.residue.resn[0] != 'GLY':
             self._sample_angle()
+
         if self.residue.nchi >= 1 and self.options.sample_rotamers:
             self._sample_sidechain()
         else:
@@ -613,14 +620,17 @@ class QFitRotamericResidue(_BaseQFit):
             self._solve(threshold=self.options.threshold,
                         cardinality=self.options.cardinality)
             self._update_conformers()
+
         # Now that the conformers have been generated, the resulting
         # conformations should be examined via GoodnessOfFit:
         validator = Validator(self.xmap, self.xmap.resolution,
                               self.options.directory)
+
         if self.xmap.resolution.high < 3.0:
             cutoff = 0.7 + (self.xmap.resolution.high - 0.6) / 3.0
         else:
             cutoff = 0.5 * self.xmap.resolution.high
+
         self.validation_metrics = validator.GoodnessOfFit(self.conformer,
                                                           self._coor_set,
                                                           self._occupancies,
@@ -871,6 +881,7 @@ class QFitRotamericResidue(_BaseQFit):
             # self._write_intermediate_conformers(f"miqp_{iteration}")
             logger.info("Nconf after MIQP: {:d}".format(len(self._coor_set)))
             # print("Nconf after MIQP: {:d}".format(len(self._coor_set)))
+
             # Check if we are done
             if chi_index == self.residue.nchi:
                 break

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1040,7 +1040,8 @@ class QFitSegment(_BaseQFit):
                 segment = []
                 collapsed = multiconformer[:]
                 for multi in collapsed:
-                    multiconformers = multiconformers.combine(multi.collapse_backbone(multi.resi[0], multi.chain[0]))
+                    multiconformers = multiconformers.combine(multi.collapse_backbone(multi.resi[0],
+                                                                                      multi.chain[0]))
 
             else:
                 segment.append(multiconformer)
@@ -1050,10 +1051,12 @@ class QFitSegment(_BaseQFit):
             for path in self.find_paths(segment):
                 multiconformers = multiconformers.combine(path)
 
-        print(f'Average number of conformers after qfit_segment run: {multiconformers.average_conformers():.2f}')
+        print(f"Average number of conformers after qfit_segment run: "
+              f"{multiconformers.average_conformers():.2f}")
         multiconformers = multiconformers.reorder()
         multiconformers = multiconformers.remove_identical_conformers(self.options.rmsd_cutoff)
-        print(f'Average number of conformers after removal of identical conformers: {multiconformers.average_conformers():.2f}')
+        print(f"Average number of conformers after removal of identical conformers: "
+              f"{multiconformers.average_conformers():.2f}")
         relab_options = RelabellerOptions()
         relabeller = Relabeller(multiconformers, relab_options)
         multiconformers = relabeller.run()
@@ -1265,7 +1268,8 @@ class QFitLigand(_BaseQFit):
         self._coor_set = new_coor_set
         self._bs = new_bs
         if len(self._coor_set) < 1:
-            print(f"{self.ligand.resn[0]}: Local search {self._cluster_index}: {len(self._coor_set)} conformers")
+            print(f"{self.ligand.resn[0]}: "
+                  f"Local search {self._cluster_index}: {len(self._coor_set)} conformers")
             return
         # QP
         logger.debug("Converting densities.")
@@ -1275,7 +1279,8 @@ class QFitLigand(_BaseQFit):
         logger.debug("Updating conformers")
         self._update_conformers()
         if len(self._coor_set) < 1:
-            print(f"{self.ligand.resn[0]}: Local search QP {self._cluster_index}: {len(self._coor_set)} conformers")
+            print(f"{self.ligand.resn[0]}: "
+                  f"Local search QP {self._cluster_index}: {len(self._coor_set)} conformers")
             return
         # MIQP
         self._convert()
@@ -1369,7 +1374,8 @@ class QFitLigand(_BaseQFit):
             logger.info("Nconf: {:d}".format(len(self._coor_set)))
 
             if not self._coor_set:
-                print(f"{self.ligand.resn[0]}: DOF search cluster {self._cluster_index} iteration {iteration}: "
+                print(f"{self.ligand.resn[0]}: "
+                      f"DOF search cluster {self._cluster_index} iteration {iteration}: "
                       f"{len(self._coor_set)} conformers.")
                 return
 
@@ -1382,7 +1388,8 @@ class QFitLigand(_BaseQFit):
             self._update_conformers()
 
             if not self._coor_set:
-                print(f"{self.ligand.resn[0]}: QP search cluster {self._cluster_index} iteration {iteration}: "
+                print(f"{self.ligand.resn[0]}: "
+                      f"QP search cluster {self._cluster_index} iteration {iteration}: "
                       f"{len(self._coor_set)} conformers.")
                 return
 
@@ -1444,7 +1451,8 @@ class QFitCovalentLigand(_BaseQFit):
         elif covalent_ligand.covalent_bonds == 1:
             # Extract the information about the residue that the
             # ligand is covalently bonded to:
-            partner_chain, partner_resi, partner_icode, self.partner_atom = (covalent_ligand.covalent_partners[0])
+            partner_chain, partner_resi, \
+                partner_icode, self.partner_atom = (covalent_ligand.covalent_partners[0])
             if partner_icode:
                 self.partner_id = (int(partner_resi), partner_icode)
             else:
@@ -1692,7 +1700,8 @@ class QFitCovalentLigand(_BaseQFit):
                 else:
                     bs_atoms = self.covalent_residue._rotamers['chi-rotate'][chi_index]
                 if self.options.sample_ligand:
-                    sel_str = f"chain {self.covalent_residue.chain[0]} and resi {self.covalent_residue.resi[0]}"
+                    sel_str = f"chain {self.covalent_residue.chain[0]} " \
+                              f"and resi {self.covalent_residue.resi[0]}"
                     if self.covalent_residue.icode[0]:
                         sel_str = f"{sel_str} and icode {self.covalent_residue.icode[0]}"
                     selection = self.covalent_residue.select(sel_str)

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -186,8 +186,11 @@ class _BaseQFit:
     def _update_transformer(self, structure):
         self.conformer = structure
         self._transformer = Transformer(
-            structure, self._xmap_model, smax=self._smax, smin=self._smin,
-            simple=self._simple, scattering=self.options.scattering)
+            structure, self._xmap_model,
+            smax=self._smax, smin=self._smin,
+            simple=self._simple,
+            scattering=self.options.scattering,
+        )
         logger.debug("Initializing radial density lookup table.")
         self._transformer.initialize()
 
@@ -199,9 +202,11 @@ class _BaseQFit:
 
         # Calculate the density that we are going to subtract:
         self._subtransformer = Transformer(
-            subtract_structure,
-            self._xmap_model2, smax=self._smax, smin=self._smin,
-            simple=self._simple, scattering=self.options.scattering)
+            subtract_structure, self._xmap_model2,
+            smax=self._smax, smin=self._smin,
+            simple=self._simple,
+            scattering=self.options.scattering,
+        )
         self._subtransformer.initialize()
         self._subtransformer.reset(full=True)
         self._subtransformer.density()
@@ -571,7 +576,8 @@ class QFitRotamericResidue(_BaseQFit):
             receptor = receptor.combine(self.structure)
             self.structure.coor = starting_coor
 
-        self._cd = ClashDetector(residue, receptor, exclude=exclude,
+        self._cd = ClashDetector(residue, receptor,
+                                 exclude=exclude,
                                  scaling_factor=self.options.clash_scaling_factor)
         # receptor.tofile('clash_receptor.pdb')
 
@@ -726,7 +732,8 @@ class QFitRotamericResidue(_BaseQFit):
             sampling_window = np.arange(
                 -opt.rotamer_neighborhood,
                 opt.rotamer_neighborhood + opt.dihedral_stepsize,
-                opt.dihedral_stepsize)
+                opt.dihedral_stepsize,
+            )
         else:
             sampling_window = [0]
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -425,10 +425,9 @@ class QFitRotamericResidue(_BaseQFit):
                             f"output.file_name={out_root}_modified.pdb"])
 
             # Add hydrogens to the structure:
-            out_mod_H = open(f"{out_root}_modified_H.pdb", "w")
-            subprocess.run(["phenix.reduce", f"{out_root}_modified.pdb"],
-                            stdout=out_mod_H)
-            out_mod_H.close()
+            with open(f"{out_root}_modified_H.pdb", "w") as out_mod_H:
+                subprocess.run(["phenix.reduce", f"{out_root}_modified.pdb"],
+                                stdout=out_mod_H)
 
             # Generate CIF file of unknown ligands for refinement:
             subprocess.run(["phenix.elbow", "--do_all",

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1512,8 +1512,8 @@ class QFitCovalentLigand(_BaseQFit):
             self.covalent_residue = conformer[self.partner_id]
 
             # Initialize using the base qFit class:
-            super().__init__(self.covalent_residue, self.structure, xmap,
-                             options)
+            super().__init__(self.covalent_residue, self.structure, xmap, options)
+
             # Update the transformer:
             self._update_transformer(self.covalent_residue)
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -418,14 +418,15 @@ class QFitRotamericResidue(_BaseQFit):
             out_root = f'out_{self.chain}_{self.resi}'
             structure.tofile(f'{out_root}.pdb')
             subprocess.run(["phenix.pdbtools",
-                            f'modify.selection=\"chain {self.chain} and'
-                            f'( resseq {self.resi} and not '
-                            f'( name n or name ca or name c or name o or name cb )'
-                            f' or ( resseq {self.prv_resi} and name n) )\"',
+                            "modify.selection="
+                                f"\"chain {self.chain} and "
+                                f"( resseq {self.resi} and not "
+                                f"( name n or name ca or name c or name o or name cb ) or "
+                                f"( resseq {self.prv_resi} and name n ) )\"",
                             "modify.occupancies.set=0",
                             "stop_for_unknowns=False",
-                            f"{out_root}.pdb",
-                            f"output.file_name={out_root}_modified.pdb"])
+                           f"{out_root}.pdb",
+                           f"output.file_name={out_root}_modified.pdb"])
 
             # Add hydrogens to the structure:
             with open(f"{out_root}_modified_H.pdb", "w") as out_mod_H:
@@ -570,7 +571,7 @@ class QFitRotamericResidue(_BaseQFit):
             selection_str = f"not (resi {resi} and icode {icode} and chain {chainid})"
             receptor = self.structure.extract(selection_str)
         else:
-            sel_str = f'not (resi {resi} and chain {chainid})'
+            sel_str = f"not (resi {resi} and chain {chainid})"
             receptor = self.structure.extract(sel_str).copy()
         # Find symmetry mates of the receptor
         starting_coor = self.structure.coor.copy()
@@ -974,8 +975,8 @@ class QFitSegment(_BaseQFit):
         self._voxel_volume /= self.xmap.array.size
 
     def __call__(self):
-        print(f'Average number of conformers before qfit_segment run: '
-            f'{self.segment.average_conformers():.2f}')
+        print(f"Average number of conformers before qfit_segment run: "
+              f"{self.segment.average_conformers():.2f}")
         # Extract hetatms
         hetatms = self.segment.extract('record', "HETATM")
         # Create an empty structure:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -396,20 +396,23 @@ class QFitRotamericResidue(_BaseQFit):
             # Generate the parameter file for phenix refinement:
             labels = options.label.split(",")
             with open(f"chain_{self.chain}_res_{self.resi}_adp.params", "w") as params:
-                params.write("refinement {\n")
-                params.write("  electron_density_maps {\n")
-                params.write("    map_coefficients {\n")
-                params.write(f"      mtz_label_amplitudes = {labels[0]}\n")
-                params.write(f"      mtz_label_phases = {labels[1]}\n")
-                params.write("      map_type = 2mFo-DFc\n")
-                params.write("    }\n  }\n")
-                params.write("  refine {\n")
-                params.write("    strategy = *individual_sites *individual_adp\n")
-                params.write("    adp {\n")
-                params.write("      individual {\n")
-                params.write(f"        anisotropic = {adp}\n")
-                params.write("      }\n    }\n  }\n}\n")
-            params.close()
+                params.write("refinement {\n"
+                             "  electron_density_maps {\n"
+                             "    map_coefficients {\n"
+                            f"      mtz_label_amplitudes = {labels[0]}\n"
+                            f"      mtz_label_phases = {labels[1]}\n"
+                             "      map_type = 2mFo-DFc\n"
+                             "    }\n"
+                             "  }\n"
+                             "  refine {\n"
+                             "    strategy = *individual_sites *individual_adp\n"
+                             "    adp {\n"
+                             "      individual {\n"
+                            f"        anisotropic = {adp}\n"
+                             "      }\n"
+                             "    }\n"
+                             "  }\n"
+                             "}\n")
 
             # Set the occupancy of the side chain to zero for omit map calculation
             out_root = f'out_{self.chain}_{self.resi}'

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -177,8 +177,8 @@ class _BaseQFit:
             conformer = self.conformer.copy()
             conformer = conformer.extract(f"resi {self.conformer.resi[0]} and "
                                           f"chain {self.conformer.chain[0]}")
-            conformer.coor = coor
             conformer.q = q
+            conformer.coor = coor
             conformer.b = b
             conformers.append(conformer)
         return conformers

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1206,38 +1206,6 @@ class QFitLigand(_BaseQFit):
                     threshold=self.options.threshold)
         self._update_conformers()
 
-        '''# Validation:
-        validator = Validator(self.xmap, self.xmap.resolution,
-                              self.options.directory)
-
-        # Order conformers based on rscc
-        conformers = np.array(self.get_conformers())
-        rsccs = np.array([validator.rscc(conformer, rmask=1.5) for
-                          conformer in conformers])
-
-        mask = (rsccs >= np.max(rsccs) * 0.9)
-        conformers_filtered = conformers[mask]
-        conformers_filtered[0].zscore = float('inf')
-        multiconformer = Structure(conformers_filtered[0].data)
-        multiconformer.data['altloc'].fill('A')
-        nconformers = 1
-        self._coor_set = [conformers_filtered[0].coor]
-        self._occupancies = [conformers_filtered[0].q]
-        for conformer in conformers_filtered[1:]:
-            conformer.data['altloc'].fill(ascii_uppercase[nconformers])
-            new_multiconformer = multiconformer.combine(conformer)
-            diff = validator.fisher_z_difference(multiconformer,
-                                                 new_multiconformer,
-                                                 rmask=1.5, simple=True)
-            if diff < 0.1:
-                continue
-            multiconformer = new_multiconformer
-            conformer.zscore = diff
-            self._coor_set.append(conformer.coor)
-            self._occupancies.append(conformer.q)
-            nconformers += 1'''
-
-
     def _local_search(self):
         """Perform a local rigid body search on the cluster."""
 

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -231,7 +231,7 @@ def main():
     if not args.pdb == None:
         pdb_id = args.pdb + '_'
     else:
-       pdb_id = ''
+        pdb_id = ''
     time0 = time.time()
 
     # Apply the arguments to options
@@ -246,12 +246,10 @@ def main():
 
     qfit_ligand = prepare_qfit_ligand(options)
 
-
     time0 = time.time()
     qfit_ligand.run()
     logger.info(f"Total time: {time.time() - time0}s")
 
-    
     #POST QFIT LIGAND WRITE OUTPUT (done withint the qfit protein run command)
     conformers = qfit.get_conformers()
     nconformers = len(conformers)
@@ -271,5 +269,3 @@ def main():
     if icode:
         fname = os.path.join(options.directory, pdb_id + f'multiconformer_{chainid}_{resi}_{icode}.pdb')
     multiconformer.tofile(fname)
-
-

--- a/src/qfit/qfit_ppiDesign.py
+++ b/src/qfit/qfit_ppiDesign.py
@@ -19,7 +19,6 @@ from .samplers import RotationSets, Translator
 from .structure import Structure
 from .structure.ligand import BondOrder
 from .transformer import Transformer
-from .validator import Validator
 from .volume import XMap
 from .scaler import MapScaler
 from .relabel import RelabellerOptions, Relabeller

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -117,7 +117,8 @@ def build_argparser():
     p.add_argument("-rn", "--rotamer-neighborhood", default=60,
                    metavar="<float>", type=float,
                    help="Neighborhood of rotamer to sample in degrees.")
-    p.add_argument("--remove-conformers-below-cutoff", action="store_true", dest="remove_conformers_below_cutoff",
+    p.add_argument("--remove-conformers-below-cutoff", action="store_true",
+                   dest="remove_conformers_below_cutoff",
                    help=("Remove conformers during sampling that have atoms "
                          "with no density support, i.e. atoms are positioned "
                          "at density values below <density-cutoff>."))
@@ -402,8 +403,9 @@ class QFitProtein:
         try:
             qfit.run()
         except RuntimeError:
-            print(f"[WARNING] qFit was unable to produce an alternate conformer for residue {resi} of chain {chainid}.")
-            print(f"Using deposited conformer A for this residue.")
+            print(f"[WARNING] qFit was unable to produce an alternate conformer "
+                  f"for residue {resi} of chain {chainid}.\n"
+                  f"Using deposited conformer A for this residue.")
             qfit.conformer = residue.copy()
             qfit._occupancies = [residue.q]
             qfit._coor_set = [residue.coor]

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -188,7 +188,7 @@ class QFitProtein:
         else:
             self.pdb = ''
         multiconformer = self._run_qfit_residue_parallel()
-        structure = Structure.fromfile('multiconformer_model.pdb')#.reorder()
+        structure = Structure.fromfile('multiconformer_model.pdb')  # .reorder()
         structure = structure.extract('e', 'H', '!=')
         multiconformer = self._run_qfit_segment(structure)
         return multiconformer

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -23,7 +23,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 '''
 import gc
-import pkg_resources  # part of setuptools
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitSegment, QFitSegmentOptions
 import multiprocessing as mp
@@ -32,11 +31,9 @@ import os.path
 import os
 import sys
 import time
-import copy
 import argparse
 import logging
 from .logtools import setup_logging, log_run_info, poolworker_setup_logging, QueueListener
-from math import ceil
 from . import MapScaler, Structure, XMap
 from .structure.rotamers import ROTAMERS
 

--- a/src/qfit/subset_structure_AH.py
+++ b/src/qfit/subset_structure_AH.py
@@ -11,7 +11,6 @@ import pkg_resources  # part of setuptools
 from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
 from .qfit import QFitSegment, QFitSegmentOptions
 from .qfit_protein import QFitProteinOptions, QFitProtein
-import multiprocessing as mp
 import os.path
 import os
 import sys

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -22,7 +22,7 @@ class TestQFitLigand:
             "../example/composite_omit_map.mtz",  # mapfile, using relative directory from tests/
             "../example/4ms6.pdb",  # structurefile, using relative directory from tests/
             "-l", "2FOFCWT,PH2FOFCWT",
-            "A, 702", #selection
+            "A, 702",  # selection
             "--directory", f"{os.environ['QFIT_OUTPUT_DIR']}",
         ]
 
@@ -59,6 +59,6 @@ class TestQFitLigand:
         # NOTE: Currently, running this qfit_ligand job takes 20-something
         #       minutes on the GitHub Actions runner. This needs to be cut down.
 
-        # output = qfit_ligand.run() # TODO: Determine if you can just run part of this 
+        # output = qfit_ligand.run() # TODO: Determine if you can just run part of this
         # conformers = qfit_ligand.get_conformers()
         # assert len(conformers) == 3  # TODO: fix when qfit_ligand working

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -1,6 +1,4 @@
-import pytest
 import os
-import multiprocessing as mp
 import logging
 
 from qfit.qfit_ligand import (
@@ -15,17 +13,6 @@ from qfit.logtools import (
 
 
 logger = logging.getLogger(__name__)
-
-
-def setup_module(module):
-    # Here, we add compatibility for multiprocessing coverage reports.
-    # via: https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing-pool
-    try:
-        from pytest_cov.embed import cleanup_on_sigterm
-    except ImportError:
-        pass
-    else:
-        cleanup_on_sigterm()
 
 
 class TestQFitLigand:


### PR DESCRIPTION
I've extracted all my typo commits so far and packaged them up into this PR.
There is no change to meaning of the code / to logic-flow in these commits.

This doesn't attempt to go through _all_ qFit files, just the ones that I've touched / intend to work closely with.

The major commit (PEP8ify) hits most of the PEP8 warnings from `pycodestyle --max-line-length=110`. I've set the length of lines to 110 because 79 (the default) is too short to be reasonable.