### PR TITLE
Rewrite XMap.extract() for 500x speed boost

### DIFF
--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -343,7 +343,14 @@ class QFitProtein:
             self.options.fragment_length = 3
         else:
             self.options.threshold = 0.2
+
+        # Extract map of multiconformer in P1, with 5 A padding
+        logger.debug("Extracting map...")
+        _then = time.process_time()
         self.xmap = self.xmap.extract(self.structure.coor, padding=5)
+        _now = time.process_time()
+        logger.debug(f"Map extraction took {(_now - _then):.03f} s.")
+
         qfit = QFitSegment(multiconformer, self.xmap, self.options)
         multiconformer = qfit()
         fname = os.path.join(self.options.directory,

--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -4,6 +4,8 @@ from itertools import product
 from numbers import Real
 from struct import unpack as _unpack, pack as _pack
 from sys import byteorder as _BYTEORDER
+import logging
+import time
 
 import numpy as np
 from scipy.ndimage import map_coordinates
@@ -11,6 +13,9 @@ from scipy.ndimage import map_coordinates
 from .spacegroups import GetSpaceGroup, SpaceGroup, SymOpFromString
 from .unitcell import UnitCell
 from ._extensions import extend_to_p1
+
+
+logger = logging.getLogger(__name__)
 
 
 class GridParameters:
@@ -248,6 +253,7 @@ class XMap(_BaseVolume):
         """
         if not self.is_canonical_unit_cell():
             raise RuntimeError("XMap should contain full unit cell.")
+        logger.debug(f"Extracting map around {len(orth_coor)} atoms")
 
         # Convert atomic Cartesian coordinates to voxelgrid coordinates
         grid_coor = orth_coor @ self.unit_cell.orth_to_frac.T
@@ -263,6 +269,9 @@ class XMap(_BaseVolume):
         lb = np.floor(lb).astype(int)
         ru = np.ceil(ru).astype(int)
         shape = (ru - lb)[::-1]
+        logger.debug(f"From old map size (voxels): {self.shape}")
+        logger.debug(f"Extract between corners:    {lb[::-1]}, {ru[::-1]}")
+        logger.debug(f"New map size (voxels):      {shape}")
 
         # Make new GridParameters, make sure to update offset
         grid_parameters = GridParameters(self.voxelspacing, self.offset + lb)

--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -277,17 +277,21 @@ class XMap(_BaseVolume):
         grid_parameters = GridParameters(self.voxelspacing, self.offset + lb)
         offset = grid_parameters.offset
 
-        # Fill new array
-        imax, jmax, kmax = self.unit_cell_shape
-        ranges = [range(shape[i]) for i in range(3)]
-        array = np.zeros(shape, np.float64)
-        for k, j, i in product(*ranges):
-            x = (i + offset[0]) % imax
-            y = (j + offset[1]) % jmax
-            z = (k + offset[2]) % kmax
-            array[k, j, i] = self.array[z, y, x]
+        # Use index math to get appropriate region of map
+        #     - Create a tuple of axis-indexes
+        #     - Perform wrapping maths on the indexes
+        #     - Apply new index to the original map to get re-mapped map
+        # This is ~500--1000x faster than working element-by-element
+        # (BTR: I don't understand why we're indexing jki and not ijk)
+        ranges = [range(axis_len) for axis_len in shape]
+        ixgrid = np.ix_(*ranges)
+        ixgrid = tuple(
+            (dimension_index + offset) % wrap_to
+            for dimension_index, offset, wrap_to in zip(ixgrid, offset[::-1], self.unit_cell_shape[::-1])
+        )
+        density_map = self.array[ixgrid]
 
-        return XMap(array, grid_parameters=grid_parameters,
+        return XMap(density_map, grid_parameters=grid_parameters,
                     unit_cell=self.unit_cell, resolution=self.resolution,
                     hkl=self.hkl, origin=self.origin)
 

--- a/src/qfit/volume.py
+++ b/src/qfit/volume.py
@@ -262,14 +262,14 @@ class XMap(_BaseVolume):
         ru = grid_coor.max(axis=0) + grid_padding
         lb = np.floor(lb).astype(int)
         ru = np.ceil(ru).astype(int)
-        shape = [h - l for h, l in zip(ru, lb)][::-1]
+        shape = (ru - lb)[::-1]
 
         # Make new GridParameters, make sure to update offset
         grid_parameters = GridParameters(self.voxelspacing, self.offset + lb)
         offset = grid_parameters.offset
 
         # Fill new array
-        kmax, jmax, imax = self.unit_cell_shape[::-1]
+        imax, jmax, kmax = self.unit_cell_shape
         ranges = [range(shape[i]) for i in range(3)]
         array = np.zeros(shape, np.float64)
         for k, j, i in product(*ranges):


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

XMap.extract creates a copy of the map (around target coords).
This is used for:
- subsetting the density map to just the portion around the residue-of-interest (as in QFitProtein)
- expanding the map to include a buffer around the protein-of-interest (as in QFitSegment)

Before this PR, it creates this new map-copy by iterating voxel-by-voxel through the map.
This is terribly inefficient, and on an ordinary-size, average-resolution map, takes about 120 s to iterate through 8 million voxels.
If the resolution is higher, then, well...

This PR does the same maths, but in bulk to an array of indices.
This index array then re-indexes the map.
It's way faster, and now takes ~0.2 s to do the same thing.

Also, I added some more comments through this function, since I took the time to understand how it works.

I still don't understand why we're using Fortran-style column-major indexing, so if you do, please update the comments!

### Release Notes

- Rewrite density-map extraction for speed boost