### PR TITLE
179 qfit protein outputting duplicate hetatms

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -979,10 +979,10 @@ class QFitRotamericResidue(_BaseQFit):
 
     def tofile(self):
         # Which directory are we saving into?
-        residue_directory = f"{self.chain}_{self.resi}"
+        resi_identifier = f"{self.chain}_{self.resi}"
         if self.icode:
-            residue_directory += f"_{self.icode}"
-        residue_directory = os.path.join(self.options.directory, residue_directory)
+            resi_identifier += f"_{self.icode}"
+        residue_directory = os.path.join(self.options.directory, resi_identifier)
 
         # Save the individual conformers
         conformers = self.get_conformers()
@@ -1007,6 +1007,7 @@ class QFitRotamericResidue(_BaseQFit):
         mc_residue = mc_residue.reorder()
 
         # Save the multiconformer residue
+        logger.info(f"Saving {resi_identifier} multiconformer to multiconformer_residue.pdb")
         fname = os.path.join(residue_directory, f"multiconformer_residue.pdb")
         mc_residue.tofile(fname)
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

Closes #179 .
Make sure that qfit_protein doesn't double up on HETATM residues in the multiconformer_model.pdb output.

Add a bunch of commentary to improve clarity --- so this doesn't happen again.


### Release Notes

- Fixed an issue where qfit_protein would duplicate HETATM residues

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
