### PR TITLE
Changes to intermediate file output, and more logging

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -656,8 +656,8 @@ class QFitRotamericResidue(_BaseQFit):
         # active = self.residue.active
         nn = self.options.neighbor_residues_required
         if index < nn or index + nn > len(self.segment):
-            logger.warning(f"[_sample_backbone] Not enough (<{nn}) neighbor residues: "
-                           f"lower {index < nn}, upper {index + nn > len(self.segment)}")
+            logger.info(f"[_sample_backbone] Not enough (<{nn}) neighbor residues: "
+                        f"lower {index < nn}, upper {index + nn > len(self.segment)}")
             return
         segment = self.segment[(index - nn):(index + nn + 1)]
         atom_name = "CB"

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -696,6 +696,7 @@ class QFitRotamericResidue(_BaseQFit):
             segment.coor = starting_coor
         # print(f"Backbone sampling generated {len(self._coor_set)}"
         #      f" conformers.")
+        self._write_intermediate_conformers(prefix=f"_sample_backbone_segment{index:03d}")
 
     def _sample_angle(self):
         """Sample residue along the N-CA-CB angle."""
@@ -736,6 +737,7 @@ class QFitRotamericResidue(_BaseQFit):
 
         self._coor_set = new_coor_set
         self._bs = new_bs
+        self._write_intermediate_conformers(prefix=f"_sample_angle")
         # print(f"Bond angle sampling generated {len(self._coor_set)} "
         #      f"conformers.")
 
@@ -862,11 +864,10 @@ class QFitRotamericResidue(_BaseQFit):
                        clashes and density support."
                 raise RuntimeError(msg)
             if opt.debug:
-                prefix = os.path.join(opt.directory,
-                                      f'_conformer_{iteration}.pdb')
-                self._write_intermediate_conformers(prefix=prefix)
+                self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}")
             # print(f"Side chain sampling generated {len(self._coor_set)} conformers")
             # print(f"{len(self._coor_set)} {ex}")
+
             # QP
             logger.debug("Converting densities.")
             self._convert()
@@ -874,15 +875,15 @@ class QFitRotamericResidue(_BaseQFit):
             self._solve()
             logger.debug("Updating conformers")
             self._update_conformers()
+            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_qp")
 
-            # self._write_intermediate_conformers(f"qp_{iteration}")
             # MIQP
             self._convert()
             logger.info("Solving MIQP.")
             self._solve(cardinality=opt.cardinality,
                         threshold=opt.threshold)
             self._update_conformers()
-            # self._write_intermediate_conformers(f"miqp_{iteration}")
+            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_miqp")
             logger.info("Nconf after MIQP: {:d}".format(len(self._coor_set)))
             # print("Nconf after MIQP: {:d}".format(len(self._coor_set)))
 
@@ -1787,9 +1788,7 @@ class QFitCovalentLigand(_BaseQFit):
                        "clashes and density support.")
                 raise RuntimeError(msg)
             if opt.debug:
-                prefix = os.path.join(opt.directory,
-                                      f'_conformer_{iteration}.pdb')
-                self._write_intermediate_conformers(prefix=prefix)
+                self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}")
 
             # QP
             logger.debug("Converting densities.")
@@ -1798,6 +1797,7 @@ class QFitCovalentLigand(_BaseQFit):
             self._solve()
             logger.debug("Updating conformers")
             self._update_conformers()
+            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_qp")
 
             # MIQP
             self._convert()
@@ -1806,6 +1806,7 @@ class QFitCovalentLigand(_BaseQFit):
                         threshold=opt.threshold)
             self._update_conformers()
             logger.info("Nconf after MIQP: {:d}".format(len(self._coor_set)))
+            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_miqp")
 
             # Check if we are done
             if chi_index == self.covalent_residue.nchi:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -248,10 +248,10 @@ class _BaseQFit:
         # solvent_level = residual_sum / nvalues
         # scaling_factor = model_sum / target_sum
         # self._target *= scaling_factor
