### PR TITLE
Better error message map/model are in the incorrect order upon input. 

### DIFF
--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -24,13 +24,23 @@ os.environ["OMP_NUM_THREADS"] = "1"
 def build_argparser():
     p = argparse.ArgumentParser(formatter_class=CustomHelpFormatter,
                                 description=__doc__)
-    p.add_argument("map", type=str,
+
+    #file extension check for map and structure. 
+    def file_choices(choices,fname):
+        ext = os.path.splitext(fname)[1][1:]
+        if ext not in choices:
+           p.error(f"File doesn't end with one of {choices} Please make sure the map/model are in the correct order: map, model.")
+        return fname
+
+    p.add_argument("map",
                    help="Density map in CCP4 or MRC format, or an MTZ file "
                         "containing reflections and phases. For MTZ files "
                         "use the --label options to specify columns to read."                        
-                        "For CCP4 files, use the -r to specify resolution.", required=True)
+                        "For CCP4 files, use the -r to specify resolution.",
+                        type=lambda s:file_choices(("ccp4","mtz","mrc", "map"),s))
     p.add_argument("structure",
-                   help="PDB-file containing structure.", required=True)
+                   help="PDB-file containing structure.", 
+                   type=lambda s:file_choices(("pdb"),s))
 
     # Map input options
     p.add_argument("-l", "--label", default="FWT,PHWT",
@@ -463,6 +473,9 @@ def main():
     #   (When args==None, argparse will default to sys.argv[1:])
     p = build_argparser()
     args = p.parse_args(args=None)
+    #function to ensure map/model are correct
+    check_map_model_file()
+
     try:
         os.mkdir(args.directory)
     except OSError:

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -27,9 +27,10 @@ def build_argparser():
     p.add_argument("map", type=str,
                    help="Density map in CCP4 or MRC format, or an MTZ file "
                         "containing reflections and phases. For MTZ files "
-                        "use the --label options to specify columns to read.")
+                        "use the --label options to specify columns to read."                        
+                        "For CCP4 files, use the -r to specify resolution.", required=True)
     p.add_argument("structure",
-                   help="PDB-file containing structure.")
+                   help="PDB-file containing structure.", required=True)
 
     # Map input options
     p.add_argument("-l", "--label", default="FWT,PHWT",


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

When you input a map/model in the incorrect order qFit used to try to run and would crash because it could not read the model appropriately. 

Now qFit checks the file extension for the map and model and if the incorrect file extension exists, then qFit returns error message asking user to check the order of the input map/model. 

### Release Notes

