### PR TITLE
No NQH flips in first round of refinement

### DIFF
--- a/scripts/post_refine_phenix.sh
+++ b/scripts/post_refine_phenix.sh
@@ -116,6 +116,7 @@ if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
                 output.prefix="${pdb_name}" \
                 output.serial=2 \
                 main.number_of_macro_cycles=5 \
+                main.nqh_flips=False \
                 refinement.input.xray_data.r_free_flags.generate=$gen_Rfree \
                 refinement.input.xray_data.labels=$xray_data_labels \
                 write_maps=false --overwrite
@@ -126,6 +127,7 @@ else
                 output.prefix="${pdb_name}" \
                 output.serial=2 \
                 main.number_of_macro_cycles=5 \
+                main.nqh_flips=False \
                 refinement.input.xray_data.r_free_flags.generate=$gen_Rfree \
                 refinement.input.xray_data.labels=$xray_data_labels \
                 write_maps=false --overwrite


### PR DESCRIPTION
NQH flips rely on running phenix.reduce.
Sometimes, phenix.reduce crashes when geometry is not ideal (I think this is the reason?)
We should hold off on NQH flips until we're through this round.