### PR TITLE
Hotfix/post refine script fixes

### DIFF
--- a/scripts/post_refine_phenix.sh
+++ b/scripts/post_refine_phenix.sh
@@ -58,7 +58,7 @@ fi
 obstypes="FP FOBS F-obs IOBS"
 
 # Get amplitude fields
-ampfields=`grep "amplitude" <<< "${mtzmetadata}"`
+ampfields=`grep -E "amplitude|intensity" <<< "${mtzmetadata}"`
 ampfields=`echo "${ampfields}" | awk '{$1=$1};1' | cut -d " " -f 1`
 
 # Clear xray_data_labels variable

--- a/scripts/post_refine_phenix.sh
+++ b/scripts/post_refine_phenix.sh
@@ -102,6 +102,10 @@ phenix.pdbtools remove="element H" "${multiconf}.fixed"
 
 #__________________________________GET CIF FILE__________________________________
 phenix.ready_set hydrogens=false pdb_file_name="${multiconf}.f_modified.pdb"
+# If there are no unknown ligands, ready_set doesn't output a file. We have to do it.
+if [ ! -f "${multiconf}.f_modified.updated.pdb" ]; then
+  cp -v "${multiconf}.f_modified.pdb" "${multiconf}.f_modified.updated.pdb";
+fi
 
 #__________________________________COORDINATE REFINEMENT ONLY__________________________________
 if [ -f "${multiconf}.f_modified.ligands.cif" ]; then

--- a/scripts/post_refine_phenix.sh
+++ b/scripts/post_refine_phenix.sh
@@ -55,7 +55,7 @@ fi
 
 #__________________________________DETERMINE FOBS v IOBS v FP__________________________________
 # List of Fo types we will check for
-obstypes="FP FOBS F-obs IOBS"
+obstypes="FP FOBS F-obs I IOBS I-obs"
 
 # Get amplitude fields
 ampfields=`grep -E "amplitude|intensity" <<< "${mtzmetadata}"`


### PR DESCRIPTION
* Accept mtz files with I fields (but no F fields) for refinement
* Fixes the issue @stephaniewanko raised—add workaround for phenix.ready_set where no ligands exist, so no new pdb file is output