### PR TITLE
Improve flags (& --help) of qfit programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,22 +152,21 @@ of the Phenix software suite.
 ### 4. Deactivate backbone sampling and bond angle sampling to model alternate conformers for a single residue of interest (faster, less precise)
 
 In its default mode, *qfit_residue* and *qfit_protein* samples backbone conformations
-using our KGS routine. This can be disabled using the *-bb* flag.
+using our KGS routine. This can be disabled using the *--no-backbone* flag.
 
 For even faster (and less precise) results, one can also disable the sampling of
-the bond angle N-CA-CB, which can be deactivated by means of the *-sa* flag.
+the bond angle Cα-Cβ-Cγ, which can be deactivated by means of the *--no-sample-angle* flag.
 
 Other useful sampling parameters that can be tweaked to make qFit run faster at
 the cost of precision:
 
-* Increase step size (in degrees) sampled around each rotamer: *-s* flag (default: 10).
-* Decrease rotamer neighborhood sampled: *-rn* flag (default: 80)
-* Disable parsimonious selection of the number of conformers output by qFit using the Bayesian
-Information Criterion (BIC): *-T* flag.
+* Increase step size (in degrees) of sampling around each rotamer: *-s* flag (default: 10)
+* Decrease range/neighborhood of sampling about preferred rotamers: *-rn* flag (default: 60)
+* Disable parsimonious selection of the number of conformers output by qFit using the Bayesian Information Criterion (BIC): *--no-threshold-selection* flag.
 
 Using the example 3K0N:
 
-`qfit_residue /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb A,113 -bb -sa -s 20 -T -rn 45`
+`qfit_residue /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb A,113 --no-backbone --no-sample-angle -s 20 -rn 45 --no-threshold-selection`
 
 For a full list of options, run:
 
@@ -178,17 +177,17 @@ For a full list of options, run:
 
 Using the example 3K0N:
 
-`qfit_protein /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb -bb -sa -s 20 -T -rn 45`
+`qfit_protein /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb --no-backbone --no-sample-angle -s 20 -rn 45 --no-threshold-selection`
 
 
 ### 6.  Parallelization:
 
-The *qfit_protein* routine can be executed in parallel and the number of concurrent threads
+The *qfit_protein* program can be executed in parallel and the number of concurrent processes
 can be adjusted using the *-p* flag.
 
-Using the example 3K0N, spawning 30 parallel threads:
+Using the example 3K0N, spawning 30 parallel processes:
 
-`qfit_protein /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb  -p 30`
+`qfit_protein /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/3K0N.pdb -p 30`
 
 
 ### 7. Revisiting the consistent protein segment output by qfit_protein
@@ -200,9 +199,9 @@ of the parameters in a resolution-dependent manner.
 
 In the meantime, if you notice that your conformer of interest is present in
 *multiconformer_model.pdb*, but was subsequently removed by *qfit_protein*, you
-can re-process the initial model with less stringent parameters using the *qfit_segment* routine:
+can re-process the initial model with less stringent parameters using the *qfit_segment* program:
 
-`qfit_segment /path/to/3K0N.mtz  -l 2FOFCWT,PH2FOFCWT /path/to/multiconformer_model.pdb -Ts -f 3`
+`qfit_segment /path/to/3K0N.mtz -l 2FOFCWT,PH2FOFCWT /path/to/multiconformer_model.pdb --no-segment-threshold-selection -f 3`
 
 
 ### 8. Modeling alternate conformers of a ligand (under development)

--- a/src/qfit/custom_argparsers.py
+++ b/src/qfit/custom_argparsers.py
@@ -3,6 +3,54 @@
 import argparse
 
 
+class ToggleActionFlag(argparse.Action):
+    """Adds a 'no' prefix to disable store_true actions.
+
+    For example, --debug will have an additional --no-debug to explicitly disable it.
+    """
+    def __init__(self, option_strings, dest=None, **kwargs):
+        super().__init__(option_strings, dest, **kwargs)
+
+        if len(option_strings) != 1:
+            raise argparse.ArgumentError(self,
+                                         f"An argument of type {self.__class__.__name__} "
+                                         f"can only have one opt-string.")
+
+        option_string = option_strings[0].lstrip('-')
+        self.option_strings = ['--' + option_string,
+                               '--no-' + option_string]
+        self.dest = (option_string.replace('-', '_') if dest is None else dest)
+        self.nargs = 0
+        self.const = None
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string.startswith('--no-'):
+            setattr(namespace, self.dest, False)
+        else:
+            setattr(namespace, self.dest, True)
+
+
+class ToggleActionFlagFormatter(argparse.HelpFormatter):
+    """Condenses --help output.
+
+    This changes the --help output, what is originally this:
+        --file, --no-file, -f
+    will be condensed like this:
+        --[no-]file, -f
+    """
+    # ht: https://stackoverflow.com/questions/9234258/in-python-argparse-is-it-possible-to-have-paired-no-something-something-arg/36803315#36803315
+
+    def _format_action_invocation(self, action):
+        if isinstance(action, ToggleActionFlag):
+            return ', '.join(
+                [action.option_strings[0][:2] + '[no-]' + action.option_strings[0][2:]]
+                + action.option_strings[2:]
+            )
+        else:
+            return super()._format_action_invocation(action)
+
+
 class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter,
-                          argparse.ArgumentDefaultsHelpFormatter):
+                          argparse.ArgumentDefaultsHelpFormatter,
+                          ToggleActionFlagFormatter):
     pass

--- a/src/qfit/custom_argparsers.py
+++ b/src/qfit/custom_argparsers.py
@@ -1,0 +1,8 @@
+"""Contains custom argparse actions & formatters."""
+
+import argparse
+
+
+class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter,
+                          argparse.ArgumentDefaultsHelpFormatter):
+    pass

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -69,7 +69,7 @@ class _BaseQFitOptions:
         self.density_cutoff_value = -1
         self.subtract = True
         self.padding = 8.0
