### PR TITLE
Fix non-convex objective errors by selectively deleting conformers

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -335,16 +335,16 @@ class _BaseQFit:
         #   `idx_low_rmsd` will contain the coordinates of the lowest value in the pairwise matrix
         #   a.k.a. the indices of the closest confs
         idx_low_rmsd = np.array(np.unravel_index(np.argmin(pairwise_rmsd_matrix), pairwise_rmsd_matrix.shape))
-        rmsd = pairwise_rmsd_matrix[tuple(idx_low_rmsd)]
-        logger.debug(f"Lowest rmsd between conformers: {rmsd}")
+        low_rmsd = pairwise_rmsd_matrix[tuple(idx_low_rmsd)]
+        logger.debug(f"Lowest RMSD between conformers {idx_low_rmsd.tolist()}: {low_rmsd:.06f} Å")
 
         # Of these, which has the lowest occupancy?
         occs_low_rmsd = self._occupancies[idx_low_rmsd]
         idx_to_zero, idx_to_keep = idx_low_rmsd[occs_low_rmsd.argsort()]
-        min_occ = self._occupancies[idx_to_zero]
-        logger.debug(f"Minimum occupancy: {min_occ}")
 
         # Assign conformer we want to remove with an occupancy of 0
+        logger.debug(f"Zeroing occupancy of conf {idx_to_zero} (of {n_confs}): "
+                     f"occ={self._occupancies[idx_to_zero]:.06f} vs {self._occupancies[idx_to_keep]:.06f}")
         if self.options.write_intermediate_conformers:  # Output all conformations before we remove them
             self._write_intermediate_conformers(prefix="cplex_remove")
         self._occupancies[idx_to_zero] = 0

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -311,11 +311,12 @@ class _BaseQFit:
         # residual = 0
         return solver.obj_value
 
-    def _removed_conformer_cplex(self):
-        """Remove the lowest occupancy, most similar conformer.
+    def _zero_out_most_similar_conformer(self):
+        """Zero-out the lowest occupancy, most similar conformer.
 
         Find the most similar pair of conformers, based on backbone RMSD.
         Of these, remove the conformer with the lowest occupancy.
+        This is done by setting its occupancy to 0.
 
         This aims to reduce the 'non-convex objective' errors we encounter during qFit-segment MIQP.
         These errors are likely due to a degenerate conformers, causing a non-invertible matrix.

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -14,7 +14,7 @@ from .samplers import ChiRotator, CBAngleRotator, BondRotator
 from .samplers import CovalentBondRotator, GlobalRotator
 from .samplers import RotationSets, Translator
 from .solvers import QPSolver, MIQPSolver
-from .structure import Structure, _Segment
+from .structure import Structure, _Segment, calc_rmsd
 from .structure.residue import residue_type
 from .structure.ligand import BondOrder
 from .transformer import Transformer