-        # print("Solvent level advice:", solvent_level)
-        # print("Scaling factor:", scaling_factor)
-        # print("Target sum:", target_sum)
-        # print("Model sum:", model_sum)
+        # logger.debug("Solvent level advice:", solvent_level)
+        # logger.debug("Scaling factor:", scaling_factor)
+        # logger.debug("Target sum:", target_sum)
+        # logger.debug("Model sum:", model_sum)
         # self._transformer.reset(full=True)
         for n, coor in enumerate(self._coor_set):
             self.conformer.coor = coor
@@ -990,8 +990,8 @@ class QFitSegment(_BaseQFit):
         self._voxel_volume /= self.xmap.array.size
 
     def __call__(self):
-        print(f"Average number of conformers before qfit_segment run: "
-              f"{self.segment.average_conformers():.2f}")
+        logger.info(f"Average number of conformers before qfit_segment run: "
+                    f"{self.segment.average_conformers():.2f}")
         # Extract hetatms
         hetatms = self.segment.extract('record', "HETATM")
         # Create an empty structure:
@@ -1019,9 +1019,9 @@ class QFitSegment(_BaseQFit):
                 if (CA_single and O_single):
                     mask = np.isin(conformer.name, ['CA', 'O'])
                     if np.sum(mask) > 2:
-                        print("f[WARNING] Conformer {altloc} of residue"
-                              f"{rg.resi[0]} has more than one coordinate"
-                              f" for CA/O atoms.")
+                        logger.warning(f"Conformer {altloc} of residue "
+                                       f"{rg.resi[0]} has more than one coordinate "
+                                       f"for CA/O atoms.")
                         mask = mask[:2]
                     try:
                         CA_single = np.linalg.norm(CA_pos - conformer.coor[mask][0])
@@ -1061,16 +1061,16 @@ class QFitSegment(_BaseQFit):
                 segment.append(multiconformer)
 
         if len(segment):
-            print(f"Running find_paths for segment of length {len(segment)}")
+            logger.debug(f"Running find_paths for segment of length {len(segment)}")
             for path in self.find_paths(segment):
                 multiconformers = multiconformers.combine(path)
 
-        print(f"Average number of conformers after qfit_segment run: "
-              f"{multiconformers.average_conformers():.2f}")
+        logger.info(f"Average number of conformers after qfit_segment run: "
+                    f"{multiconformers.average_conformers():.2f}")
         multiconformers = multiconformers.reorder()
         multiconformers = multiconformers.remove_identical_conformers(self.options.rmsd_cutoff)
-        print(f"Average number of conformers after removal of identical conformers: "
-              f"{multiconformers.average_conformers():.2f}")
+        logger.info(f"Average number of conformers after removal of identical conformers: "
+                    f"{multiconformers.average_conformers():.2f}")
         relab_options = RelabellerOptions()
         relabeller = Relabeller(multiconformers, relab_options)
         multiconformers = relabeller.run()
@@ -1145,7 +1145,7 @@ class QFitSegment(_BaseQFit):
                 if fragment.name[i] == "CA":
                     path.append(residue_altloc)
                     # coor.append(fragment.coor[i])
-            print(f"Path {k+1}:\t{path}\t{fragment.q[-1]}")
+            logger.info(f"Path {k+1}:\t{path}\t{fragment.q[-1]}")
 
 
 class QFitLigandOptions(_BaseQFitOptions):
@@ -1191,8 +1191,7 @@ class QFitLigand(_BaseQFit):
                 nhydrogen = (self.ligand.e[cluster] == 'H').sum()
                 if len(cluster) - nhydrogen > 1:
                     self._clusters_to_sample.append(cluster)
-        # msg = f"Number of clusters to sample: {len(self._clusters_to_sample)}"
-        # print(msg)
+        # logger.debug(f"Number of clusters to sample: {len(self._clusters_to_sample)}")
 
         # Initialize the transformer
         if options.subtract:
@@ -1641,7 +1640,7 @@ class QFitCovalentLigand(_BaseQFit):
             optimizer.rotator(solution)
             self._coor_set.append(self.segment[index].coor)
             segment.coor = starting_coor
-        # print(f"Backbone sampling generated {len(self._coor_set)} conformers")
+        # logger.debug(f"Backbone sampling generated {len(self._coor_set)} conformers")
 
     def _sample_angle(self):
         """Sample residue along the N-CA-CB angle."""
