### PR TITLE
Move to python 3.7, 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.6']
+        python-version: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once these are installed, you can:
 
 1. Create a new conda env & activate it
    ```bash
-   conda create --name qfit "python>=3.6"
+   conda create --name qfit "python>=3.7,<3.9"
    conda activate qfit
    ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,14 @@
 name: qfit
 
 channels:
-  - anaconda
-  - ibmdecisionoptimization
+  - conda-forge
   
 dependencies:
-  - mkl
-  - numpy>=1.17,<1.20
+  - libblas[build=*mkl]
+  - numpy>=1.20,<1.22
   - scipy>=1.0
-  - pandas>=1.1,<1.4
+  - pandas>=1.2,<1.4
   - pyparsing>=2.2.0
   - cvxopt
-  - cplex
+  - ibmdecisionoptimization::cplex
   - tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = [
 	"setuptools",  # PEP 508 specifications.
 	"wheel",       # PEP 508 specifications.
 	"setuptools_scm",
-	"numpy>=1.17,<1.20",
+	"numpy>=1.20,<1.22",
 ]

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ def main():
         'setuptools_scm',
     ]
     install_requires = [
-        'numpy>=1.17,<1.20',
+        'numpy>=1.20,<1.22',
         'scipy>=1.0',
-        'pandas>=1.1,<1.4',
+        'pandas>=1.2,<1.4',
         'pyparsing>=2.2.0',
         'tqdm>=4.0.0',
     ]

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -315,7 +315,7 @@ class CovalentBondRotator:
         # Determine which atoms will be moved by the rotation.
         self._root = getattr(covalent_residue, key).tolist().index(a1)
         self._conn = ligand.connectivity
-        self.atoms_to_rotate = [range(len(ligand.name))]
+        self.atoms_to_rotate = range(len(ligand.name))
 
         # Find the rigid motion that aligns the axis of rotation onto the z-axis.
         self._coor_to_rotate = self.ligand.coor[self.atoms_to_rotate].copy()

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -65,7 +65,7 @@ class Structure(_BaseStructure):
 
         data['coor'] = coor
         # Add an active array, to check for collisions and density creation.
-        data['active'] = np.ones(len(dd['x']), dtype=np.bool)
+        data['active'] = np.ones(len(dd['x']), dtype=bool)
         if pdbfile.anisou:
             natoms = len(data['record'])
             anisou = np.zeros((natoms, 6), float)


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

This bumps the version of python we require to 3.7+.
Python 3.6 is end-of-life at the end of 2021.
On top of this, moving to 3.7 means that we can rely on dataclasses being part of the standard library (which will make future development easier).


### Release Notes

- Now require python 3.7+