@@ -321,15 +321,10 @@ class _BaseQFit:
         This aims to reduce the 'non-convex objective' errors we encounter during qFit-segment MIQP.
         These errors are likely due to a degenerate conformers, causing a non-invertible matrix.
         """
-
-        def find_rmsd(coor_a, coor_b):
-            rmsd = np.sqrt(np.mean((coor_a - coor_b)**2))
-            return rmsd
-
         rmsd = 100  # Set an arbitrarily high rmsd
         for a, b in itertools.combinations(self._coor_set, 2):  # For every combination of the list
             if np.array_equal(a, b): continue  # If we get the same conformation, continue
-            rmsd_tmp = find_rmsd(a, b)  # Find the RMSD between each conformation
+            rmsd_tmp = calc_rmsd(a, b)  # Find the RMSD between each conformation
             if rmsd_tmp < rmsd:
                 rmsd = rmsd_tmp
                 remove_conf_1 = a

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -299,8 +299,6 @@ class _BaseQFit:
                     BIC = n * np.log(rss / n) + k * np.log(n)
                     if BIC < self.BIC:
                         self.BIC = BIC
-                    # else:
-                    #     break
             else:
                 solver(cardinality=cardinality, threshold=threshold)
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -311,6 +311,44 @@ class _BaseQFit:
         # residual = 0
         return solver.obj_value
 
+    def _removed_conformer_cplex(self):
+        """Remove the lowest occupancy, most similar conformer.
+
+        Find the most similar pair of conformers, based on backbone RMSD.
+        Of these, remove the conformer with the lowest occupancy.
+
+        This aims to reduce the 'non-convex objective' errors we encounter during qFit-segment MIQP.
+        These errors are likely due to a degenerate conformers, causing a non-invertible matrix.
+        """
+
+        def find_rmsd(coor_a, coor_b):
+            rmsd = np.sqrt(np.mean((coor_a - coor_b)**2))
+            return rmsd
+
+        rmsd = 100  # Set an arbitrarily high rmsd
+        for a, b in itertools.combinations(self._coor_set, 2):  # For every combination of the list
+            if np.array_equal(a, b): continue  # If we get the same conformation, continue
+            rmsd_tmp = find_rmsd(a, b)  # Find the RMSD between each conformation
+            if rmsd_tmp < rmsd:
+                rmsd = rmsd_tmp
+                remove_conf_1 = a
+                remove_conf_2 = b
+        logger.debug(f"Lowest rmsd between conformers: {rmsd}")
+
+        # Now we have our conformations that are closest, remove the one with the lower occupancy
+        for q, coor in zip(self._occupancies, self._coor_set):
+            if np.all(coor == remove_conf_1):
+                occ_1 = q
+            elif np.all(coor == remove_conf_2):
+                occ_2 = q
+        min_occ = min(occ_1, occ_2)
+        logger.debug(f"Minimum occupancy: {min_occ}")
+
+        if self.options.write_intermediate_conformers:  # Output all conformations before we remove them
+            self._write_intermediate_conformers(prefix="cplex_remove")
+        zero_occ_mask = (self._occupancies == min_occ)  # Create filter for those with the minimum occupancy to remove conf
+        self._occupancies[zero_occ_mask] = 0  # Assign conformer you want to remove with an occupancy of 0
+
     def _update_conformers(self, cutoff=0.002):
         """Removes conformers with occupancy lower than cutoff.
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1248,6 +1248,13 @@ class QFitSegment(_BaseQFit):
                     # Update conformers
                     fragments = np.array(fragments)
                     mask = self._occupancies >= 0.002
+
+                    # Drop conformers below cutoff
+                    _resi_list = list(fragments[0].residues)
+                    logger.debug(
+                        f"Removing {np.sum(np.invert(mask))} conformers from "
+                        f"fragment {_resi_list[0].shortcode}--{_resi_list[-1].shortcode}"
+                    )
                     fragments = fragments[mask]
                     self._occupancies = self._occupancies[mask]
                     self._coor_set = [fragment.coor for fragment in fragments]
@@ -1261,6 +1268,7 @@ class QFitSegment(_BaseQFit):
                                     loop_range=[0.34, 0.25, 0.2, 0.16, 0.14])
                     except SolverError:
                         # MIQP failed and we need to remove conformers that are close to each other
+                        logger.debug("MIQP failed, dropping a fragment-conformer")
                         self._zero_out_most_similar_conformer()  # Remove conformer
                         if self.options.write_intermediate_conformers:
                             self._write_intermediate_conformers(prefix="cplex_kept")
@@ -1271,6 +1279,13 @@ class QFitSegment(_BaseQFit):
 
                 # Update conformers for the last time
                 mask = self._occupancies >= 0.002
