### PR TITLE
Add adp parameters to iterative refinement loop

### DIFF
--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -153,6 +153,7 @@ while [ $zeroes -gt 1 ]; do
     phenix.refine "${pdb_name}_002.pdb" \
                   "${pdb_name}_002.mtz" \
                   "${multiconf}.f_modified.ligands.cif" \
+                  "$adp" \
                   strategy="*individual_sites *individual_adp *occupancies" \
                   output.prefix="${pdb_name}" \
                   output.serial=3 \
@@ -162,6 +163,7 @@ while [ $zeroes -gt 1 ]; do
   else
     phenix.refine "${pdb_name}_002.pdb" \
                   "${pdb_name}_002.mtz" \
+                  "$adp" \
                   strategy="*individual_sites *individual_adp *occupancies" \
                   output.prefix="${pdb_name}" \
                   output.serial=3 \


### PR DESCRIPTION
Currently, there is a non-continuous adp function: inside the loop, we use (whatever is default), and we override it for the final round.
If the structure is < 1.5 Å, this can cause inconsistencies with occupancies. The last round of refinement, an alt-conf can suddenly drop to 0.02 ... without being culled.

Putting the $adp variable in the loop will improve consistency with the last round of refinement.