-        self.nowaters = False
+        self.waters_clash = True
 
         # Density creation options
         self.map_type = None
@@ -201,7 +201,7 @@ class _BaseQFit:
     def _subtract_transformer(self, residue, structure):
         # Select the atoms whose density we are going to subtract:
         subtract_structure = structure.extract_neighbors(residue, self.options.padding)
-        if self.options.nowaters:
+        if not self.options.waters_clash:
             subtract_structure = subtract_structure.extract("resn", "HOH", "!=")
 
         # Calculate the density that we are going to subtract:

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -26,6 +26,7 @@ IN THE SOFTWARE.
 """Hierarchically build a multiconformer ligand."""
 
 import argparse
+from .custom_argparsers import ToggleActionFlag, CustomHelpFormatter
 import logging
 import os.path
 import os
@@ -41,7 +42,8 @@ logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
 
 def build_argparser():
-    p = argparse.ArgumentParser(description=__doc__)
+    p = argparse.ArgumentParser(formatter_class=CustomHelpFormatter,
+                                description=__doc__)
     p.add_argument("map", type=str,
             help="Density map in CCP4 or MRC format, or an MTZ file "
                  "containing reflections and phases. For MTZ files "
@@ -54,78 +56,91 @@ def build_argparser():
             help="Chain, residue id, and optionally insertion code for residue in structure, e.g. A,105, or A,105:A.")
 
     # Map input options
-    p.add_argument("-l", "--label", default="FWT,PHWT", metavar="<F,PHI>",
-            help="MTZ column labels to build density.")
-    p.add_argument('-r', "--resolution", type=float, default=None, metavar="<float>",
-            help="Map resolution in angstrom. Only use when providing CCP4 map files.")
-    p.add_argument("-m", "--resolution_min", type=float, default=None, metavar="<float>",
-            help="Lower resolution bound in angstrom. Only use when providing CCP4 map files.")
+    p.add_argument("-l", "--label", default="FWT,PHWT",
+                   metavar="<F,PHI>",
+                   help="MTZ column labels to build density")
+    p.add_argument('-r', "--resolution", default=None,
+                   metavar="<float>", type=float,
+                   help="Map resolution (Å) (only use when providing CCP4 map files)")
+    p.add_argument("-m", "--resolution-min", default=None,
+                   metavar="<float>", type=float,
+                   help="Lower resolution bound (Å) (only use when providing CCP4 map files)")
     p.add_argument("-z", "--scattering", choices=["xray", "electron"], default="xray",
-            help="Scattering type.")
+                   help="Scattering type")
     p.add_argument("-rb", "--randomize-b", action="store_true", dest="randomize_b",
-        help="Randomize B-factors of generated conformers.")
+                   help="Randomize B-factors of generated conformers")
     p.add_argument('-o', '--omit', action="store_true",
-            help="Map file is an OMIT map. This affects the scaling procedure of the map.")
+                   help="Treat map file as an OMIT map in map scaling routines")
 
     # Map prep options
-    p.add_argument("-ns", "--no-scale", action="store_false", dest="scale",
-            help="Do not scale density.")
-    p.add_argument("-dc", "--density-cutoff", type=float, default=0.3, metavar="<float>",
-            help="Densities values below cutoff are set to <density_cutoff_value")
-    p.add_argument("-dv", "--density-cutoff-value", type=float, default=-1, metavar="<float>",
-            help="Density values below <density-cutoff> are set to this value.")
-    p.add_argument("-nosub", "--no-subtract", action="store_false", dest="subtract",
-            help="Do not subtract Fcalc of the neighboring residues when running qFit.")
-    p.add_argument("-pad", "--padding", type=float, default=8.0, metavar="<float>",
-            help="Padding size for map creation.")
-    p.add_argument("-nw", "--no-waters", action="store_true", dest="nowaters",
-        help="Keep waters, but do not consider them for soft clash detection.")
+    p.add_argument("--scale", action=ToggleActionFlag, dest="scale", default=True,
+                   help="Scale density")
+    p.add_argument("-dc", "--density-cutoff", default=0.3,
+                   metavar="<float>", type=float,
+                   help="Density values below this value are set to <density-cutoff-value>")
+    p.add_argument("-dv", "--density-cutoff-value", default=-1,
+                   metavar="<float>", type=float,
+                   help="Density values below <density-cutoff> are set to this value")
+    p.add_argument("--subtract", action=ToggleActionFlag, dest="subtract", default=True,
+                   help="Subtract Fcalc of neighboring residues when running qFit")
+    p.add_argument("-pad", "--padding", default=8.0,
+                   metavar="<float>", type=float,
+                   help="Padding size for map creation")
+    p.add_argument("--waters-clash", action=ToggleActionFlag, dest="waters_clash", default=True,
+                   help="Consider waters for soft clash detection")
 
     # Sampling options
