### PR TITLE
Unify all QFitOptions classes into a single class

### DIFF
--- a/src/qfit/__init__.py
+++ b/src/qfit/__init__.py
@@ -1,8 +1,9 @@
 import logging
 
-from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
-from .qfit import QFitCovalentLigand, QFitCovalentLigandOptions
-from .qfit import QFitLigand, QFitLigandOptions
+from .qfit import _BaseQFitOptions
+from .qfit import QFitRotamericResidue
+from .qfit import QFitCovalentLigand
+from .qfit import QFitLigand
 from .scaler import MapScaler
 from .structure import Structure, _Segment
 from .structure.ligand import Covalent_Ligand, _Ligand

--- a/src/qfit/__init__.py
+++ b/src/qfit/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from .qfit import _BaseQFitOptions
+from .qfit import QFitOptions
 from .qfit import QFitRotamericResidue
 from .qfit import QFitCovalentLigand
 from .qfit import QFitLigand

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -73,7 +73,7 @@ class _BaseQFitOptions:
         self.bic_threshold = True
         self.seg_bic_threshold = True
 
-        ### From QFitRotamericResidueOptions:
+        ### From QFitRotamericResidueOptions, QFitCovalentLigandOptions
         # Backbone sampling
         self.sample_backbone = True
         self.neighbor_residues_required = 3
@@ -88,7 +88,7 @@ class _BaseQFitOptions:
 
         # Rotamer sampling
         self.sample_rotamers = True
-        self.rotamer_neighborhood = 60
+        self.rotamer_neighborhood = 60  # Was 80 in QFitCovalentLigandOptions
         self.remove_conformers_below_cutoff = False
 
         # Anisotropic refinement using phenix
@@ -105,34 +105,13 @@ class _BaseQFitOptions:
         self.dofs_per_iteration = 2
         self.remove_conformers_below_cutoff = False
         self.local_search = True
-        self.sample_ligand_stepsize = 10
+        self.sample_ligand = True  # From QFitCovalentLigandOptions
+        self.sample_ligand_stepsize = 10  # Was 8 in QFitCovalentLigandOptions
         self.selection = None
         self.cif_file = None
 
         ### From QFitSegmentOptions
         self.fragment_length = None
-
-        ### From QFitCovalentLigandOptions
-        # Backbone sampling
-        self.sample_backbone = True
-        self.neighbor_residues_required = 3
-        self.sample_backbone_amplitude = 0.30
-        self.sample_backbone_step = 0.1
-        self.sample_backbone_sigma = 0.125
-
-        # N-CA-CB angle sampling
-        self.sample_angle = True
-        self.sample_angle_range = 7.5
-        self.sample_angle_step = 3.75
-
-        # Rotamer sampling
-        self.sample_rotamers = True
-        self.rotamer_neighborhood = 80
-        self.remove_conformers_below_cutoff = False
-
-        # Ligand sampling
-        self.sample_ligand = True
-        self.sample_ligand_stepsize = 8
 
         ### From QFitProteinOptions
         self.nproc = 1

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -113,7 +113,6 @@ class _BaseQFitOptions:
 
         ### From QFitProteinOptions
         self.nproc = 1
-        self.verbose = True
         self.checkpoint = False
         self.pdb = None
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -28,7 +28,7 @@ from .structure.rotamers import ROTAMERS
 logger = logging.getLogger(__name__)
 
 
-class _BaseQFitOptions:
+class QFitOptions:
     def __init__(self):
         # General options
         self.directory = '.'

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -73,16 +73,7 @@ class _BaseQFitOptions:
         self.bic_threshold = True
         self.seg_bic_threshold = True
 
-    def apply_command_args(self, args):
-        for key, value in vars(args).items():
-            if hasattr(self, key):
-                setattr(self, key, value)
-        return self
-
-
-class QFitRotamericResidueOptions(_BaseQFitOptions):
-    def __init__(self):
-        super().__init__()
+# From QFitRotamericResidueOptions:
 
         # Backbone sampling
         self.sample_backbone = True
