### PR TITLE
Update setup-miniconda GitHub Action (repairs failing CI)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ['3.7', '3.6']
     steps:
       - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This is updating the miniconda set up tools to https://github.com/conda-incubator/setup-miniconda/issues/101. Github updated about 2 days ago (11/18/2020). See: https://github.com/conda-incubator/setup-miniconda/issues/101


### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

- Update the setup-miniconda action in the CI yaml: `.github/workflows/main.yaml`

### Release Notes

- (dev only) Fixed an issue with failing CI on GitHub

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
