### PR TITLE
Mark raw strings in regex as such to fix DeprecationWarnings

### DIFF
--- a/src/qfit/structure/mmCIF.py
+++ b/src/qfit/structure/mmCIF.py
@@ -849,15 +849,15 @@ class mmCIFFileParser(object):
         re_tok = re.compile(
             r"(?:"
 
-             "(?:_(.+?)[.](\S+))"               "|"  # _section.subsection
+            r"(?:_(.+?)[.](\S+))"               "|"  # _section.subsection
 
-             "(?:['\"](.*?)(?:['\"]\s|['\"]$))" "|"  # quoted strings
+            r"(?:['\"](.*?)(?:['\"]\s|['\"]$))" "|"  # quoted strings
 
-             "(?:\s*#.*$)"                      "|"  # comments
+            r"(?:\s*#.*$)"                      "|"  # comments
 
-             "(\S+)"                                 # unquoted tokens
+            r"(\S+)"                                 # unquoted tokens
 
-             ")")
+            r")")
 
         file_iter = iter(fileobj)
 


### PR DESCRIPTION
py.test was throwing out DeprecationWarnings.
Fix was pretty straightforward.

```
=============================== warnings summary ===============================
/Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:852
  /Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:852: DeprecationWarning: invalid escape sequence \S
    "(?:_(.+?)[.](\S+))"               "|"  # _section.subsection

/Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:854
  /Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:854: DeprecationWarning: invalid escape sequence \s
    "(?:['\"](.*?)(?:['\"]\s|['\"]$))" "|"  # quoted strings

/Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:856
  /Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:856: DeprecationWarning: invalid escape sequence \s
    "(?:\s*#.*$)"                      "|"  # comments

/Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:858
  /Users/runner/work/qfit-3.0/qfit-3.0/src/qfit/structure/mmCIF.py:858: DeprecationWarning: invalid escape sequence \S
    "(\S+)"                                 # unquoted tokens
```

These strings (with \s) need to be marked as raw strings (so python doesn't attempt to expand the escape).