@@ -109,6 +100,56 @@ class QFitRotamericResidueOptions(_BaseQFitOptions):
         # influence QP / MIQP. Provide a list of atom names, e.g. ['N', 'CA']
         # TODO not implemented
         self.exclude_atoms = None
+
+#From QFitLigandOptions:
+
+        self.dofs_per_iteration = 2
+        self.remove_conformers_below_cutoff = False
+        self.local_search = True
+        self.sample_ligand_stepsize = 10
+        self.selection = None
+        self.cif_file = None
+
+# From QFitSegmentOptions:
+
+        self.fragment_length = None
+
+#From QFitCovalentLigandOptions:
+
+        # Backbone sampling
+        self.sample_backbone = True
+        self.neighbor_residues_required = 3
+        self.sample_backbone_amplitude = 0.30
+        self.sample_backbone_step = 0.1
+        self.sample_backbone_sigma = 0.125
+
+        # N-CA-CB angle sampling
+        self.sample_angle = True
+        self.sample_angle_range = 7.5
+        self.sample_angle_step = 3.75
+
+        # Rotamer sampling
+        self.sample_rotamers = True
+        self.rotamer_neighborhood = 80
+        self.remove_conformers_below_cutoff = False
+
+        # Ligand sampling
+        self.sample_ligand = True
+        self.sample_ligand_stepsize = 8
+
+#From QFitProteinOptions:
+
+        self.nproc = 1
+        self.verbose = True
+        self.omit = False
+        self.checkpoint = False
+        self.pdb = None
+
+    def apply_command_args(self, args):
+        for key, value in vars(args).items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+        return self
 
 
 class _BaseQFit:
@@ -992,12 +1033,6 @@ class QFitRotamericResidue(_BaseQFit):
         mc_residue.tofile(fname)
 
 
-class QFitSegmentOptions(_BaseQFitOptions):
-    def __init__(self):
-        super().__init__()
-        self.fragment_length = None
-
-
 class QFitSegment(_BaseQFit):
     """Determines consistent protein segments based on occupancy and
        density fit"""
@@ -1215,18 +1250,6 @@ class QFitSegment(_BaseQFit):
                     path.append(residue_altloc)
                     # coor.append(fragment.coor[i])
             logger.info(f"Path {k+1}:\t{path}\t{fragment.q[-1]}")
-
-
-class QFitLigandOptions(_BaseQFitOptions):
-    def __init__(self):
-        super().__init__()
-
-        self.dofs_per_iteration = 2
-        self.remove_conformers_below_cutoff = False
-        self.local_search = True
-        self.sample_ligand_stepsize = 10
-        self.selection = None
-        self.cif_file = None
 
 
 class QFitLigand(_BaseQFit):
@@ -1515,32 +1538,6 @@ class QFitLigand(_BaseQFit):
             else:
                 starting_bond_index += self.options.dofs_per_iteration
             iteration += 1
-
-
-class QFitCovalentLigandOptions(_BaseQFitOptions):
-    def __init__(self):
-        super().__init__()
-
-        # Backbone sampling
-        self.sample_backbone = True
-        self.neighbor_residues_required = 3
-        self.sample_backbone_amplitude = 0.30
-        self.sample_backbone_step = 0.1
-        self.sample_backbone_sigma = 0.125
-
-        # N-CA-CB angle sampling
-        self.sample_angle = True
-        self.sample_angle_range = 7.5
-        self.sample_angle_step = 3.75
-
-        # Rotamer sampling
-        self.sample_rotamers = True
-        self.rotamer_neighborhood = 80
-        self.remove_conformers_below_cutoff = False
-
-        # Ligand sampling
-        self.sample_ligand = True
-        self.sample_ligand_stepsize = 8
 
 
 class QFitCovalentLigand(_BaseQFit):

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -113,7 +113,6 @@ class _BaseQFitOptions:
 
         ### From QFitProteinOptions
         self.nproc = 1
