### PR TITLE
Fixup python version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once these are installed, you can:
 
 1. Create a new conda env & activate it
    ```bash
-   conda create --name qfit --python>=3.6
+   conda create --name qfit "python>=3.6"
    conda activate qfit
    ```
 


### PR DESCRIPTION
- `--python` doesn't appear to be an option for conda
- Needed to be quoted so zsh (probably bash too?) doesn't treat it as a redirect