-    p.add_argument("-nb", "--no-build", action="store_false", dest="build",
-            help="Do not build ligand.")
-    p.add_argument("-nl", "--no-local", action="store_false", dest="local_search",
-            help="Do not perform a local search.")
+    p.add_argument("--build", action=ToggleActionFlag, dest="build", default=True,
+                   help="Build ligand")
+    p.add_argument("--local", action=ToggleActionFlag, dest="local_search", default=True,
+                   help="Perform a local search")
     p.add_argument("--remove-conformers-below-cutoff", action="store_true",
                    dest="remove_conformers_below_cutoff",
-            help=("Remove conformers during sampling that have atoms that have "
-                  "no density support for, i.e. atoms are positioned at density "
-                  "values below cutoff value."))
-    p.add_argument('-cf', "--clash_scaling_factor", type=float, default=0.75, metavar="<float>",
-            help="Set clash scaling factor. Default = 0.75")
-    p.add_argument('-ec', "--external_clash", dest="external_clash", action="store_true",
-            help="Enable external clash detection during sampling.")
-    p.add_argument("-bs", "--bulk_solvent_level", default=0.3, type=float, metavar="<float>",
-            help="Bulk solvent level in absolute values.")
-    p.add_argument("-b", "--build-stepsize", type=int, default=2, metavar="<int>", dest="dofs_per_iteration",
-            help="Number of internal degrees that are sampled/built per iteration.")
-    p.add_argument("-s", "--stepsize", type=float, default=10,
-            metavar="<float>", dest="sample_ligand_stepsize",
-            help="Stepsize for dihedral angle sampling in degree.")
-    p.add_argument("-c", "--cardinality", type=int, default=5, metavar="<int>",
-            help="Cardinality constraint used during MIQP.")
-    p.add_argument("-t", "--threshold", type=float, default=0.2, metavar="<float>",
-            help="Threshold constraint used during MIQP.")
-    p.add_argument("-it", "--intermediate-threshold", type=float, default=0.01, metavar="<float>",
-            help="Threshold constraint during intermediate MIQP.")
-    p.add_argument("-ic", "--intermediate-cardinality", type=int, default=5, metavar="<int>",
-            help="Cardinality constraint used during intermediate MIQP.")
-    p.add_argument("-hy", "--hydro", dest="hydro", action="store_true",
-            help="Include hydrogens during calculations.")
-    p.add_argument("-T","--no-threshold-selection", dest="bic_threshold", action="store_false",
-            help="Do not use BIC to select the most parsimonious MIQP threshold")
-
+                   help=("Remove conformers during sampling that have atoms "
+                         "with no density support, i.e. atoms are positioned "
+                         "at density values below <density-cutoff>"))
+    p.add_argument('-cf', "--clash-scaling-factor", default=0.75,
+                   metavar="<float>", type=float,
+                   help="Set clash scaling factor")
+    p.add_argument('-ec', "--external-clash", action="store_true", dest="external_clash",
+                   help="Enable external clash detection during sampling")
+    p.add_argument("-bs", "--bulk-solvent-level", default=0.3,
+                   metavar="<float>", type=float,
+                   help="Bulk solvent level in absolute values")
+    p.add_argument("-b", "--dofs-per-iteration", default=2,
+                   metavar="<int>", type=int,
+                   help="Number of internal degrees that are sampled/built per iteration")
+    p.add_argument("-s", "--dihedral-stepsize", default=10,
+                   metavar="<float>", type=float,
+                   help="Stepsize for dihedral angle sampling in degrees")
+    p.add_argument("-c", "--cardinality", default=5,
+                   metavar="<int>", type=int,
+                   help="Cardinality constraint used during MIQP")
+    p.add_argument("-t", "--threshold", default=0.2,
+                   metavar="<float>", type=float,
+                   help="Threshold constraint used during MIQP")
+    p.add_argument("-ic", "--intermediate-cardinality", default=5,
+                   metavar="<int>", type=int,
+                   help="Cardinality constraint used during intermediate MIQP")
+    p.add_argument("-it", "--intermediate-threshold", default=0.01,
+                   metavar="<float>", type=float,
+                   help="Threshold constraint during intermediate MIQP")
+    p.add_argument("-hy", "--hydro", action="store_true", dest="hydro",
+                   help="Include hydrogens during calculations")
+    p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
+                   help="Use BIC to select the most parsimonious MIQP threshold")
 
     # Output options
-    p.add_argument("-d", "--directory", type=os.path.abspath, default='.', metavar="<dir>",
-            help="Directory to store results.")
+    p.add_argument("-d", "--directory", default='.',
+                   metavar="<dir>", type=os.path.abspath,
+                   help="Directory to store results")
     p.add_argument("-v", "--verbose", action="store_true",
-            help="Be verbose.")
+                   help="Be verbose")
     p.add_argument("--debug", action="store_true",
-            help="Log as much information as possible.")
-    p.add_argument("--write_intermediate_conformers", action="store_true",
-            help="Write intermediate structures to file (useful with debugging).")
-    p.add_argument("--pdb", help="Name of the input PDB.")
+                   help="Log as much information as possible")
+    p.add_argument("--write-intermediate-conformers", action="store_true",
+                   help="Write intermediate structures to file (useful with debugging)")
+    p.add_argument("--pdb", help="Name of the input PDB")
 
     return p
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -32,6 +32,7 @@ import os
 import sys
 import time
 import argparse
+from .custom_argparsers import CustomHelpFormatter
 import logging
 import traceback
 from .logtools import setup_logging, log_run_info, poolworker_setup_logging, QueueListener
@@ -41,11 +42,6 @@ from .structure.rotamers import ROTAMERS
 
 logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
-
-
-class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter,
-                          argparse.ArgumentDefaultsHelpFormatter):
-    pass
 
 
 def build_argparser():

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -85,8 +85,8 @@ def build_argparser():
     p.add_argument("-pad", "--padding", default=8.0,
                    metavar="<float>", type=float,
                    help="Padding size for map creation.")