-        self.checkpoint = False
         self.pdb = None
 
     def apply_command_args(self, args):

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -73,8 +73,7 @@ class _BaseQFitOptions:
         self.bic_threshold = True
         self.seg_bic_threshold = True
 
-# From QFitRotamericResidueOptions:
-
+        ### From QFitRotamericResidueOptions:
         # Backbone sampling
         self.sample_backbone = True
         self.neighbor_residues_required = 3
@@ -101,8 +100,8 @@ class _BaseQFitOptions:
         # TODO not implemented
         self.exclude_atoms = None
 
-#From QFitLigandOptions:
-
+        ### From QFitLigandOptions
+        # Ligand sampling
         self.dofs_per_iteration = 2
         self.remove_conformers_below_cutoff = False
         self.local_search = True
@@ -110,12 +109,10 @@ class _BaseQFitOptions:
         self.selection = None
         self.cif_file = None
 
-# From QFitSegmentOptions:
-
+        ### From QFitSegmentOptions
         self.fragment_length = None
 
-#From QFitCovalentLigandOptions:
-
+        ### From QFitCovalentLigandOptions
         # Backbone sampling
         self.sample_backbone = True
         self.neighbor_residues_required = 3
@@ -137,8 +134,7 @@ class _BaseQFitOptions:
         self.sample_ligand = True
         self.sample_ligand_stepsize = 8
 
-#From QFitProteinOptions:
-
+        ### From QFitProteinOptions
         self.nproc = 1
         self.verbose = True
         self.omit = False

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -102,8 +102,6 @@ class _BaseQFitOptions:
 
         ### From QFitLigandOptions
         # Ligand sampling
-        self.dofs_per_iteration = 2
-        self.remove_conformers_below_cutoff = False
         self.local_search = True
         self.sample_ligand = True  # From QFitCovalentLigandOptions
         self.sample_ligand_stepsize = 10  # Was 8 in QFitCovalentLigandOptions
@@ -116,7 +114,6 @@ class _BaseQFitOptions:
         ### From QFitProteinOptions
         self.nproc = 1
         self.verbose = True
-        self.omit = False
         self.checkpoint = False
         self.pdb = None
 

--- a/src/qfit/qfit_covalent_ligand.py
+++ b/src/qfit/qfit_covalent_ligand.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 
 from . import MapScaler, Structure, XMap, Covalent_Ligand
-from . import QFitCovalentLigand, _BaseQFitOptions
+from . import QFitCovalentLigand, QFitOptions
 
 os.environ["OMP_NUM_THREADS"] = "1"
 
@@ -198,7 +198,7 @@ def main():
     receptor = structure.extract(sel_str)
     logger.info("Receptor atoms selected: {natoms}".format(natoms=receptor.natoms))
 
-    options = _BaseQFitOptions()
+    options = QFitOptions()
     options.apply_command_args(args)
 
     # Load and process the electron density map:

--- a/src/qfit/qfit_covalent_ligand.py
+++ b/src/qfit/qfit_covalent_ligand.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 
 from . import MapScaler, Structure, XMap, Covalent_Ligand
-from . import QFitCovalentLigand, QFitCovalentLigandOptions
+from . import QFitCovalentLigand, _BaseQFitOptions
 
 os.environ["OMP_NUM_THREADS"] = "1"
 
@@ -198,7 +198,7 @@ def main():
     receptor = structure.extract(sel_str)
     logger.info("Receptor atoms selected: {natoms}".format(natoms=receptor.natoms))
 
-    options = QFitCovalentLigandOptions()
+    options = _BaseQFitOptions()
     options.apply_command_args(args)
 
     # Load and process the electron density map:

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -10,7 +10,7 @@ import time
 import numpy as np
 from string import ascii_uppercase
 from . import MapScaler, Structure, XMap, _Ligand
-from .qfit import QFitLigand, QFitLigandOptions
+from .qfit import QFitLigand, _BaseQFitOptions
 from .logtools import setup_logging, log_run_info
 
 logger = logging.getLogger(__name__)
