### PR TITLE
Improve pdb parsing

### DIFF
--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -24,7 +24,7 @@ IN THE SOFTWARE.
 '''
 
 import gzip
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 import sys
 import numpy as np
 
@@ -79,24 +79,24 @@ class PDBFile:
         with open(fname, 'w') as f:
             if structure.link_data:
                 for record in zip(*[structure.link_data[x] for x in LinkRecord.fields]):
-                    record = LinkRecord.recordstruct(*record)
-                    if not record.length:
+                    record = dict(zip(LinkRecord.fields, record))
+                    if not record['length']:
                         # If the LINK length is 0, then leave it blank.
                         # This is a deviation from the PDB standard.
-                        record = record._replace(length='')
+                        record['length'] = ''
                         fmtstr = LinkRecord.fmtstr.replace('{:>5.2f}', '{:5s}')
-                        f.write(fmtstr.format(*record))
+                        f.write(fmtstr.format(*record.values()))
                     else:
-                        f.write(LinkRecord.fmtstr.format(*record))
+                        f.write(LinkRecord.fmtstr.format(*record.values()))
             atomid = 1
             for record in zip(*[getattr(structure, x) for x in CoorRecord.fields]):
-                record = CoorRecord.recordstruct(*record)
-                record = record._replace(atomid=atomid)  # Overwrite atomid for consistency within this file.
+                record = dict(zip(CoorRecord.fields, record))
+                record['atomid'] = atomid  # Overwrite atomid for consistency within this file.
                 # If the element name is a single letter,
                 # PDB specification says the atom name should start one column in.
-                if len(record.e) == 1 and not len(record.name) == 4:
-                    record = record._replace(name=" " + record.name)
-                f.write(CoorRecord.fmtstr.format(*record))
+                if len(record['e']) == 1 and not len(record['name']) == 4:
+                    record['name'] = " " + record['name']
+                    f.write(CoorRecord.fmtstr.format(*record.values()))
                 atomid += 1
             f.write(EndRecord.fmtstr)
 
@@ -104,15 +104,9 @@ class RecordParser(object):
     """Interface class to provide record parsing routines for a PDB file.
 
     Deriving classes should have class variables for {fields, columns, dtypes, fmtstr}.
-
-    Deriving classes will have a namedtuple factory available at `.recordstruct`.
     """
 
     __slots__ = ("fields", "columns", "dtypes", "fmtstr")
-
-    def __init_subclass__(cls, **kwargs):
-        cls.recordstruct = namedtuple(cls.__name__ + "Struct", cls.fields)
-        super().__init_subclass__(**kwargs)
 
     @classmethod
     def parse_line(cls, line):

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -115,10 +115,12 @@ class Record:
 
 
 class ModelRecord(Record):
-    fields = 'record modelid'
-    columns = [(0, 6), (11, 15)]
-    dtypes = (str, int)
-    line = '{:6s}' + ' ' * 5 + '{:6d}\n'
+    # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#MODEL
+    fields  = ("record", "modelid")
+    columns = [(0, 6),   (10, 14)]
+    dtypes  = (str,      int)
+    fmtstr  = '{:<6s}' + ' ' * 4 + '{:>4d}' + '\n'
+
 
 class LinkRecord(Record):
     fields = ('record name1 altloc1 resn1 chain1 resi1 icode1 name2 '

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -83,7 +83,7 @@ class PDBFile:
                     if not record.length:
                         # If the LINK length is 0, then leave it blank.
                         # This is a deviation from the PDB standard.
-                        record.length = ''
+                        record = record._replace(length='')
                         fmtstr = LinkRecord.fmtstr.replace('{:>5.2f}', '{:5s}')
                         f.write(fmtstr.format(*record))
                     else:
@@ -91,11 +91,11 @@ class PDBFile:
             atomid = 1
             for record in zip(*[getattr(structure, x) for x in CoorRecord.fields]):
                 record = CoorRecord.recordstruct(*record)
-                record.atomid = atomid  # Overwrite atomid for consistency within this file.
+                record = record._replace(atomid=atomid)  # Overwrite atomid for consistency within this file.
                 # If the element name is a single letter,
                 # PDB specification says the atom name should start one column in.
                 if len(record.e) == 1 and not len(record.name) == 4:
-                    record.name = " " + record.name
+                    record = record._replace(name=" " + record.name)
                 f.write(CoorRecord.fmtstr.format(*record))
                 atomid += 1
             f.write(EndRecord.fmtstr)

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -38,7 +38,7 @@ class PDBFile:
         coor (dict[str, list): coordinate data
         anisou (dict[str, list]): anisotropic displacement parameter data
         link (dict[str, list]): link records
-        cryst1 (dict[str, Union[str, float, int, None]]): cryst1 record
+        cryst1 (dict[str, Union[str, float, int]]): cryst1 record
         resolution (Optional[float]): resolution of pdb file
     """
 
@@ -157,7 +157,7 @@ class RecordParser(object):
             line (str): A record, as read from a PDB file.
 
         Returns:
-            dict[str, Union[str, int, float, None]]: fields that were parsed
+            dict[str, Union[str, int, float]]: fields that were parsed
                 from the record.
         """
         values = {}
@@ -167,7 +167,7 @@ class RecordParser(object):
             except ValueError:
                 logger.error(f"RecordParser.parse_line: could not parse "
                              f"{field} ({line[slice(*column)]}) as {dtype}")
-                values[field] = None
+                values[field] = dtype()
         return values
 
 

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -100,11 +100,25 @@ class PDBFile:
                 atomid += 1
             f.write(EndRecord.fmtstr)
 
+class RecordParser(object):
+    """Interface class to provide record parsing routines for a PDB file.
 
-class Record:
+    Deriving classes should have class variables for {fields, columns, dtypes, fmtstr}.
+    """
+
+    __slots__ = ("fields", "columns", "dtypes", "fmtstr")
 
     @classmethod
     def parse_line(cls, line):
+        """Common interface for parsing a record from a PDB file.
+
+        Args:
+            line (str): A record, as read from a PDB file.
+
+        Returns:
+            dict[str, Union[str, int, float, None]]: fields that were parsed
+                from the record.
+        """
         values = {}
         for field, column, dtype in zip(cls.fields, cls.columns, cls.dtypes):
             try:
@@ -114,7 +128,7 @@ class Record:
         return values
 
 
-class ModelRecord(Record):
+class ModelRecord(RecordParser):
     # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#MODEL
     fields  = ("record", "modelid")
     columns = [(0, 6),   (10, 14)]
@@ -122,7 +136,7 @@ class ModelRecord(Record):
     fmtstr  = '{:<6s}' + ' ' * 4 + '{:>4d}' + '\n'
 
 
-class LinkRecord(Record):
+class LinkRecord(RecordParser):
     # http://www.wwpdb.org/documentation/file-format-content/format33/sect6.html#LINK
     fields  = ("record",
                "name1",  "altloc1", "resn1",  "chain1", "resi1",  "icode1",
@@ -142,7 +156,7 @@ class LinkRecord(Record):
                + '{:>6s} {:>6s} {:>5.2f}' + '\n')
 
 
-class CoorRecord(Record):
+class CoorRecord(RecordParser):
     # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ATOM
     fields  = ("record",
                "atomid", "name",   "altloc", "resn",   "chain",  "resi",   "icode",
@@ -162,7 +176,7 @@ class CoorRecord(Record):
                + '{:>2s}{:>2s}' + '\n')
 
 
-class AnisouRecord(Record):
+class AnisouRecord(RecordParser):
     # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ANISOU
     fields  = ("record",
                "atomid", "atomname", "altloc", "resn",   "chain",  "resi",   "icode",
@@ -182,33 +196,33 @@ class AnisouRecord(Record):
                + '{:>2s}{:>2s}' + '\n')
 
 
-class ExpdtaRecord(Record):
+class ExpdtaRecord(RecordParser):
     fields  = ("record", "cont",  "technique")
     columns = ((0, 6),   (8, 10), (10, 79))
     dtypes  = (str,      str,     str)
 
 
-class RemarkRecord(Record):
+class RemarkRecord(RecordParser):
     fields  = ("record", "remarkid", "text")
     columns = ((0, 6),   (7, 10),    (11, 79))
     dtypes  = (str,      int,        str)
 
 
-class Remark2DiffractionRecord(Record):
+class Remark2DiffractionRecord(RecordParser):
     # For diffraction experiments
     fields  = ("record", "remarkid", "RESOLUTION", "resolution", "ANGSTROM")
     columns = ((0, 6),   (9, 10),    (11, 22),     (23, 30),     (31, 41))
     dtypes  = (str,      str,        str,          float,        str)
 
 
-class Remark2NonDiffractionRecord(Record):
+class Remark2NonDiffractionRecord(RecordParser):
     # For diffraction experiments
     fields  = ("record", "remarkid", "NOTAPPLICABLE")
     columns = ((0, 6),   (9, 10),    (11, 38))
     dtypes  = (str,      str,        str)
 
 
-class Cryst1Record(Record):
+class Cryst1Record(RecordParser):
     fields  = ("record",
                "a",     "b",      "c",      "alpha",  "beta",   "gamma",  "spg")
     columns = ((0, 6),
@@ -217,7 +231,7 @@ class Cryst1Record(Record):
                float,   float,    float,    float,    float,    float,    str,      int)
 
 
-class EndRecord(Record):
+class EndRecord(RecordParser):
     fields  = ("record",)
     columns = ((0, 6),)
     dtypes  = (str,)

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -26,7 +26,7 @@ IN THE SOFTWARE.
 import gzip
 from collections import defaultdict
 import sys
-import numpy as np
+
 
 class PDBFile:
 

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -163,17 +163,23 @@ class CoorRecord(Record):
 
 
 class AnisouRecord(Record):
-    fields = 'record atomid atomname altloc resn chain resi icode u00 u11 u22 u01 u02 u12 e charge'.split()
-    columns = [
-        (0, 6), (6, 11), (12, 16), (16, 17), (17, 20), (21, 22), (22, 26),
-        (26, 27), (28, 35), (35, 42), (42, 49), (49, 56), (56, 63), (63, 70), (76, 78), (78, 80),
-    ]
-    dtypes = (str, int, str, str, str, str, int, str, float, float, float,
-              float, float, float, str, str)
-    line1 = ('{:6s}{:5d}  {:3s}{:1s}{:3s} {:1s}{:4d}{:1s}   '
-             '{:7d}' * 6 + ' ' * 7 + '{:>2s}{:>2s}\n')
-    line2 = ('{:6s}{:5d} {:<4s}{:1s}{:3s} {:1s}{:4d}{:1s}   '
-             '{:7d}' * 6 + ' ' * 7 + '{:>2s}{:>2s}\n')
+    # http://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ANISOU
+    fields  = ("record",
+               "atomid", "atomname", "altloc", "resn",   "chain",  "resi",   "icode",
+               "u00",    "u11",      "u22",    "u01",    "u02",    "u12",
+               "e",      "charge")
+    columns = ((0, 6),
+               (6, 11),  (12, 16),   (16, 17), (17, 20), (21, 22), (22, 26), (26, 27),
+               (28, 35), (35, 42),   (42, 49), (49, 56), (56, 63), (63, 70),
+               (76, 78), (78, 80))
+    dtypes  = (str,
+               int,      str,        str,      str,      str,      int,      str,
+               float,    float,      float,    float,    float,    float,
+               str,      str)
+    fmtstr  = ('{:<6s}'
+               + '{:>5d} {:<4s}{:1s}{:>3s} {:1s}{:>4d}{:1s}' + ' '
+               + '{:>7d}' * 6 + ' ' * 6
+               + '{:>2s}{:>2s}' + '\n')
 
 
 class ExpdtaRecord(Record):

--- a/src/qfit/structure/pdbfile.py
+++ b/src/qfit/structure/pdbfile.py
@@ -98,7 +98,7 @@ class PDBFile:
                     record[2] = " " + record[2]
                 f.write(CoorRecord.fmtstr.format(*record))
                 atomid += 1
-            f.write(EndRecord.line)
+            f.write(EndRecord.fmtstr)
 
 
 class Record:
@@ -183,37 +183,42 @@ class AnisouRecord(Record):
 
 
 class ExpdtaRecord(Record):
-    fields = 'record cont technique'.split()
-    columns = [(0,6), (8, 10), (10, 79)]
-    dtypes= (str, str, str)
+    fields  = ("record", "cont",  "technique")
+    columns = ((0, 6),   (8, 10), (10, 79))
+    dtypes  = (str,      str,     str)
 
 
 class RemarkRecord(Record):
-    fields = 'record remarkid text'.split()
-    columns = [(0, 6), (7, 10), (11, 79)]
-    dtypes = (str, int, str)
+    fields  = ("record", "remarkid", "text")
+    columns = ((0, 6),   (7, 10),    (11, 79))
+    dtypes  = (str,      int,        str)
 
 
 class Remark2DiffractionRecord(Record):
     # For diffraction experiments
-    fields = 'record remarkid RESOLUTION resolution ANGSTROM'.split()
-    columns = [(0, 6), (9, 10), (11, 22), (23, 30), (31, 41)]
-    dtypes = (str, str, str, float, str)
+    fields  = ("record", "remarkid", "RESOLUTION", "resolution", "ANGSTROM")
+    columns = ((0, 6),   (9, 10),    (11, 22),     (23, 30),     (31, 41))
+    dtypes  = (str,      str,        str,          float,        str)
 
 
 class Remark2NonDiffractionRecord(Record):
     # For diffraction experiments
-    fields = 'record remarkid NOTAPPLICABLE'.split()
-    columns = [(0, 6), (9, 10), (11, 38)]
-    dtypes = (str, str, str)
+    fields  = ("record", "remarkid", "NOTAPPLICABLE")
+    columns = ((0, 6),   (9, 10),    (11, 38))
+    dtypes  = (str,      str,        str)
+
 
 class Cryst1Record(Record):
-    fields = 'record a b c alpha beta gamma spg'.split()
-    columns = [(0,6), (6, 15), (15, 24), (24, 33), (33, 40), (40, 47), (47, 54), (55, 66), (66, 70)]
-    dtypes = (str, float, float, float, float, float, float, str, int)
+    fields  = ("record",
+               "a",     "b",      "c",      "alpha",  "beta",   "gamma",  "spg")
+    columns = ((0, 6),
+               (6, 15), (15, 24), (24, 33), (33, 40), (40, 47), (47, 54), (55, 66), (66, 70))
+    dtypes  = (str,
+               float,   float,    float,    float,    float,    float,    str,      int)
+
 
 class EndRecord(Record):
-    fields = ['record']
-    columns = [(0,6)]
-    dtypes = (str,)
-    line = 'END   ' + ' ' * 74 +'\n'
+    fields  = ("record",)
+    columns = ((0, 6),)
+    dtypes  = (str,)
+    fmtstr  = 'END   ' + ' ' * 74 + '\n'


### PR DESCRIPTION
In some situations (e.g. #65 ), PDBs were incorrectly formatted for intermediate structures. This PR helps with this.
Some fields held None. This is no longer the case, instead we hold the default of `dtype()` for the field.
We also alert the user of _all_ errors encountered in reading the PDB file rather than just letting them disappear.

This PR also adds documentation for functions in structure/pdbfile.py .

This commit goes some way to addressing the problems in #65 , though I think I'm still seeing errors caused by missing atoms in an input pdb.