-    p.add_argument("-nw", "--no-waters", action="store_true", dest="nowaters",
-                   help="Keep waters, but do not consider them for soft clash detection.")
+    p.add_argument("--waters-clash", action=ToggleActionFlag, dest="waters_clash", default=True,
+                   help="Consider waters for soft clash detection.")
 
     # Sampling options
     p.add_argument("--backbone", action=ToggleActionFlag, dest="sample_backbone", default=True,

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -57,113 +57,113 @@ def build_argparser():
     # Map input options
     p.add_argument("-l", "--label", default="FWT,PHWT",
                    metavar="<F,PHI>",
-                   help="MTZ column labels to build density.")
+                   help="MTZ column labels to build density")
     p.add_argument('-r', "--resolution", default=None,
                    metavar="<float>", type=float,
-                   help="Map resolution in angstrom. Only use when providing CCP4 map files.")
+                   help="Map resolution (Å) (only use when providing CCP4 map files)")
     p.add_argument("-m", "--resolution-min", default=None,
                    metavar="<float>", type=float,
-                   help="Lower resolution bound in angstrom. Only use when providing CCP4 map files.")
+                   help="Lower resolution bound (Å) (only use when providing CCP4 map files)")
     p.add_argument("-z", "--scattering", choices=["xray", "electron"], default="xray",
-                   help="Scattering type.")
+                   help="Scattering type")
     p.add_argument("-rb", "--randomize-b", action="store_true", dest="randomize_b",
-                   help="Randomize B-factors of generated conformers.")
+                   help="Randomize B-factors of generated conformers")
     p.add_argument('-o', '--omit', action="store_true",
-                   help="Map file is an OMIT map. This affects the scaling procedure of the map.")
+                   help="Treat map file as an OMIT map in map scaling routines")
 
     # Map prep options
     p.add_argument("--scale", action=ToggleActionFlag, dest="scale", default=True,
-                   help="Scale density.")
+                   help="Scale density")
     p.add_argument("-dc", "--density-cutoff", default=0.3,
                    metavar="<float>", type=float,
-                   help="Density values below this value are set to <density-cutoff-value>.")
+                   help="Density values below this value are set to <density-cutoff-value>")
     p.add_argument("-dv", "--density-cutoff-value", default=-1,
                    metavar="<float>", type=float,
-                   help="Density values below <density-cutoff> are set to this value.")
+                   help="Density values below <density-cutoff> are set to this value")
     p.add_argument("--subtract", action=ToggleActionFlag, dest="subtract", default=True,
-                   help="Subtract Fcalc of neighboring residues when running qFit.")
+                   help="Subtract Fcalc of neighboring residues when running qFit")
     p.add_argument("-pad", "--padding", default=8.0,
                    metavar="<float>", type=float,
-                   help="Padding size for map creation.")
+                   help="Padding size for map creation")
     p.add_argument("--waters-clash", action=ToggleActionFlag, dest="waters_clash", default=True,
-                   help="Consider waters for soft clash detection.")
+                   help="Consider waters for soft clash detection")
 
     # Sampling options
     p.add_argument("--backbone", action=ToggleActionFlag, dest="sample_backbone", default=True,
-                   help="Sample backbone using inverse kinematics.")
+                   help="Sample backbone using inverse kinematics")
     p.add_argument('-bbs', "--backbone-step", default=0.1, dest="sample_backbone_step",
                    metavar="<float>", type=float,
-                   help="Stepsize for the amplitude of backbone sampling (Å).")
+                   help="Stepsize for the amplitude of backbone sampling (Å)")
     p.add_argument('-bba', "--backbone-amplitude", default=0.3, dest="sample_backbone_amplitude",
                    metavar="<float>", type=float,
-                   help="Maximum backbone amplitude (Å).")
+                   help="Maximum backbone amplitude (Å)")
     p.add_argument('-bbv', "--backbone-sigma", default=0.125, dest="sample_backbone_sigma",
                    metavar="<float>", type=float,
-                   help="Backbone random-sampling displacement (Å).")
+                   help="Backbone random-sampling displacement (Å)")
     p.add_argument("--sample-angle", action=ToggleActionFlag, dest="sample_angle", default=True,
                    help="Sample CA-CB-CG angle for aromatic F/H/W/Y residues")
     p.add_argument('-sas', "--sample-angle-step", default=3.75, dest="sample_angle_step",
                    metavar="<float>", type=float,
-                   help="CA-CB-CG bond angle sampling step in degrees.")
+                   help="CA-CB-CG bond angle sampling step in degrees")
     p.add_argument('-sar', "--sample-angle-range", default=7.5, dest="sample_angle_range",
                    metavar="<float>", type=float,
-                   help="CA-CB-CG bond angle sampling range in degrees [-x,x].")
+                   help="CA-CB-CG bond angle sampling range in degrees [-x,x]")
     p.add_argument("-b", "--dofs-per-iteration", default=2,
                    metavar="<int>", type=int,
-                   help="Number of internal degrees that are sampled/built per iteration.")
+                   help="Number of internal degrees that are sampled/built per iteration")
     p.add_argument("-s", "--dihedral-stepsize", default=10,
                    metavar="<float>", type=float,
-                   help="Stepsize for dihedral angle sampling in degrees.")
+                   help="Stepsize for dihedral angle sampling in degrees")
     p.add_argument("-rn", "--rotamer-neighborhood", default=60,
                    metavar="<float>", type=float,
-                   help="Chi dihedral-angle sampling range around each rotamer in degrees [-x,x].")
+                   help="Chi dihedral-angle sampling range around each rotamer in degrees [-x,x]")
     p.add_argument("--remove-conformers-below-cutoff", action="store_true",
                    dest="remove_conformers_below_cutoff",
                    help=("Remove conformers during sampling that have atoms "
                          "with no density support, i.e. atoms are positioned "
-                         "at density values below <density-cutoff>."))
+                         "at density values below <density-cutoff>"))
     p.add_argument('-cf', "--clash-scaling-factor", default=0.75,
                    metavar="<float>", type=float,
-                   help="Set clash scaling factor.")
+                   help="Set clash scaling factor")
     p.add_argument('-ec', "--external-clash", action="store_true", dest="external_clash",
-                   help="Enable external clash detection during sampling.")
+                   help="Enable external clash detection during sampling")
     p.add_argument("-bs", "--bulk-solvent-level", default=0.3,
                    metavar="<float>", type=float,
-                   help="Bulk solvent level in absolute values.")
+                   help="Bulk solvent level in absolute values")
     p.add_argument("-c", "--cardinality", default=5,
                    metavar="<int>", type=int,
-                   help="Cardinality constraint used during MIQP.")
+                   help="Cardinality constraint used during MIQP")
     p.add_argument("-t", "--threshold", default=0.2,
                    metavar="<float>", type=float,
-                   help="Threshold constraint used during MIQP.")
+                   help="Threshold constraint used during MIQP")
     p.add_argument("-hy", "--hydro", action="store_true", dest="hydro",
-                   help="Include hydrogens during calculations.")
+                   help="Include hydrogens during calculations")
     p.add_argument('-rmsd', "--rmsd-cutoff", default=0.01,
                    metavar="<float>", type=float,
-                   help="RMSD cutoff for removal of identical conformers.")
+                   help="RMSD cutoff for removal of identical conformers")
     p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
                    help="Use BIC to select the most parsimonious MIQP threshold")
     p.add_argument("-p", "--nproc", type=int, default=1, metavar="<int>",
-                   help="Number of processors to use.")
+                   help="Number of processors to use")
 
     # qFit Segment options
     p.add_argument("-f", "--fragment-length", default=4, dest="fragment_length",
                    metavar="<int>", type=int,
-                   help="Fragment length used during qfit_segment.")
+                   help="Fragment length used during qfit_segment")
     p.add_argument("--segment-threshold-selection", action=ToggleActionFlag, dest="seg_bic_threshold", default=True,
-                   help="Use BIC to select the most parsimonious MIQP threshold (segment).")
+                   help="Use BIC to select the most parsimonious MIQP threshold (segment)")
 
     # Output options
     p.add_argument("-d", "--directory", default='.',
                    metavar="<dir>", type=os.path.abspath,
-                   help="Directory to store results.")
+                   help="Directory to store results")
     p.add_argument("-v", "--verbose", action="store_true",
-                   help="Be verbose.")
+                   help="Be verbose")
     p.add_argument("--debug", action="store_true",
-                   help="Log as much information as possible.")
+                   help="Log as much information as possible")
     p.add_argument("--write-intermediate-conformers", action="store_true",
-                   help="Write intermediate structures to file (useful with debugging).")
-    p.add_argument("--pdb", help="Name of the input PDB.")
+                   help="Write intermediate structures to file (useful with debugging)")
+    p.add_argument("--pdb", help="Name of the input PDB")
 
     return p
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -61,7 +61,7 @@ def build_argparser():
     p.add_argument('-r', "--resolution", default=None,
                    metavar="<float>", type=float,
                    help="Map resolution in angstrom. Only use when providing CCP4 map files.")
