### PR TITLE
Fixing: 52 cplex error 5002 objective is not convex

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -309,15 +309,15 @@ class _BaseQFit:
             else:
                 solver(cardinality=cardinality, threshold=threshold)
                 
-                if solver.error == True:
-                    logger.debug('CPLEX ERROR: Removing conformer')
-                    self.CPLEX_error = True
-                    return
-                else:
-                    self.CPLEX_error = False
-                    # Update occupancies from solver weights
-                    self._occupancies = solver.weights
-                    return solver.obj_value
+        if solver.error == True:
+           logger.debug('CPLEX ERROR: Removing conformer')
+            self.CPLEX_error = True
+            return
+        else:
+            self.CPLEX_error = False
+            # Update occupancies from solver weights
+            self._occupancies = solver.weights
+            return solver.obj_value
         
     def _removed_conformer_cplex(self):
         '''This will removed conformations with the closest backbone coords to other conformations with the lowest occupancy.

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -328,7 +328,6 @@ class _BaseQFit:
 
         rmsd = 100 #set arbitrarily high rsmd
         for a, b in itertools.combinations(self._coor_set, 2): #for every combination of the list
-            if np.isnan(np.sum(a)) | np.isnan(np.sum(b)): continue
             if np.array_equal(a,b): continue # if we get the same conformation, continue
             rmsd_tmp = find_rmsd(a, b) #find the RMSD between each conformation
             if rmsd_tmp < rmsd:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1269,8 +1269,8 @@ class QFitSegment(_BaseQFit):
                    self._occupancies = self._occupancies[mask]
                    self._coor_set = [fragment.coor for fragment in fragments]
                    self._bs = [fragment.b for fragment in fragments]
-                   logger.info(np.sum(self._occupancies))
-                   if self.debug:
+
+                   if self.options.write_intermediate_conformers:
                       self._write_intermediate_conformers(prefix="cplex_kept")
                    self._convert() #rerun covert with updated conformers
                    self._solve(threshold=self.options.threshold,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -309,7 +309,7 @@ class _BaseQFit:
                     #     break
             else:
                 solver(cardinality=cardinality, threshold=threshold)
-       if solver.error == True:
+        if solver.error == True:
            logger.debug('CPLEX ERROR: Removing conformer')
            self.CPLEX_error = True
            return

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1048,6 +1048,7 @@ class QFitSegment(_BaseQFit):
         self._simple = True
         self._rmask = 1.5
         reso = None
+        self.CPLEX_error = False #this is to catch CPLEX errors and iteratively remove conformer causing issues in CPLEX
         if self.xmap.resolution.high is not None:
             reso = self.xmap.resolution.high
         elif options.resolution is not None:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1224,6 +1224,9 @@ class QFitSegment(_BaseQFit):
                 self._solve(threshold=self.options.threshold,
                             cardinality=self.options.cardinality,
                             loop_range=[0.34, 0.25, 0.2, 0.16, 0.14])
+                while self.CPLEX_error == True: #cplex failed and we need to remove conformers that are close to each other
+                   self._removed_conformer_cplex() #remove conformer
+
 
                 # Update conformers
                 mask = self._occupancies >= 0.002

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -323,7 +323,7 @@ class _BaseQFit:
         '''This will removed conformations with the closest backbone coords to other conformations with the lowest occupancy.
            This will remove CPLEX errors we are having.'''
         def find_rmsd(coor_a, coor_b):
-            rmsd = np.sqrt(np.mean((coor_a-coor_b)**2)) #np.sum(np.linalg.norm(diff, axis=1))
+            rmsd = np.sqrt(np.mean((coor_a-coor_b)**2)) 
             return rmsd
 
         rmsd = 100 #set arbitrarily high rsmd

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -279,7 +279,6 @@ class _BaseQFit:
         else:
             logger.info("Solving MIQP")
             solver = MIQPSolver(self._target, self._models, use_cplex=self.options.cplex)
-
             # Threshold selection by BIC:
             if self.options.bic_threshold:
                 self.BIC = np.inf
@@ -309,15 +308,16 @@ class _BaseQFit:
                     #     break
             else:
                 solver(cardinality=cardinality, threshold=threshold)
-        if solver.error == True:
-           logger.debug('CPLEX ERROR: Removing conformer')
-           self.CPLEX_error = True
-           return
-        else:
-            self.CPLEX_error = False
-            # Update occupancies from solver weights
-            self._occupancies = solver.weights
-            return solver.obj_value
+                
+                if solver.error == True:
+                    logger.debug('CPLEX ERROR: Removing conformer')
+                    self.CPLEX_error = True
+                    return
+                else:
+                    self.CPLEX_error = False
+                    # Update occupancies from solver weights
+                    self._occupancies = solver.weights
+                    return solver.obj_value
         
     def _removed_conformer_cplex(self):
         '''This will removed conformations with the closest backbone coords to other conformations with the lowest occupancy.

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -310,7 +310,7 @@ class _BaseQFit:
                 solver(cardinality=cardinality, threshold=threshold)
                 
         if solver.error == True:
-           logger.debug('CPLEX ERROR: Removing conformer')
+            logger.debug('CPLEX ERROR: Removing conformer')
             self.CPLEX_error = True
             return
         else:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -289,6 +289,8 @@ class _BaseQFit:
                        logger.debug('CPLEX ERROR: Removing conformer')
                        self.CPLEX_error = True
                        return
+                    else: 
+                       self.CPLEX_error = False
                     rss = solver.obj_value * self._voxel_volume
                     confs = np.sum(solver.weights >= 0.002)
                     n = len(self._target)
@@ -312,6 +314,7 @@ class _BaseQFit:
            self.CPLEX_error = True
            return
         else:
+            self.CPLEX_error = False
             # Update occupancies from solver weights
             self._occupancies = solver.weights
             return solver.obj_value

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1260,6 +1260,20 @@ class QFitSegment(_BaseQFit):
                             loop_range=[0.34, 0.25, 0.2, 0.16, 0.14])
                 while self.CPLEX_error == True: #cplex failed and we need to remove conformers that are close to each other
                    self._removed_conformer_cplex() #remove conformer
+                   fragments = np.array(fragments) #update fragments
+                   mask = self._occupancies >= 0.002
+                   fragments = fragments[mask]
+                   self._occupancies = self._occupancies[mask]
+                   self._coor_set = [fragment.coor for fragment in fragments]
+                   self._bs = [fragment.b for fragment in fragments]
+                   logger.info(np.sum(self._occupancies))
+                   if self.debug:
+                      self._write_intermediate_conformers(prefix="cplex_kept")
+                   self._convert() #rerun covert with updated conformers
+                   self._solve(threshold=self.options.threshold,
+                            cardinality=self.options.cardinality,
+                            loop_range=[0.34, 0.25, 0.2, 0.16, 0.14]) #rerun solve with updated conformers
+
 
 
                 # Update conformers

--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -183,16 +183,6 @@ if CPLEX:
               logger.debug('CPLEX error')
               self.error = True
 
-            #print("CPLEX MIQP")
-            #print('P:', P)
-            #print('q:', q)
-            #print('w:', w)
-
-            #obj = 0.5 * w.T @ P @ w + q.T @ w
-            #print("calculated myself OBJ:", obj)
-            #print('from solver OBJ:', self.obj_value)
-            #print("TOTAL:", self.obj_value * 2 + np.inner(self._target, self._target))
-
 
 # Create a "pseudo-class" to abstract the choice of solver.
 class QPSolver(object):

--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -53,6 +53,7 @@ if CPLEX:
 
             self._solution = None
             self.weights = None
+            self.error = False #to catch CPLEX errors
 
         def initialize(self):
             # Set up the matrices and restraints


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

This pull request fixes the issue of CPLEX not being able to find a solution in qFit segment. It was identified that this was due to too many similar conformations being fed into CPLEX during the MIQP step.

The solution decided on (agreed by: Stephanie, Blake, Daniel, Jaime) was to create a heuristic to iteratively remove one conformer at a time and feed the reduced conformers back into MIQP.

The heuristic implemented here is:
1) Find 2 conformers that are the closest via RMSD (RMSD is calculated between all atoms in each conformation)
2) From the 2 conformations that are the closet via RMSD, remove the conformation with the lowest occupancy.
3) Assign the conformer with the lowest occupancy to have an occupancy of 0, feed into the existing masking process to remove conformer (existing process removes conformers with an occupancy < 0.002)
4) If CPLEX fails again, the remaining conformers are fed into the SAME heuristic.

In 4 test structures, this was removing somewhere between 2-7 conformers per input into MIQP (out of 25-76 conformers). 

Other changes in this pull request include the flags in both solvers and in the solve function in qFit protein to trigger the new function to remove conformers upon CPLEX errors. 

There is a while statement to keep removing conformers until CPLEX is able to find a solution. 

Additionally, information about the conformers removed is available with the `--debug` flag and `--write_intermediate_conformers`

### Release Notes

- Added conformer culling (to reduce likelihood of matrix degeneracy) as fix for "non-convex objective" errors from CPLEX

