### PR TITLE
If a residue-sampling checkpoint exists, don't add it to the list of residues to be sampled

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -572,9 +572,7 @@ class QFitRotamericResidue(_BaseQFit):
     def directory_name(self):
         # This is a QFitRotamericResidue, so we're working on a residue.
         # Which residue are we working on?
-        resi_identifier = f"{self.chain}_{self.resi}"
-        if self.icode:
-            resi_identifier += f"_{self.icode}"
+        resi_identifier = self.residue.shortcode
 
         dname = os.path.join(super().directory_name, resi_identifier)
         return dname

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -166,7 +166,6 @@ def main():
 
     #Skip over if everything is completed
     #try:
-    print(args.directory)
     if os.path.isfile(args.directory + '/multiconformer_residue.pdb'):
         print('This residue has completed')
         exit()

--- a/src/qfit/structure/ligand.py
+++ b/src/qfit/structure/ligand.py
@@ -39,6 +39,15 @@ class _Ligand(_BaseStructure):
         string = 'Ligand: {}. Number of atoms: {}.'.format(self.resn[0], self.natoms)
         return string
 
+    @property
+    def shortcode(self):
+        resi, icode = self.id
+        shortcode = f"{resi}"
+        if icode:
+            shortcode += f'_{icode}'
+
+        return shortcode
+
     def _get_connectivity(self):
         """Determine connectivity matrix of ligand and associated distance
         cutoff matrix for later clash detection.
@@ -446,6 +455,23 @@ class Covalent_Ligand(_BaseStructure):
         string = (f'Covalent Ligand: {self.resn[0]}.'
                   f' Number of atoms: {self.natoms}.')
         return string
+
+    @property
+    def _identifier_tuple(self):
+        """Returns (chain, resi, icode) to identify this covalent ligand."""
+        chainid = self.chain[0]
+        resi, icode = self.id
+
+        return (chainid, resi, icode)
+
+    @property
+    def shortcode(self):
+        (chainid, resi, icode) = self._identifier_tuple
+        shortcode = f"{chainid}_{resi}"
+        if icode:
+            shortcode += f'_{icode}'
+
+        return shortcode
 
     def _get_connectivity_from_cif(self, cif_file):
         """Determine connectivity matrix of ligand and associated distance

--- a/src/qfit/structure/residue.py
+++ b/src/qfit/structure/residue.py
@@ -61,6 +61,23 @@ class _BaseResidue(_BaseStructure):
             string += ":{}".format(icode)
         return string
 
+    @property
+    def _identifier_tuple(self):
+        """Returns (chain, resi, icode) to identify this residue."""
+        chainid = self.chain[0]
+        resi, icode = self.id
+
+        return (chainid, resi, icode)
+
+    @property
+    def shortcode(self):
+        (chainid, resi, icode) = self._identifier_tuple
+        shortcode = f"{chainid}_{resi}"
+        if icode:
+            shortcode += f'_{icode}'
+
+        return shortcode
+
 
 class _Residue(_BaseResidue):
     pass


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

In a QFitProtein job, we throw _all_ rotameric residues onto a queue, and fork PoolWorker jobs to residue sampling.
At the start of these jobs, we check to see if a residue-sampling checkpoint (multiconformer_residue.pdb) exists.

The issue with this approach is that the map around the residue has to be extracted, pickled, sent to the PoolWorker, unpickled before we check whether this residue has been already sampled. If it has, we do ~1.5s worth of work for nothing!

This PR changes this behaviour.
We now check to see if a residue-sampling checkpoint (multiconformer_residue.pdb) exists before we add the residue to the queue of residues to be sampled.

Will fix #191.

The approach taken also adds some convenience functions to the _Residue, _Ligand and CovalentLigand objects that are used in logging and constructing filepath names.

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

- Performance improvement: if a residue checkpoint exists, don't add it to the list of residues to be sampled (fixes #191)