-    p.add_argument("-m", "--resolution_min", default=None,
+    p.add_argument("-m", "--resolution-min", default=None,
                    metavar="<float>", type=float,
                    help="Lower resolution bound in angstrom. Only use when providing CCP4 map files.")
     p.add_argument("-z", "--scattering", choices=["xray", "electron"], default="xray",
@@ -122,12 +122,12 @@ def build_argparser():
                    help=("Remove conformers during sampling that have atoms "
                          "with no density support, i.e. atoms are positioned "
                          "at density values below <density-cutoff>."))
-    p.add_argument('-cf', "--clash_scaling_factor", default=0.75,
+    p.add_argument('-cf', "--clash-scaling-factor", default=0.75,
                    metavar="<float>", type=float,
                    help="Set clash scaling factor.")
-    p.add_argument('-ec', "--external_clash", action="store_true", dest="external_clash",
+    p.add_argument('-ec', "--external-clash", action="store_true", dest="external_clash",
                    help="Enable external clash detection during sampling.")
-    p.add_argument("-bs", "--bulk_solvent_level", default=0.3,
+    p.add_argument("-bs", "--bulk-solvent-level", default=0.3,
                    metavar="<float>", type=float,
                    help="Bulk solvent level in absolute values.")
     p.add_argument("-c", "--cardinality", default=5,
@@ -138,7 +138,7 @@ def build_argparser():
                    help="Threshold constraint used during MIQP.")
     p.add_argument("-hy", "--hydro", action="store_true", dest="hydro",
                    help="Include hydrogens during calculations.")
-    p.add_argument('-rmsd', "--rmsd_cutoff", default=0.01,
+    p.add_argument('-rmsd', "--rmsd-cutoff", default=0.01,
                    metavar="<float>", type=float,
                    help="RMSD cutoff for removal of identical conformers.")
     p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
@@ -161,7 +161,7 @@ def build_argparser():
                    help="Be verbose.")
     p.add_argument("--debug", action="store_true",
                    help="Log as much information as possible.")
-    p.add_argument("--write_intermediate_conformers", action="store_true",
+    p.add_argument("--write-intermediate-conformers", action="store_true",
                    help="Write intermediate structures to file (useful with debugging).")
     p.add_argument("--pdb", help="Name of the input PDB.")
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -72,16 +72,16 @@ def build_argparser():
                    help="Map file is an OMIT map. This affects the scaling procedure of the map.")
 
     # Map prep options
-    p.add_argument("-ns", "--no-scale", action="store_false", dest="scale",
-                   help="Do not scale density.")
+    p.add_argument("--scale", action=ToggleActionFlag, dest="scale", default=True,
+                   help="Scale density.")
     p.add_argument("-dc", "--density-cutoff", default=0.3,
                    metavar="<float>", type=float,
                    help="Density values below this value are set to <density-cutoff-value>.")
     p.add_argument("-dv", "--density-cutoff-value", default=-1,
                    metavar="<float>", type=float,
                    help="Density values below <density-cutoff> are set to this value.")
-    p.add_argument("-nosub", "--no-subtract", action="store_false", dest="subtract",
-                   help="Do not subtract Fcalc of the neighboring residues when running qFit.")
+    p.add_argument("--subtract", action=ToggleActionFlag, dest="subtract", default=True,
+                   help="Subtract Fcalc of neighboring residues when running qFit.")
     p.add_argument("-pad", "--padding", default=8.0,
                    metavar="<float>", type=float,
                    help="Padding size for map creation.")
@@ -89,8 +89,8 @@ def build_argparser():
                    help="Keep waters, but do not consider them for soft clash detection.")
 
     # Sampling options
-    p.add_argument('-bb', "--no-backbone", action="store_false", dest="sample_backbone",
-                   help="Do not sample backbone using inverse kinematics.")
+    p.add_argument("--backbone", action=ToggleActionFlag, dest="sample_backbone", default=True,
+                   help="Sample backbone using inverse kinematics.")
     p.add_argument('-bbs', "--backbone-step", default=0.1, dest="sample_backbone_step",
                    metavar="<float>", type=float,
                    help="Stepsize for the amplitude of backbone sampling (Å).")
@@ -100,8 +100,8 @@ def build_argparser():
     p.add_argument('-bbv', "--backbone-sigma", default=0.125, dest="sample_backbone_sigma",
                    metavar="<float>", type=float,
                    help="Backbone random-sampling displacement (Å).")
-    p.add_argument('-sa', "--no-sample-angle", action="store_false", dest="sample_angle",
-                   help="Do not sample CA-CB-CG angle.")
+    p.add_argument("--sample-angle", action=ToggleActionFlag, dest="sample_angle", default=True,
+                   help="Sample CA-CB-CG angle for aromatic F/H/W/Y residues")
     p.add_argument('-sas', "--sample-angle-step", default=3.75, dest="sample_angle_step",
                    metavar="<float>", type=float,
                    help="CA-CB-CG bond angle sampling step in degrees.")
@@ -141,8 +141,8 @@ def build_argparser():
     p.add_argument('-rmsd', "--rmsd_cutoff", default=0.01,
                    metavar="<float>", type=float,
                    help="RMSD cutoff for removal of identical conformers.")
-    p.add_argument("-T", "--no-threshold-selection", dest="bic_threshold",
-                   action="store_false", help="Do not use BIC to select the most parsimonious MIQP threshold")
+    p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
+                   help="Use BIC to select the most parsimonious MIQP threshold")
     p.add_argument("-p", "--nproc", type=int, default=1, metavar="<int>",
                    help="Number of processors to use.")
 
@@ -150,9 +150,8 @@ def build_argparser():
     p.add_argument("-f", "--fragment-length", default=4, dest="fragment_length",
                    metavar="<int>", type=int,
                    help="Fragment length used during qfit_segment.")
-    p.add_argument("-Ts", "--no-segment-threshold-selection", action="store_false", dest="seg_bic_threshold",
-                   help="Do not use BIC to select the most "
-                        "parsimonious MIQP threshold (segment).")
+    p.add_argument("--segment-threshold-selection", action=ToggleActionFlag, dest="seg_bic_threshold", default=True,
+                   help="Use BIC to select the most parsimonious MIQP threshold (segment).")
 
     # Output options
     p.add_argument("-d", "--directory", default='.',

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -32,7 +32,7 @@ import os
 import sys
 import time
 import argparse
-from .custom_argparsers import CustomHelpFormatter
+from .custom_argparsers import ToggleActionFlag, CustomHelpFormatter
 import logging
 import traceback
 from .logtools import setup_logging, log_run_info, poolworker_setup_logging, QueueListener

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -26,9 +26,9 @@ IN THE SOFTWARE.
 """Automatically build a multiconformer residue"""
 
 import argparse
+from .custom_argparsers import ToggleActionFlag, CustomHelpFormatter
 import logging
 import os
-from os import path
 import sys
 import time
 import numpy as np
@@ -41,110 +41,132 @@ from .structure import residue_type
 logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
 
-def parse_args():
-    p = argparse.ArgumentParser(description=__doc__)
+def build_argparser():
+    p = argparse.ArgumentParser(formatter_class=CustomHelpFormatter,
+                                description=__doc__)
     p.add_argument("map", type=str,
-            help="Density map in CCP4 or MRC format, or an MTZ file "
-                 "containing reflections and phases. For MTZ files "
-                 "use the --label options to specify columns to read.")
-    p.add_argument("structure", type=str,
-            help="PDB-file containing structure.")
+                   help="Density map in CCP4 or MRC format, or an MTZ file "
+                        "containing reflections and phases. For MTZ files "
+                        "use the --label options to specify columns to read.")
+    p.add_argument("structure",
+                   help="PDB-file containing structure.")
     p.add_argument('selection', type=str,
-            help="Chain, residue id, and optionally insertion code for residue in structure, e.g. A,105, or A,105:A.")
+                   help="Chain, residue id, and optionally insertion code for "
+                        "residue in structure, e.g. A,105, or A,105:A.")
 
     # Map input options
-    p.add_argument("-l", "--label", default="FWT,PHWT", metavar="<F,PHI>",
-            help="MTZ column labels to build density.")
-    p.add_argument('-r', "--resolution", type=float, default=None, metavar="<float>",
-            help="Map resolution in angstrom. Only use when providing CCP4 map files.")
-    p.add_argument("-m", "--resolution_min", type=float, default=None, metavar="<float>",
-            help="Lower resolution bound in angstrom. Only use when providing CCP4 map files.")
+    p.add_argument("-l", "--label", default="FWT,PHWT",
+                   metavar="<F,PHI>",
+                   help="MTZ column labels to build density")
+    p.add_argument('-r', "--resolution", default=None,
+                   metavar="<float>", type=float,
+                   help="Map resolution (Å) (only use when providing CCP4 map files)")
+    p.add_argument("-m", "--resolution-min", default=None,
+                   metavar="<float>", type=float,
+                   help="Lower resolution bound (Å) (only use when providing CCP4 map files)")
     p.add_argument("-z", "--scattering", choices=["xray", "electron"], default="xray",
-            help="Scattering type.")
+                   help="Scattering type")
     p.add_argument("-rb", "--randomize-b", action="store_true", dest="randomize_b",
-        help="Randomize B-factors of generated conformers.")
+                   help="Randomize B-factors of generated conformers")
     p.add_argument('-o', '--omit', action="store_true",
-            help="Map file is an OMIT map. This affects the scaling procedure of the map.")
+                   help="Treat map file as an OMIT map in map scaling routines")
 
     # Map prep options