@@ -1677,7 +1676,7 @@ class QFitCovalentLigand(_BaseQFit):
 
         self._coor_set = new_coor_set
         self._bs = new_bs
-        # print(f"Bond angle sampling generated {len(self._coor_set)} conformers.")
+        # logger.debug(f"Bond angle sampling generated {len(self._coor_set)} conformers.")
 
     def _sample_sidechain(self):
         opt = self.options

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1227,6 +1227,9 @@ class QFitLigand(_BaseQFit):
         if len(self._coor_set) < 1:
             print("[ERROR] qFit-ligand failed to produce a valid conformer.")
             exit()
+
+        # TODO: Check why we don't run QP here.
+
         # MIQP score conformer occupancy
         self._convert()
         self._solve(threshold=self.options.threshold,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -701,8 +701,10 @@ class QFitRotamericResidue(_BaseQFit):
             self._coor_set.append(self.segment[index].coor)
             self._bs.append(self.conformer.b)
             segment.coor = starting_coor
-        self._write_intermediate_conformers(prefix=f"_sample_backbone_segment{index:03d}")
-        logger.debug(f"[_sample_backbone] Backbone sampling generated {len(self._coor_set)} conformers.")
+
+        if self.options.debug:
+            self._write_intermediate_conformers(prefix=f"_sample_backbone_segment{index:03d}")
+            logger.debug(f"[_sample_backbone] Backbone sampling generated {len(self._coor_set)} conformers.")
 
     def _sample_angle(self):
         """Sample residue along the N-CA-CB angle."""
@@ -743,9 +745,10 @@ class QFitRotamericResidue(_BaseQFit):
 
         self._coor_set = new_coor_set
         self._bs = new_bs
-        self._write_intermediate_conformers(prefix=f"_sample_angle")
-        # print(f"Bond angle sampling generated {len(self._coor_set)} "
-        #      f"conformers.")
+        if self.options.debug:
+            self._write_intermediate_conformers(prefix=f"_sample_angle")
+            # print(f"Bond angle sampling generated {len(self._coor_set)} "
+            #      f"conformers.")
 
     def _sample_sidechain(self):
         opt = self.options
@@ -869,10 +872,10 @@ class QFitRotamericResidue(_BaseQFit):
                 msg = "No conformers could be generated. Check for initial \
                        clashes and density support."
                 raise RuntimeError(msg)
-            if opt.debug:
+            if self.options.debug:
                 self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}")
-            # print(f"Side chain sampling generated {len(self._coor_set)} conformers")
-            # print(f"{len(self._coor_set)} {ex}")
+                # print(f"Side chain sampling generated {len(self._coor_set)} conformers")
+                # print(f"{len(self._coor_set)} {ex}")
 
             # QP
             logger.debug("Converting densities.")
@@ -881,7 +884,8 @@ class QFitRotamericResidue(_BaseQFit):
             self._solve()
             logger.debug("Updating conformers")
             self._update_conformers()
-            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_qp")
+            if self.options.debug:
+                self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_qp")
 
             # MIQP
             self._convert()
@@ -889,7 +893,8 @@ class QFitRotamericResidue(_BaseQFit):
             self._solve(cardinality=opt.cardinality,
                         threshold=opt.threshold)
             self._update_conformers()
-            self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_miqp")
+            if self.options.debug:
+                self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}_miqp")
             logger.info("Nconf after MIQP: {:d}".format(len(self._coor_set)))
             # print("Nconf after MIQP: {:d}".format(len(self._coor_set)))
 
@@ -1793,7 +1798,7 @@ class QFitCovalentLigand(_BaseQFit):
                 msg = ("No conformers could be generated. Check for initial "
                        "clashes and density support.")
                 raise RuntimeError(msg)
-            if opt.debug:
+            if self.options.debug:
                 self._write_intermediate_conformers(prefix=f"_sample_sidechain_iter{iteration}")
 
             # QP

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -223,7 +223,7 @@ class _BaseQFit:
 
     def _convert(self):
         """Convert structures to densities and extract relevant values for (MI)QP."""
-        logger.info("Converting")
+        logger.info("Converting conformers to density")
         logger.debug("Masking")
         self._transformer.reset(full=True)
         for n, coor in enumerate(self._coor_set):
