### PR TITLE
If options.nproc is 1, run QFitRotamericResidue job in MainProcess

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -978,10 +978,18 @@ class QFitRotamericResidue(_BaseQFit):
             iteration += 1
 
     def tofile(self):
+        # Which directory are we saving into?
+        residue_directory = f"{self.chain}_{self.resi}"
+        if self.icode:
+            residue_directory += f"_{self.icode}"
+        residue_directory = os.path.join(self.options.directory, residue_directory)
+
+        # Save the individual conformers
         conformers = self.get_conformers()
         for n, conformer in enumerate(conformers, start=1):
-            fname = os.path.join(self.options.directory, f'conformer_{n}.pdb')
+            fname = os.path.join(residue_directory, f'conformer_{n}.pdb')
             conformer.tofile(fname)
+
         # Make a multiconformer residue
         nconformers = len(conformers)
         if nconformers < 1:
@@ -996,10 +1004,10 @@ class QFitRotamericResidue(_BaseQFit):
             for altloc, conformer in zip(ascii_uppercase[1:], conformers[1:]):
                 conformer.altloc = altloc
                 mc_residue = mc_residue.combine(conformer)
-
         mc_residue = mc_residue.reorder()
-        fname = os.path.join(self.options.directory,
-                             f"multiconformer_residue.pdb")
+
+        # Save the multiconformer residue
+        fname = os.path.join(residue_directory, f"multiconformer_residue.pdb")
         mc_residue.tofile(fname)
 
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -380,15 +380,14 @@ class QFitProtein:
         identifier = f"{chainid}_{resi}"
         if icode:
             identifier += f'_{icode}'
-        base_directory = options.directory
-        options.directory = os.path.join(base_directory, identifier)
+        residue_directory = os.path.join(options.directory, identifier)
         try:
-            os.makedirs(options.directory)
+            os.makedirs(residue_directory)
         except OSError:
             pass
 
         # Exit early if we have already run qfit for this residue
-        fname = os.path.join(options.directory, 'multiconformer_residue.pdb')
+        fname = os.path.join(residue_directory, 'multiconformer_residue.pdb')
         if os.path.exists(fname):
             return
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

Currently, when options.nproc is 1, qfit_protein launches a multiprocessing.Pool with a single worker. This is a bit much.
With this PR, we no longer bother launching a Pool, and instead just run the residue sampling/scoring in MainProcess.

We will need to watch out for differences in behaviour that might occur between things run with nproc=1 and those with nproc>1. Errors might be masked in either one of these situations.
Where nproc=1, there will be access to the parent's memory, with nproc>1, this is not true.

The second commit in this PR catches one such error --- editing the QFitOptions object was acceptable in MainProcess only because the PoolWorkers didn't see such changes.

### Release Notes

- Simplify execution when running qfit_protein on single processor

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