-    p.add_argument("-ns", "--no-scale", action="store_false", dest="scale",
-            help="Do not scale density.")
-    p.add_argument("-sv", "--scale-rmask", type=float, dest="scale_rmask", default=1.0, metavar="<float>",
-            help="Radius mask for the map scaling.")
-    p.add_argument("-dc", "--density-cutoff", type=float, default=0.3, metavar="<float>",
-            help="Densities values below cutoff are set to <density_cutoff_value")
-    p.add_argument("-dv", "--density-cutoff-value", type=float, default=-1, metavar="<float>",
-            help="Density values below <density-cutoff> are set to this value.")
+    p.add_argument("--scale", action=ToggleActionFlag, dest="scale", default=True,
+                   help="Scale density")
+    p.add_argument("-sv", "--scale-rmask", dest="scale_rmask", default=1.0,
+                   metavar="<float>", type=float,
+                   help="Radius mask for map scaling")
+    p.add_argument("-dc", "--density-cutoff", default=0.3,
+                   metavar="<float>", type=float,
+                   help="Density values below this value are set to <density-cutoff-value>")
+    p.add_argument("-dv", "--density-cutoff-value", default=-1,
+                   metavar="<float>", type=float,
+                   help="Density values below <density-cutoff> are set to this value")
+    p.add_argument("--subtract", action=ToggleActionFlag, dest="subtract", default=True,
+                   help="Subtract Fcalc of neighboring residues when running qFit")
+    p.add_argument("-pad", "--padding", default=8.0,
+                   metavar="<float>", type=float,
+                   help="Padding size for map creation")
+    p.add_argument("--waters-clash", action=ToggleActionFlag, dest="waters_clash", default=True,
+                   help="Consider waters for soft clash detection")
     p.add_argument("-par", "--phenix-aniso", action="store_true", dest="phenix_aniso",
-            help="Use phenix to perform anisotropic refinement of individual sites."
-                 "This option creates an OMIT map and uses it as a default.")
-    p.add_argument("-nosub", "--no-subtract", action="store_false", dest="subtract",
-            help="Do not subtract Fcalc of the neighboring residues when running qFit.")
-    p.add_argument("-pad", "--padding", type=float, default=8.0, metavar="<float>",
-            help="Padding size for map creation.")
-    p.add_argument("-nw", "--no-waters", action="store_true", dest="nowaters",
-        help="Keep waters, but do not consider them for soft clash detection.")
+                   help="Use phenix to perform anisotropic refinement of individual sites."
+                        "This option creates an OMIT map and uses it as a default.")
 
     # Sampling options