+
+                # Drop conformers below cutoff
+                _resi_list = list(fragments[0].residues)
+                logger.debug(
+                    f"Removing {np.sum(np.invert(mask))} conformers from "
+                    f"fragment {_resi_list[0].shortcode}--{_resi_list[-1].shortcode}"
+                )
                 for fragment, occ in zip(fragments[mask],
                                          self._occupancies[mask]):
                     fragment.q = occ

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -321,29 +321,33 @@ class _BaseQFit:
         This aims to reduce the 'non-convex objective' errors we encounter during qFit-segment MIQP.
         These errors are likely due to a degenerate conformers, causing a non-invertible matrix.
         """
-        rmsd = 100  # Set an arbitrarily high rmsd
-        for a, b in itertools.combinations(self._coor_set, 2):  # For every combination of the list
-            if np.array_equal(a, b): continue  # If we get the same conformation, continue
-            rmsd_tmp = calc_rmsd(a, b)  # Find the RMSD between each conformation
-            if rmsd_tmp < rmsd:
-                rmsd = rmsd_tmp
-                remove_conf_1 = a
-                remove_conf_2 = b
+        n_confs = len(self._coor_set)
+
+        # Make a square matrix for pairwise RMSDs, where
+        #   - the lower triangle (and diagonal) are np.inf
+        #   - the upper triangle contains the pairwise RMSDs (k=1 to exclude diagonal)
+        pairwise_rmsd_matrix = np.zeros((n_confs,) * 2)
+        pairwise_rmsd_matrix[np.tril_indices(n_confs)] = np.inf
+        for i, j in zip(*np.triu_indices(n_confs, k=1)):
+            pairwise_rmsd_matrix[i, j] = calc_rmsd(self._coor_set[i], self._coor_set[j])
+
+        # Which coords have the lowest RMSD?
+        #   `idx_low_rmsd` will contain the coordinates of the lowest value in the pairwise matrix
+        #   a.k.a. the indices of the closest confs
+        idx_low_rmsd = np.array(np.unravel_index(np.argmin(pairwise_rmsd_matrix), pairwise_rmsd_matrix.shape))
+        rmsd = pairwise_rmsd_matrix[tuple(idx_low_rmsd)]
         logger.debug(f"Lowest rmsd between conformers: {rmsd}")
 
-        # Now we have our conformations that are closest, remove the one with the lower occupancy
-        for q, coor in zip(self._occupancies, self._coor_set):
-            if np.all(coor == remove_conf_1):
-                occ_1 = q
-            elif np.all(coor == remove_conf_2):
-                occ_2 = q
-        min_occ = min(occ_1, occ_2)
+        # Of these, which has the lowest occupancy?
+        occs_low_rmsd = self._occupancies[idx_low_rmsd]
+        idx_to_zero, idx_to_keep = idx_low_rmsd[occs_low_rmsd.argsort()]
+        min_occ = self._occupancies[idx_to_zero]
         logger.debug(f"Minimum occupancy: {min_occ}")
 
+        # Assign conformer we want to remove with an occupancy of 0
         if self.options.write_intermediate_conformers:  # Output all conformations before we remove them
             self._write_intermediate_conformers(prefix="cplex_remove")
-        zero_occ_mask = (self._occupancies == min_occ)  # Create filter for those with the minimum occupancy to remove conf
-        self._occupancies[zero_occ_mask] = 0  # Assign conformer you want to remove with an occupancy of 0
+        self._occupancies[idx_to_zero] = 0
 
     def _update_conformers(self, cutoff=0.002):
         """Removes conformers with occupancy lower than cutoff.

--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -15,10 +15,11 @@ except ImportError:
     CPLEX = False
 else:
     CPLEX = True
+    SolverError = cplex.exceptions.CplexSolverError
 
 
 # Only these classes should be "public"
-__all__ = ['QPSolver', 'MIQPSolver']
+__all__ = ['QPSolver', 'MIQPSolver', 'SolverError']
 
 
 # Define the required functions for (MI)QP solver objects

--- a/src/qfit/structure/__init__.py
+++ b/src/qfit/structure/__init__.py
@@ -1,3 +1,3 @@
 from .pdbfile import PDBFile
-from .structure import Structure, _Segment
+from .structure import Structure, _Segment, calc_rmsd
 from .residue import residue_type

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -865,3 +865,19 @@ class _Segment(_BaseStructure):
         coor = np.dot(coor, R.T)
         coor += origin
         self._coor[selection] = coor
+
+
+def calc_rmsd(coor_a, coor_b):
+    """Determine root-mean-square distance between two structures.
+
+    Args:
+        coor_a (np.ndarray[(n_atoms, 3), dtype=np.float]):
+            Coordinates for structure a.
+        coor_b (np.ndarray[(n_atoms, 3), dtype=np.float]):
+            Coordinates for structure b.
+
+    Returns:
+        np.float:
+            Distance between two structures.
+    """
+    return np.sqrt(np.mean((coor_a - coor_b)**2))


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

This will close #52.
This will also make #199 redundant.

This takes Steph's function from #199 for removing the lowest-occupancy conformer from the closest conformer pair.

I then flatten the code:
- move calc_RMSD to the structure module
- use the _indexes_ of selected conformers, rather than match on their values

I also make the debug messages more informative, though I currently have to wait on the convenience property "shortcode" added in PR #211 .

### Release Notes

- Added conformer culling (to reduce likelihood of matrix degeneracy) as fix for "non-convex objective" errors from CPLEX