@@ -238,7 +238,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = QFitLigandOptions()
+    options = _BaseQFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -10,7 +10,7 @@ import time
 import numpy as np
 from string import ascii_uppercase
 from . import MapScaler, Structure, XMap, _Ligand
-from .qfit import QFitLigand, _BaseQFitOptions
+from .qfit import QFitLigand, QFitOptions
 from .logtools import setup_logging, log_run_info
 
 logger = logging.getLogger(__name__)
@@ -238,7 +238,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = _BaseQFitOptions()
+    options = QFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_ppiDesign.py
+++ b/src/qfit/qfit_ppiDesign.py
@@ -22,7 +22,7 @@ from .transformer import Transformer
 from .volume import XMap
 from .scaler import MapScaler
 from .relabel import RelabellerOptions, Relabeller
-from .qfit import _BaseQFitOptions
+from .qfit import QFitOptions
 from .structure.rotamers import ROTAMERS
 from .vdw_radii import vdwRadiiTable, EpsilonTable
 from itertools import groupby
@@ -287,7 +287,7 @@ def main():
     sel_str = f"chain {chainID2}"
     prot2 = structure.extract(sel_str)
     """
-    options = _BaseQFitOptions()
+    options = QFitOptions()
 
     L_res = []
     R_res = []

--- a/src/qfit/qfit_ppiDesign.py
+++ b/src/qfit/qfit_ppiDesign.py
@@ -22,7 +22,7 @@ from .transformer import Transformer
 from .volume import XMap
 from .scaler import MapScaler
 from .relabel import RelabellerOptions, Relabeller
-from .qfit import QFitRotamericResidueOptions
+from .qfit import _BaseQFitOptions
 from .structure.rotamers import ROTAMERS
 from .vdw_radii import vdwRadiiTable, EpsilonTable
 from itertools import groupby
@@ -287,7 +287,7 @@ def main():
     sel_str = f"chain {chainID2}"
     prot2 = structure.extract(sel_str)
     """
-    options = QFitRotamericResidueOptions()
+    options = _BaseQFitOptions()
 
     L_res = []
     R_res = []

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -1,5 +1,5 @@
 import gc
-from .qfit import _BaseQFitOptions
+from .qfit import QFitOptions
 from .qfit import QFitRotamericResidue
 from .qfit import QFitSegment
 import multiprocessing as mp
@@ -457,7 +457,7 @@ def main():
         pass
 
     # Apply the arguments to options
-    options = _BaseQFitOptions()
+    options = QFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -1,6 +1,7 @@
 import gc
-from .qfit import QFitRotamericResidue, QFitRotamericResidueOptions
-from .qfit import QFitSegment, QFitSegmentOptions
+from .qfit import _BaseQFitOptions
+from .qfit import QFitRotamericResidue
+from .qfit import QFitSegment
 import multiprocessing as mp
 from tqdm import tqdm
 import os.path
@@ -152,16 +153,6 @@ def build_argparser():
     p.add_argument("--pdb", help="Name of the input PDB")
 
     return p
-
-
-class QFitProteinOptions(QFitRotamericResidueOptions, QFitSegmentOptions):
-    def __init__(self):
-        super().__init__()
-        self.nproc = 1
-        self.verbose = True
-        self.omit = False
-        self.checkpoint = False
-        self.pdb = None
 
 
 class QFitProtein:
@@ -466,7 +457,7 @@ def main():
         pass
 
     # Apply the arguments to options
-    options = QFitProteinOptions()
+    options = _BaseQFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -10,7 +10,7 @@ import numpy as np
 from string import ascii_uppercase
 from .logtools import setup_logging, log_run_info
 from . import MapScaler, Structure, XMap
-from .qfit import _BaseQFitOptions
+from .qfit import QFitOptions
 from . import QFitRotamericResidue
 from .structure import residue_type
 
@@ -157,7 +157,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = _BaseQFitOptions()
+    options = QFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -10,7 +10,8 @@ import numpy as np
 from string import ascii_uppercase
 from .logtools import setup_logging, log_run_info
 from . import MapScaler, Structure, XMap