-    p.add_argument('-bb', "--no-backbone", dest="sample_backbone", action="store_false",
-            help="Do not sample backbone using inverse kinematics.")
-    p.add_argument('-bbs', "--backbone-step", dest="sample_backbone_step",
-            type=float, default=0.1, metavar="<float>",
-            help="Stepsize for the amplitude of backbone sampling")
-    p.add_argument('-bba', "--backbone-amplitude", dest="sample_backbone_amplitude",
-            type=float, default=0.3, metavar="<float>",
-            help="Maximum backbone amplitude.")
-    p.add_argument('-sa', "--no-sample-angle", dest="sample_angle", action="store_false",
-            help="Sample N-CA-CB angle.")
-    p.add_argument('-sas', "--sample-angle-step", dest="sample_angle_step",
-            type=float, default=3.75, metavar="<float>",
-            help="N-CA-CB bond angle sampling step in degrees")
-    p.add_argument('-sar', "--sample-angle-range", dest="sample_angle_range",
-            type=float, default=7.5, metavar="<float>",
-            help="N-CA-CB bond angle sampling range in degrees [-x,x].")
-    p.add_argument("-b", "--dofs-per-iteration", type=int, default=2, metavar="<int>",
-            help="Number of internal degrees that are sampled/build per iteration.")
-    p.add_argument("-s", "--dihedral-stepsize", type=float, default=10, metavar="<float>",
-            help="Stepsize for dihedral angle sampling in degrees.")
-    p.add_argument("-rn", "--rotamer-neighborhood", type=float,
-            default=80, metavar="<float>",
-            help="Neighborhood of rotamer to sample in degree.")
+    p.add_argument("--backbone", action=ToggleActionFlag, dest="sample_backbone", default=True,
+                   help="Sample backbone using inverse kinematics")
+    p.add_argument('-bbs', "--backbone-step", default=0.1, dest="sample_backbone_step",
+                   metavar="<float>", type=float,
+                   help="Stepsize for the amplitude of backbone sampling (Å)")
+    p.add_argument('-bba', "--backbone-amplitude", default=0.3, dest="sample_backbone_amplitude",
+                   metavar="<float>", type=float,
+                   help="Maximum backbone amplitude (Å)")
+    p.add_argument('-bbv', "--backbone-sigma", default=0.125, dest="sample_backbone_sigma",
+                   metavar="<float>", type=float,
+                   help="Backbone random-sampling displacement (Å)")
+    p.add_argument("--sample-angle", action=ToggleActionFlag, dest="sample_angle", default=True,
+                   help="Sample CA-CB-CG angle for aromatic F/H/W/Y residues")
+    p.add_argument('-sas', "--sample-angle-step", default=3.75, dest="sample_angle_step",
+                   metavar="<float>", type=float,
+                   help="CA-CB-CG bond angle sampling step in degrees")
+    p.add_argument('-sar', "--sample-angle-range", default=7.5, dest="sample_angle_range",
+                   metavar="<float>", type=float,
+                   help="CA-CB-CG bond angle sampling range in degrees [-x,x]")
+    p.add_argument("-b", "--dofs-per-iteration", default=2,
+                   metavar="<int>", type=int,
+                   help="Number of internal degrees that are sampled/built per iteration")
+    p.add_argument("-s", "--dihedral-stepsize", default=10,
+                   metavar="<float>", type=float,
+                   help="Stepsize for dihedral angle sampling in degrees")
+    p.add_argument("-rn", "--rotamer-neighborhood", default=60,
+                   metavar="<float>", type=float,
+                   help="Chi dihedral-angle sampling range around each rotamer in degrees [-x,x]")
     p.add_argument("--remove-conformers-below-cutoff", action="store_true",
                    dest="remove_conformers_below_cutoff",
-            help=("Remove conformers during sampling that have atoms that have "
-                  "no density support for, i.e. atoms are positioned at density "
-                  "values below cutoff value."))
-    p.add_argument('-cf', "--clash_scaling_factor", type=float, default=0.75, metavar="<float>",
-            help="Set clash scaling factor. Default = 0.75")
-    p.add_argument('-ec', "--external_clash", dest="external_clash", action="store_true",
-            help="Enable external clash detection during sampling.")
-    p.add_argument("-bs", "--bulk_solvent_level", default=0.3, type=float, metavar="<float>",
-            help="Bulk solvent level in absolute values.")
-    p.add_argument("-c", "--cardinality", type=int, default=5, metavar="<int>",
-            help="Cardinality constraint used during MIQP.")
-    p.add_argument("-t", "--threshold", type=float, default=0.2, metavar="<float>",
-            help="Threshold constraint used during MIQP.")
-    p.add_argument("-hy", "--hydro", dest="hydro", action="store_true",
-            help="Include hydrogens during calculations.")
-    p.add_argument("-T", "--no-threshold-selection", dest="bic_threshold", action="store_false",
-            help="Do not use BIC to select the most parsimonious MIQP threshold")
-    p.add_argument('-rmsd', "--rmsd_cutoff", type=float, default=0.01, metavar="<float>",
-            help="RMSD cutoff for removal of identical conformers. Default = 0.01")
+                   help=("Remove conformers during sampling that have atoms "
+                         "with no density support, i.e. atoms are positioned "
+                         "at density values below <density-cutoff>"))
+    p.add_argument('-cf', "--clash-scaling-factor", default=0.75,
+                   metavar="<float>", type=float,
+                   help="Set clash scaling factor")
+    p.add_argument('-ec', "--external-clash", action="store_true", dest="external_clash",
+                   help="Enable external clash detection during sampling")
+    p.add_argument("-bs", "--bulk-solvent-level", default=0.3,
+                   metavar="<float>", type=float,
+                   help="Bulk solvent level in absolute values")
+    p.add_argument("-c", "--cardinality", default=5,
+                   metavar="<int>", type=int,
+                   help="Cardinality constraint used during MIQP")
+    p.add_argument("-t", "--threshold", default=0.2,
+                   metavar="<float>", type=float,
+                   help="Threshold constraint used during MIQP")
+    p.add_argument("-hy", "--hydro", action="store_true", dest="hydro",
+                   help="Include hydrogens during calculations")
+    p.add_argument('-rmsd', "--rmsd-cutoff", default=0.01,
+                   metavar="<float>", type=float,
+                   help="RMSD cutoff for removal of identical conformers")
+    p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
+                   help="Use BIC to select the most parsimonious MIQP threshold")
 
     # Output options
