### PR TITLE
Fixing large maps being able to be fed into qFit Protein without crashing

### DIFF
--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -16,6 +16,7 @@ from .logtools import setup_logging, log_run_info, poolworker_setup_logging, Que
 from . import MapScaler, Structure, XMap
 from .structure.rotamers import ROTAMERS
 
+
 logger = logging.getLogger(__name__)
 os.environ["OMP_NUM_THREADS"] = "1"
 
@@ -182,7 +183,7 @@ class QFitProtein:
             ctx = mp.get_context(method="spawn")
 
         # Print execution stats
-        residues = list(self.structure.single_conformer_residues) 
+        residues = list(self.structure.single_conformer_residues)
         logger.info(f"RESIDUES: {len(residues)}")
         logger.info(f"NPROC: {self.options.nproc}")
 
@@ -434,7 +435,7 @@ def prepare_qfit_protein(options):
     )
     xmap = xmap.canonical_unit_cell()
 
-    #scaling map based on input structure
+    # Scale map based on input structure
     if options.scale is True:
         scaler = MapScaler(xmap, scattering=options.scattering)
         radius = 1.5
@@ -477,4 +478,3 @@ def main():
     time0 = time.time()
     multiconformer = qfit.run()
     logger.info(f"Total time: {time.time() - time0}s")
-


### PR DESCRIPTION
# Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.


### Description of the Change

This fix is related to bug #139. qFit protein was crashing when large maps (only examples were from cryoEM) were fed into the pool multiprocessor due to memory issues.

The fix that was created was to subset the map for every residue before we launch the pool jobs. ~A dictionary is created which has a reduced map attached to the residue.~ This step was previously done within each pool job (ie pool job got entire map, then subsetted and fed into qFit residue).


### Release Notes

- qfit_protein should now work with large maps without crashing
