### PR TITLE
Make sure the user provides a resolution value if the input map is in MRC/CCP4 or MAP formats

### DIFF
--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -137,6 +137,8 @@ class XMap(_BaseVolume):
         if fmt is None:
             fmt = os.path.splitext(fname)[1]
         if fmt in ('.ccp4', '.mrc', '.map'):
+            if resolution is None:
+                raise ValueError(f"{fname} is a CCP4/MRC/MAP file. Please provide resolution using -r option")
             parser = parse_volume(fname, fmt=fmt)
             a, b, c = parser.abc
             alpha, beta, gamma = parser.angles

--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -138,7 +138,7 @@ class XMap(_BaseVolume):
             fmt = os.path.splitext(fname)[1]
         if fmt in ('.ccp4', '.mrc', '.map'):
             if resolution is None:
-                raise ValueError(f"{fname} is a CCP4/MRC/MAP file. Please provide resolution using -r option")
+                raise ValueError(f"{fname} is a CCP4/MRC/MAP file. Please provide a resolution (use the '-r'/'--resolution' flag).")
             parser = parse_volume(fname, fmt=fmt)
             a, b, c = parser.abc
             alpha, beta, gamma = parser.angles


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change
This fix adds a check to make sure the user provides a resolution value if the input map is in MRC/CCP4 or MAP formats. If not provided, raises an error and stops.

### Release Notes
- If using a real-space map, the user must provide a resolution value