-    p.add_argument("-d", "--directory", type=os.path.abspath, default='.', metavar="<dir>",
-            help="Directory to store results.")
-    p.add_argument("--debug", action="store_true",
-            help="Write intermediate structures to file for debugging.")
+    p.add_argument("-d", "--directory", default='.',
+                   metavar="<dir>", type=os.path.abspath,
+                   help="Directory to store results")
     p.add_argument("-v", "--verbose", action="store_true",
-            help="Be verbose.")
-    args = p.parse_args()
+                   help="Be verbose")
+    p.add_argument("--debug", action="store_true",
+                   help="Log as much information as possible")
+    p.add_argument("--write-intermediate-conformers", action="store_true",
+                   help="Write intermediate structures to file (useful with debugging)")
 
-    return args
+    return p
 
 
 def main():
-    args = parse_args()
+    p = build_argparser()
+    args = p.parse_args(args=None)
     try:
         os.makedirs(args.directory)
     except OSError:


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

Fixes #69 .


### Release Notes

- Make default values for all command-line options appear in --help
- Improve clarity by making all flags positively worded, removing some short flags
- Change options to use internal hyphenation (no internal underscores) for consistency
- Unified some options across programs


### Command line changes

Flags that changed (maintained short form):
* ~~`--build-stepsize`~~ → `--dofs-per-iteration` (`-b`)
* ~~`--stepsize`~~ → `--dihedral-stepsize` (`-s`)
* ~~`--no-waters`~~ → `--no-waters-clash`

Removed short flags (now-required long form):
* ~~`-ns`~~ (`--no-scale`)
* ~~`-nosub`~~ (`--no-subtract`)
* ~~`-nw`~~ (`--no-waters-clash`)
* ~~`-nb`~~ (`--no-build`)
* ~~`-nl`~~ (`--no-local`)
* ~~`-bb`~~ (`--no-backbone`)
* ~~`-sa`~~ (`--no-sample-angle`)
* ~~`-T`~~ (`--no-threshold-selection`)
* ~~`-Ts`~~ (`--no-segment-threshold-selection`)

Now-hyphenated flags:
* ~~`--resolution_min`~~ → `--resolution-min`
* ~~`--clash_scaling_factor`~~ → `--clash-scaling-factor`
* ~~`--external_clash`~~ → `--external-clash`
* ~~`--bulk_solvent_level`~~ → `--bulk-solvent-level`
* ~~`--rmsd_cutoff`~~ → `--rmsd-cutoff`
* ~~`--write_intermediate_conformers`~~ → `--write-intermediate-conformers`

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