@@ -274,13 +274,16 @@ class _BaseQFit:
 
     def _solve(self, cardinality=None, threshold=None,
                loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2]):
+        # Create and run QP or MIQP solver
         do_qp = cardinality is threshold is None
         if do_qp:
+            logger.info("Solving QP")
             solver = QPSolver(self._target, self._models, use_cplex=self.options.cplex)
             solver()
             if self.options.bic_threshold:
                 self._occupancies = solver.weights
         else:
+            logger.info("Solving MIQP")
             solver = MIQPSolver(self._target, self._models, use_cplex=self.options.cplex)
 
             # Threshold selection by BIC:
@@ -315,6 +318,7 @@ class _BaseQFit:
         return solver.obj_value
 
     def _update_conformers(self):
+        logger.debug("Updating conformers based on occupancy")
         new_coor_set = []
         new_occupancies = []
         new_bs = []

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -699,7 +699,6 @@ class QFitRotamericResidue(_BaseQFit):
             endpoint = start_coor + (amplitude + sigma * np.random.random()) * direction
             optimize_result = optimizer.optimize(atom_name, endpoint)
             torsion_solutions.append(optimize_result['x'])
-            logger.debug(f"[_sample_backbone] optimize_result={optimize_result}")
 
             endpoint = start_coor - (amplitude + sigma * np.random.random()) * direction
             optimize_result = optimizer.optimize(atom_name, endpoint)

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -206,8 +206,8 @@ class QFitProtein:
 
         # Print execution stats
         residues = list(self.structure.single_conformer_residues)
-        print(f"RESIDUES: {len(residues)}")
-        print(f"NPROC: {self.options.nproc}")
+        logger.info(f"RESIDUES: {len(residues)}")
+        logger.info(f"NPROC: {self.options.nproc}")
 
         # Build a Manager, have it construct a Queue. This will conduct
         #   thread-safe and process-safe passing of LogRecords.
@@ -287,7 +287,7 @@ class QFitProtein:
             except UnboundLocalError:
                 multiconformer = residue_multiconformer
             except FileNotFoundError:
-                print("File not found!", fname)
+                logger.error(f"File \"{fname}\" not found!")
                 pass
 
         multiconformer = multiconformer.combine(hetatms)
@@ -403,9 +403,9 @@ class QFitProtein:
         try:
             qfit.run()
         except RuntimeError:
-            print(f"[WARNING] qFit was unable to produce an alternate conformer "
-                  f"for residue {resi} of chain {chainid}.\n"
-                  f"Using deposited conformer A for this residue.")
+            logger.warning(f"qFit was unable to produce an alternate conformer "
+                           f"for residue {resi} of chain {chainid}.\n"
+                           f"Using deposited conformer A for this residue.")
             qfit.conformer = residue.copy()
             qfit._occupancies = [residue.q]
             qfit._coor_set = [residue.coor]
@@ -480,4 +480,4 @@ def main():
     # Run the QFitProtein job
     time0 = time.time()
     multiconformer = qfit.run()
-    print(f"Total time: {time.time() - time0}s")
+    logger.info(f"Total time: {time.time() - time0}s")

--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -23,8 +23,14 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 '''
 
+import logging
+
 import numpy as np
 from scipy import sparse
+
+
+logger = logging.getLogger(__name__)
+
 
 # Try load solver sets
 try:
@@ -75,6 +81,7 @@ if CPLEX:
 
         def initialize(self):
             # Set up the matrices and restraints
+            logger.debug(f"Building cvxopt matrix, size: ({self._nconformers},{self._nconformers})")
             self._quad_obj = cvxopt.matrix(0, (self._nconformers, self._nconformers), tc='d')
             self._lin_obj = cvxopt.matrix(self._nconformers * [0], tc='d')
             for i in range(self._nconformers):


### PR DESCRIPTION
**Intermediate files**
Output of intermediate files now requires the `--debug` flag for most qfit programs.
Most users don't need the sampled structures (>>10 MB) to be created; they will generally only be interested in the selected structures.

**Logging**
There are no more print() in qfit.py, qfit_protein.py.
Some print() calls still exist in test_qfit_protein.py, where it makes sense to print---this way we can do further debugging if an Assertion fails during testing.

Merge after #57 .