### PR TITLE
Use epsilon to prevent FP errors in calculating backbone amplitude array

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -731,7 +731,8 @@ class QFitRotamericResidue(_BaseQFit):
         # Create an array of amplitudes to scan:
         #   We start from stepsize, making sure to stop only after bba.
         #   Also include negative amplitudes.
-        amplitudes = np.arange(start=bbs, stop=bba + bbs, step=bbs)
+        eps = ((bba / bbs) / 2) * np.finfo(float).epsneg  # ε to avoid FP errors in arange
+        amplitudes = np.arange(start=bbs, stop=bba + bbs - eps, step=bbs)
         amplitudes = np.concatenate([-amplitudes[::-1], amplitudes])
 
         # Optimize in torsion space to achieve the target atom position


### PR DESCRIPTION
np.arange should create a range across [start, stop).
np.arange.__doc__, however, states that there are 'inconsistencies' with non-integer steps.
This refers to floating point (FP) errors: there are fundamental limits to representing real numbers with a finite number of bits.
0.1 is one of those real numbers that _cannot_ be represented precisely in binary FP.

np.arange works by repeated addition, so the magnitude of error will increase with an increasing length of arange.

The fix I am implementing here is to bring _stop_ inwards by N/2 * ε,
  where N is the expected length of the array, and
        ε is the smallest negative FP such that 1 - ε < 1.