-from . import QFitRotamericResidue, QFitRotamericResidueOptions
+from .qfit import _BaseQFitOptions
+from . import QFitRotamericResidue
 from .structure import residue_type
 
 logger = logging.getLogger(__name__)
@@ -156,7 +157,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = QFitRotamericResidueOptions()
+    options = _BaseQFitOptions()
     options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_segment.py
+++ b/src/qfit/qfit_segment.py
@@ -5,7 +5,8 @@ import logger
 from argparse import ArgumentParser
 
 from . import MapScaler, Structure, XMap
-from .qfit import QFitSegment, QFitSegmentOptions
+from .qfit import _BaseQFitOptions
+from .qfit import QFitSegment
 from .logtools import setup_logging, log_run_info
 
 
@@ -91,7 +92,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = QFitSegmentOptions()
+    options = _BaseQFitOptions()
     options = options.apply_command_args(args)
 
     # Setup logger

--- a/src/qfit/qfit_segment.py
+++ b/src/qfit/qfit_segment.py
@@ -5,7 +5,7 @@ import logger
 from argparse import ArgumentParser
 
 from . import MapScaler, Structure, XMap
-from .qfit import _BaseQFitOptions
+from .qfit import QFitOptions
 from .qfit import QFitSegment
 from .logtools import setup_logging, log_run_info
 
@@ -92,7 +92,7 @@ def main():
     time0 = time.time()
 
     # Apply the arguments to options
-    options = _BaseQFitOptions()
+    options = QFitOptions()
     options = options.apply_command_args(args)
 
     # Setup logger

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 from qfit.qfit_ligand import (
-    QFitLigandOptions,
+    _BaseQFitOptions,
     prepare_qfit_ligand,
     build_argparser,
 )
@@ -36,7 +36,7 @@ class TestQFitLigand:
             pass
 
         # Apply the arguments to options
-        options = QFitLigandOptions()
+        options = _BaseQFitOptions()
         options.apply_command_args(args)
         options.debug = True  # For debugging in tests
 

--- a/tests/test_qfit_ligand.py
+++ b/tests/test_qfit_ligand.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 from qfit.qfit_ligand import (
-    _BaseQFitOptions,
+    QFitOptions,
     prepare_qfit_ligand,
     build_argparser,
 )
@@ -36,7 +36,7 @@ class TestQFitLigand:
             pass
 
         # Apply the arguments to options
-        options = _BaseQFitOptions()
+        options = QFitOptions()
         options.apply_command_args(args)
         options.debug = True  # For debugging in tests
 

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -4,7 +4,7 @@ import logging
 import multiprocessing as mp
 
 from qfit.qfit_protein import (
-    QFitProteinOptions,
+    _BaseQFitOptions,
     build_argparser,
     prepare_qfit_protein,
 )
@@ -52,7 +52,7 @@ class TestQFitProtein:
             pass
 
         # Apply the arguments to options
-        options = QFitProteinOptions()
+        options = _BaseQFitOptions()
         options.apply_command_args(args)
         options.debug = True  # For debugging in tests
 

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -4,7 +4,7 @@ import logging
 import multiprocessing as mp
 
 from qfit.qfit_protein import (
-    _BaseQFitOptions,
+    QFitOptions,
     build_argparser,
     prepare_qfit_protein,
 )
@@ -52,7 +52,7 @@ class TestQFitProtein:
             pass
 
         # Apply the arguments to options
-        options = _BaseQFitOptions()
+        options = QFitOptions()
         options.apply_command_args(args)
         options.debug = True  # For debugging in tests
 


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

There were multiple 'option' classes in the src code in qfit.py, qfit_ligand.py, qfit_segment.py, qfit_covalent_ligand.py, qfit_protein.py, qfit_residue.py, init.py as well as the test files for qfit_ligand and qfit_protein that were inheriting from BaseQFitOptions class.
These classes have been merged into a single class called QFitOptions.


### Release Notes

- Merged all derived classes into QFitOptions

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
