### PR TITLE
Calc pairwise energy if _at least one atom_ within cutoff

### DIFF
--- a/src/qfit/relabel.py
+++ b/src/qfit/relabel.py
@@ -113,8 +113,8 @@ class Relabeller:
         dist_ij_x = node1.coor[:, np.newaxis] - node2.coor[np.newaxis, :]
         dist_ij = np.linalg.norm(dist_ij_x, axis=-1)
 
-        # Only proceed if N interatomic distance is within cutoff
-        if np.linalg.norm(node1.coor[0] - node2.coor[0]) >= INTERACTION_DISTANCE_CUTOFF:
+        # Only proceed if at least one interatomic distance is within cutoff
+        if np.all(dist_ij >= INTERACTION_DISTANCE_CUTOFF):
             return 0.0
 
         # epsilon


### PR DESCRIPTION
During relabelling, we calculate residue pairwise energies to help decide which labelling is optimal.
Previously, the code would calculate residue pairwise energies if the N-atoms of two residues was within a certain cutoff.
I preserved this behaviour when modifying the section.

However, it seems more consistent to me that we should calculate residue pairwise energies if _any_ atom is within the cutoff radius.
This PR will produce this new behaviour.
I expect results coming from relabel.py will be slightly different.