### PR TITLE
Improved error message: unknown file type error in qfit residue

### DIFF
--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -23,9 +23,9 @@ def build_argparser():
     p.add_argument("map", type=str,
                    help="Density map in CCP4 or MRC format, or an MTZ file "
                         "containing reflections and phases. For MTZ files "
-                        "use the --label options to specify columns to read.")
+                        "use the --label options to specify columns to read.", type=str, action=ValidateMapFileArgument)
     p.add_argument("structure",
-                   help="PDB-file containing structure.")
+                   help="PDB-file containing structure.", type=str, action=ValidateStructureFileArgument)
     p.add_argument('selection', type=str,
                    help="Chain, residue id, and optionally insertion code for "
                         "residue in structure, e.g. A,105, or A,105:A.")

--- a/src/qfit/qfit_residue.py
+++ b/src/qfit/qfit_residue.py
@@ -1,7 +1,7 @@
 """Automatically build a multiconformer residue."""
 
 import argparse
-from .custom_argparsers import ToggleActionFlag, CustomHelpFormatter
+from .custom_argparsers import ToggleActionFlag, CustomHelpFormatter, ValidateMapFileArgument, ValidateStructureFileArgument
 import logging
 import os
 import sys


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.


This adds in custom argparse commands to make sure that the map and model are in the correct order in qFit_residue. If they are not in the correct order, an error message stating this is outputted. 
