### PR TITLE
Add --rmsd-cutoff option to qFit-ligand

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1372,7 +1372,7 @@ class QFitLigand(_BaseQFit):
                         if not self._cd() and not self.ligand.clashes():
                             if new_coor_set:
                                 delta = np.array(new_coor_set) - np.array(new_coor)
-                                if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= 0.01:
+                                if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= self.options.rmsd_cutoff:
                                     new_coor_set.append(new_coor)
                                     new_bs.append(b)
                             else:
@@ -1381,7 +1381,7 @@ class QFitLigand(_BaseQFit):
                     elif not self.ligand.clashes():
                         if new_coor_set:
                             delta = np.array(new_coor_set) - np.array(new_coor)
-                            if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= 0.01:
+                            if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= self.options.rmsd_cutoff:
                                 new_coor_set.append(new_coor)
                                 new_bs.append(b)
                         else:
@@ -1471,7 +1471,7 @@ class QFitLigand(_BaseQFit):
                             if not self._cd() and not self.ligand.clashes():
                                 if new_coor_set:
                                     delta = np.array(new_coor_set) - np.array(new_coor)
-                                    if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= 0.01:
+                                    if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= self.options.rmsd_cutoff:
                                         new_coor_set.append(new_coor)
                                         new_bs.append(b)
                                 else:
@@ -1480,7 +1480,7 @@ class QFitLigand(_BaseQFit):
                         elif not self.ligand.clashes():
                             if new_coor_set:
                                 delta = np.array(new_coor_set) - np.array(new_coor)
-                                if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= 0.01:
+                                if np.sqrt(min(np.square((delta)).sum(axis=2).sum(axis=1))) >= self.options.rmsd_cutoff:
                                     new_coor_set.append(new_coor)
                                     new_bs.append(b)
                             else:

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -130,6 +130,9 @@ def build_argparser():
                    help="Threshold constraint during intermediate MIQP")
     p.add_argument("-hy", "--hydro", action="store_true", dest="hydro",
                    help="Include hydrogens during calculations")
+    p.add_argument('-rmsd', "--rmsd-cutoff", default=0.01,
+                   metavar="<float>", type=float,
+                   help="RMSD cutoff for removal of identical conformers")
     p.add_argument("--threshold-selection", dest="bic_threshold", action=ToggleActionFlag, default=True,
                    help="Use BIC to select the most parsimonious MIQP threshold")
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

- Add --rmsd-cutoff option to reject new sampled confs that are too close to existing samplings
- Use the value defined on the command line

### Release Notes

- Add --rmsd-cutoff option to qFit-ligand

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
