### PR TITLE
Catch error when MRC files contain 2D stack

### DIFF
--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -167,7 +167,7 @@ class XMap(_BaseVolume):
             alpha, beta, gamma = parser.angles
             spacegroup = parser.spacegroup
             if spacegroup == 0:
-                raise RuntimeError("File format is 2D image or image stack. Please convert to map.")
+                raise RuntimeError(f"File {fname} is 2D image or image stack. Please convert to a 3D map.")
             unit_cell = UnitCell(a, b, c, alpha, beta, gamma, spacegroup)
             offset = parser.offset
             array = parser.density

--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -166,6 +166,8 @@ class XMap(_BaseVolume):
             a, b, c = parser.abc
             alpha, beta, gamma = parser.angles
             spacegroup = parser.spacegroup
+            if spacegroup == 0:
+                raise RuntimeError("File format is 2D image or image stack. Please convert to map.")
             unit_cell = UnitCell(a, b, c, alpha, beta, gamma, spacegroup)
             offset = parser.offset
             array = parser.density


### PR DESCRIPTION
If MRC file is a 2D stack, its spacegroup==0. qFit will then tell the user to input map not 2D stack.