### PR TITLE
adding re-refined 3K0N for tests

### DIFF
--- a/example/3K0N_refine.pdb
+++ b/example/3K0N_refine.pdb
@@ -1,0 +1,3297 @@
+REMARK   3
+REMARK   3 REFINEMENT.
+REMARK   3   PROGRAM     : PHENIX (1.19.2_4158: ???)
+REMARK   3   AUTHORS     : Adams,Afonine,Bunkoczi,Burnley,Chen,Dar,Davis,
+REMARK   3               : Draizen,Echols,Gildea,Gros,Grosse-Kunstleve,Headd,
+REMARK   3               : Hintze,Hung,Ioerger,Liebschner,McCoy,McKee,Moriarty,
+REMARK   3               : Oeffner,Poon,Read,Richardson,Richardson,Sacchettini,
+REMARK   3               : Sauter,Sobolev,Storoni,Terwilliger,Williams,Zwart
+REMARK   3
+REMARK   3  X-RAY DATA.
+REMARK   3  
+REMARK   3  REFINEMENT TARGET : ML
+REMARK   3  
+REMARK   3  DATA USED IN REFINEMENT.
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.39    
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 33.33   
+REMARK   3   MIN(FOBS/SIGMA_FOBS)              : 1.36  
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 98.99 
+REMARK   3   NUMBER OF REFLECTIONS             : 41076     
+REMARK   3   NUMBER OF REFLECTIONS (NON-ANOMALOUS) : 41076     
+REMARK   3  
+REMARK   3  FIT TO DATA USED IN REFINEMENT.
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.1514
+REMARK   3   R VALUE            (WORKING SET) : 0.1505
+REMARK   3   FREE R VALUE                     : 0.1692
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 4.84  
+REMARK   3   FREE R VALUE TEST SET COUNT      : 1989      
+REMARK   3  
+REMARK   3  FIT TO DATA USED IN REFINEMENT (IN BINS).
+REMARK   3   BIN  RESOLUTION RANGE  COMPL.    NWORK NFREE   RWORK  RFREE  CCWORK CCFREE
+REMARK   3     1   33.33 -    3.35    0.99     2999   153  0.1199 0.1367   0.967  0.959
+REMARK   3     2    3.35 -    2.66    1.00     2882   145  0.1517 0.1612   0.948  0.933
+REMARK   3     3    2.66 -    2.32    1.00     2852   146  0.1515 0.1891   0.943  0.933
+REMARK   3     4    2.32 -    2.11    1.00     2831   143  0.1401 0.1537   0.950  0.940
+REMARK   3     5    2.11 -    1.96    1.00     2816   143  0.1504 0.1630   0.942  0.925
+REMARK   3     6    1.96 -    1.84    1.00     2814   144  0.1607 0.2028   0.933  0.883
+REMARK   3     7    1.84 -    1.75    1.00     2795   140  0.1657 0.1965   0.930  0.894
+REMARK   3     8    1.75 -    1.68    1.00     2805   144  0.1835 0.2105   0.912  0.912
+REMARK   3     9    1.68 -    1.61    1.00     2810   143  0.1836 0.2056   0.918  0.909
+REMARK   3    10    1.61 -    1.56    1.00     2752   140  0.1884 0.1935   0.904  0.909
+REMARK   3    11    1.56 -    1.51    1.00     2795   143  0.1984 0.2299   0.891  0.865
+REMARK   3    12    1.51 -    1.46    1.00     2777   141  0.2126 0.2093   0.880  0.882
+REMARK   3    13    1.46 -    1.43    0.98     2742   138  0.2538 0.2145   0.827  0.856
+REMARK   3    14    1.43 -    1.39    0.88     2417   126  0.2928 0.3084   0.783  0.738
+REMARK   3  
+REMARK   3  BULK SOLVENT MODELLING.
+REMARK   3   METHOD USED        : FLAT BULK SOLVENT MODEL
+REMARK   3   SOLVENT RADIUS     : 1.11    
+REMARK   3   SHRINKAGE RADIUS   : 0.90    
+REMARK   3   GRID STEP FACTOR   : 4.00    
+REMARK   3  
+REMARK   3  ERROR ESTIMATES.
+REMARK   3   COORDINATE ERROR (MAXIMUM-LIKELIHOOD BASED)     : 0.14    
+REMARK   3   PHASE ERROR (DEGREES, MAXIMUM-LIKELIHOOD BASED) : 16.88   
+REMARK   3  
+REMARK   3  STRUCTURE FACTORS CALCULATION ALGORITHM : FFT
+REMARK   3  B VALUES.
+REMARK   3   FROM WILSON PLOT           (A**2) : 19.14   
+REMARK   3  
+REMARK   3  GEOMETRY RESTRAINTS LIBRARY: GEOSTD + MONOMER LIBRARY + CDL V1.2
+REMARK   3  DEVIATIONS FROM IDEAL VALUES.
+REMARK   3    BOND      :  0.008   0.060   1564
+REMARK   3    ANGLE     :  0.965   4.994   2118
+REMARK   3    CHIRALITY :  0.084   0.246    223
+REMARK   3    PLANARITY :  0.008   0.049    281
+REMARK   3    DIHEDRAL  : 12.283  72.237    578
+REMARK   3    MIN NONBONDED DISTANCE : 2.291
+REMARK   3  
+REMARK   3  MOLPROBITY STATISTICS.
+REMARK   3    ALL-ATOM CLASHSCORE : 6.90
+REMARK   3    RAMACHANDRAN PLOT:
+REMARK   3      OUTLIERS :  0.00 %
+REMARK   3      ALLOWED  :  3.11 %
+REMARK   3      FAVORED  : 96.89 %
+REMARK   3    ROTAMER OUTLIERS :  1.23 %
+REMARK   3    CBETA DEVIATIONS :  0.00 %
+REMARK   3    PEPTIDE PLANE:
+REMARK   3      CIS-PROLINE     : 0.00 %
+REMARK   3      CIS-GENERAL     : 0.00 %
+REMARK   3      TWISTED PROLINE : 0.00 %
+REMARK   3      TWISTED GENERAL : 0.00 %
+REMARK   3  
+REMARK   3  RAMA-Z (RAMACHANDRAN PLOT Z-SCORE):
+REMARK   3  INTERPRETATION: BAD |RAMA-Z| > 3; SUSPICIOUS 2 < |RAMA-Z| < 3; GOOD |RAMA-Z| < 2.
+REMARK   3  SCORES FOR WHOLE/HELIX/SHEET/LOOP ARE SCALED INDEPENDENTLY;
+REMARK   3  THEREFORE, THE VALUES ARE NOT RELATED IN A SIMPLE MANNER.
+REMARK   3    WHOLE: -0.76 (0.52), RESIDUES: 216
+REMARK   3    HELIX: -0.82 (0.73), RESIDUES: 27
+REMARK   3    SHEET: -0.82 (0.57), RESIDUES: 71
+REMARK   3    LOOP : -0.06 (0.55), RESIDUES: 118
+REMARK   3  
+REMARK   3                  min    max   mean <Bi,j>   iso aniso
+REMARK   3     Overall:   10.53 103.31  23.81   5.14  1650     0
+REMARK   3     Protein:   10.53 103.31  22.64   5.14  1518     0
+REMARK   3     Water:     16.45  63.15  37.31    N/A   132     0
+REMARK   3     Chain  A:  10.53 103.31  23.81    N/A  1650     0
+REMARK   3     Histogram:
+REMARK   3         Values      Number of atoms
+REMARK   3      10.53 - 19.81       834
+REMARK   3      19.81 - 29.08       527
+REMARK   3      29.08 - 38.36       125
+REMARK   3      38.36 - 47.64        81
+REMARK   3      47.64 - 56.92        34
+REMARK   3      56.92 - 66.19        17
+REMARK   3      66.19 - 75.47         9
+REMARK   3      75.47 - 84.75         8
+REMARK   3      84.75 - 94.03        11
+REMARK   3      94.03 - 103.31        4
+REMARK   3  
+REMARK   3
+HELIX    1   1 VAL A   29  GLY A   42  1                                  14
+HELIX    2   2 THR A  119  ASP A  123  5                                   5
+HELIX    3   3 GLY A  135  ARG A  144  1                                  10
+SHEET    1   A 8 PHE A  53  ILE A  57  0
+SHEET    2   A 8 MET A  61  GLY A  64 -1  O  MET A  61   N  ILE A  57
+SHEET    3   A 8 PHE A 112  CYS A 115 -1  O  ILE A 114   N  CYS A  62
+SHEET    4   A 8 ILE A  97  MET A 100 -1  N  SER A  99   O  PHE A 113
+SHEET    5   A 8 VAL A 128  GLU A 134 -1  O  PHE A 129   N  LEU A  98
+SHEET    6   A 8 GLU A  15  LEU A  24 -1  N  SER A  21   O  GLU A 134
+SHEET    7   A 8 THR A   5  VAL A  12 -1  N  ILE A  10   O  GLY A  18
+SHEET    8   A 8 ILE A 156  GLN A 163 -1  O  ASP A 160   N  ASP A   9
+CRYST1   43.096   52.592   89.249  90.00  90.00  90.00 P 21 21 21
+SCALE1      0.023204  0.000000  0.000000        0.00000
+SCALE2      0.000000  0.019014  0.000000        0.00000
+SCALE3      0.000000  0.000000  0.011205        0.00000
+ATOM      1  N   VAL A   2      19.335  -3.282  18.478  1.00 56.59           N
+ATOM      2  CA  VAL A   2      20.083  -2.032  18.411  1.00 60.60           C
+ATOM      3  C   VAL A   2      19.125  -0.863  18.133  1.00 45.83           C
+ATOM      4  O   VAL A   2      19.334   0.236  18.645  1.00 52.10           O
+ATOM      5  CB  VAL A   2      21.233  -2.089  17.353  1.00 76.41           C
+ATOM      6  CG1 VAL A   2      22.274  -0.992  17.608  1.00 78.47           C
+ATOM      7  CG2 VAL A   2      21.906  -3.456  17.333  1.00 83.17           C
+ATOM      8  HA  VAL A   2      20.507  -1.882  19.270  1.00 72.74           H
+ATOM      9  HB  VAL A   2      20.836  -1.936  16.482  1.00 91.71           H
+ATOM     10 HG11 VAL A   2      22.953  -1.035  16.917  1.00 94.19           H
+ATOM     11 HG12 VAL A   2      21.834  -0.128  17.587  1.00 94.19           H
+ATOM     12 HG13 VAL A   2      22.677  -1.136  18.479  1.00 94.19           H
+ATOM     13 HG21 VAL A   2      22.623  -3.445  16.681  1.00 99.83           H
+ATOM     14 HG22 VAL A   2      22.263  -3.646  18.215  1.00 99.83           H
+ATOM     15 HG23 VAL A   2      21.249  -4.128  17.091  1.00 99.83           H
+ATOM     16  N   ASN A   3      18.080  -1.098  17.330  1.00 34.55           N
+ATOM     17  CA  ASN A   3      17.177  -0.009  16.961  1.00 31.95           C
+ATOM     18  C   ASN A   3      16.367   0.438  18.175  1.00 27.99           C
+ATOM     19  O   ASN A   3      15.844  -0.400  18.915  1.00 29.32           O
+ATOM     20  CB  ASN A   3      16.200  -0.444  15.878  1.00 23.75           C
+ATOM     21  CG  ASN A   3      16.782  -0.356  14.477  1.00 23.58           C
+ATOM     22  OD1 ASN A   3      17.749   0.364  14.230  1.00 27.73           O
+ATOM     23  ND2 ASN A   3      16.166  -1.069  13.558  1.00 28.80           N
+ATOM     24  H   ASN A   3      17.878  -1.863  16.994  1.00 41.48           H
+ATOM     25  HA  ASN A   3      17.711   0.730  16.629  1.00 38.36           H
+ATOM     26  HB2 ASN A   3      15.945  -1.366  16.037  1.00 28.53           H
+ATOM     27  HB3 ASN A   3      15.417   0.128  15.912  1.00 28.53           H
+ATOM     28 HD21 ASN A   3      16.448  -1.060  12.746  1.00 34.59           H
+ATOM     29 HD22 ASN A   3      15.481  -1.544  13.770  1.00 34.59           H
+ATOM     30  N   PRO A   4      16.215   1.745  18.386  1.00 24.72           N
+ATOM     31  CA  PRO A   4      15.478   2.218  19.559  1.00 23.74           C
+ATOM     32  C   PRO A   4      13.989   1.953  19.459  1.00 22.43           C
+ATOM     33  O   PRO A   4      13.414   1.865  18.370  1.00 24.23           O
+ATOM     34  CB  PRO A   4      15.753   3.724  19.584  1.00 29.61           C
+ATOM     35  CG  PRO A   4      16.351   4.074  18.278  1.00 32.47           C
+ATOM     36  CD  PRO A   4      16.581   2.838  17.472  1.00 32.41           C
+ATOM     37  HA  PRO A   4      15.832   1.796  20.358  1.00 28.51           H
+ATOM     38  HB2 PRO A   4      14.919   4.202  19.715  1.00 35.56           H
+ATOM     39  HB3 PRO A   4      16.368   3.928  20.306  1.00 35.56           H
+ATOM     40  HG2 PRO A   4      15.742   4.664  17.806  1.00 38.99           H
+ATOM     41  HG3 PRO A   4      17.196   4.525  18.434  1.00 38.99           H
+ATOM     42  HD2 PRO A   4      16.013   2.832  16.685  1.00 38.92           H
+ATOM     43  HD3 PRO A   4      17.512   2.769  17.209  1.00 38.92           H
+ATOM     44  N  ATHR A   5      13.355   1.827  20.619  0.62 20.89           N
+ATOM     45  CA ATHR A   5      11.911   1.653  20.737  0.62 20.88           C
+ATOM     46  C  ATHR A   5      11.387   2.774  21.620  0.62 21.76           C
+ATOM     47  O  ATHR A   5      11.831   2.935  22.762  0.62 22.78           O
+ATOM     48  CB ATHR A   5      11.554   0.303  21.360  0.62 24.85           C
+ATOM     49  OG1ATHR A   5      12.002  -0.757  20.509  0.62 29.26           O
+ATOM     50  CG2ATHR A   5      10.043   0.180  21.558  0.62 28.46           C
+ATOM     51  H  ATHR A   5      13.754   1.838  21.380  0.62 25.09           H
+ATOM     52  HA ATHR A   5      11.505   1.700  19.857  0.62 25.08           H
+ATOM     53  HB ATHR A   5      11.984   0.230  22.226  0.62 29.84           H
+ATOM     54  HG1ATHR A   5      11.680  -1.489  20.769  0.62 35.14           H
+ATOM     55 HG21ATHR A   5       9.824  -0.699  21.904  0.62 34.18           H
+ATOM     56 HG22ATHR A   5       9.735   0.852  22.186  0.62 34.18           H
+ATOM     57 HG23ATHR A   5       9.586   0.308  20.712  0.62 34.18           H
+ATOM     58  N  BTHR A   5      13.381   1.831  20.631  0.38 21.16           N
+ATOM     59  CA BTHR A   5      11.944   1.740  20.808  0.38 21.15           C
+ATOM     60  C  BTHR A   5      11.475   2.993  21.532  0.38 22.62           C
+ATOM     61  O  BTHR A   5      12.134   3.478  22.462  0.38 19.07           O
+ATOM     62  CB BTHR A   5      11.581   0.515  21.648  0.38 24.36           C
+ATOM     63  OG1BTHR A   5      12.151  -0.659  21.055  0.38 26.01           O
+ATOM     64  CG2BTHR A   5      10.066   0.354  21.737  0.38 27.39           C
+ATOM     65  H  BTHR A   5      13.805   1.797  21.378  0.38 25.41           H
+ATOM     66  HA BTHR A   5      11.499   1.668  19.949  0.38 25.40           H
+ATOM     67  HB BTHR A   5      11.929   0.625  22.547  0.38 29.26           H
+ATOM     68  HG1BTHR A   5      11.884  -1.344  21.460  0.38 31.24           H
+ATOM     69 HG21BTHR A   5       9.846  -0.433  22.260  0.38 32.89           H
+ATOM     70 HG22BTHR A   5       9.674   1.133  22.161  0.38 32.89           H
+ATOM     71 HG23BTHR A   5       9.689   0.257  20.849  0.38 32.89           H
+ATOM     72  N  AVAL A   6      10.446   3.554  21.094  0.62 19.27           N
+ATOM     73  CA AVAL A   6       9.811   4.605  21.868  0.62 16.25           C
+ATOM     74  C  AVAL A   6       8.330   4.295  22.002  0.62 18.35           C
+ATOM     75  O  AVAL A   6       7.743   3.579  21.190  0.62 18.52           O
+ATOM     76  CB AVAL A   6      10.029   6.001  21.244  0.62 20.60           C
+ATOM     77  CG1AVAL A   6      11.510   6.323  21.142  0.62 23.56           C
+ATOM     78  CG2AVAL A   6       9.392   6.068  19.874  0.62 22.96           C
+ATOM     79  H  AVAL A   6      10.160   3.490  20.285  0.62 23.14           H
+ATOM     80  HA AVAL A   6      10.192   4.614  22.760  0.62 19.52           H
+ATOM     81  HB AVAL A   6       9.612   6.663  21.818  0.62 24.74           H
+ATOM     82 HG11AVAL A   6      11.614   7.223  20.794  0.62 28.30           H
+ATOM     83 HG12AVAL A   6      11.908   6.263  22.025  0.62 28.30           H
+ATOM     84 HG13AVAL A   6      11.932   5.686  20.545  0.62 28.30           H
+ATOM     85 HG21AVAL A   6       9.644   6.903  19.449  0.62 27.57           H
+ATOM     86 HG22AVAL A   6       9.705   5.319  19.343  0.62 27.57           H
+ATOM     87 HG23AVAL A   6       8.428   6.025  19.971  0.62 27.57           H
+ATOM     88  N  BVAL A   6      10.339   3.517  21.087  0.38 19.69           N
+ATOM     89  CA BVAL A   6       9.690   4.676  21.679  0.38 17.23           C
+ATOM     90  C  BVAL A   6       8.277   4.265  22.047  0.38 18.29           C
+ATOM     91  O  BVAL A   6       7.717   3.343  21.449  0.38 18.94           O
+ATOM     92  CB BVAL A   6       9.691   5.848  20.668  0.38 19.23           C
+ATOM     93  CG1BVAL A   6       8.637   6.893  21.028  0.38 19.92           C
+ATOM     94  CG2BVAL A   6      11.078   6.471  20.595  0.38 20.32           C
+ATOM     95  H  BVAL A   6       9.906   3.202  20.414  0.38 23.65           H
+ATOM     96  HA BVAL A   6      10.140   4.963  22.489  0.38 20.70           H
+ATOM     97  HB BVAL A   6       9.462   5.504  19.791  0.38 23.10           H
+ATOM     98 HG11BVAL A   6       8.752   7.668  20.456  0.38 23.93           H
+ATOM     99 HG12BVAL A   6       7.755   6.512  20.895  0.38 23.93           H
+ATOM    100 HG13BVAL A   6       8.750   7.149  21.957  0.38 23.93           H
+ATOM    101 HG21BVAL A   6      11.055   7.221  19.980  0.38 24.41           H
+ATOM    102 HG22BVAL A   6      11.334   6.776  21.480  0.38 24.41           H
+ATOM    103 HG23BVAL A   6      11.708   5.804  20.280  0.38 24.41           H
+ATOM    104  N  APHE A   7       7.716   4.855  23.038  0.62 19.00           N
+ATOM    105  CA APHE A   7       6.297   4.657  23.260  0.62 17.75           C
+ATOM    106  C  APHE A   7       5.570   5.990  23.320  0.62 16.04           C
+ATOM    107  O  APHE A   7       6.156   7.036  23.628  0.62 16.97           O
+ATOM    108  CB APHE A   7       6.009   3.873  24.560  0.62 20.06           C
+ATOM    109  CG APHE A   7       6.190   4.687  25.820  0.62 17.35           C
+ATOM    110  CD1APHE A   7       7.436   4.789  26.420  0.62 19.59           C
+ATOM    111  CD2APHE A   7       5.121   5.371  26.390  0.62 17.81           C
+ATOM    112  CE1APHE A   7       7.615   5.552  27.567  0.62 19.89           C
+ATOM    113  CE2APHE A   7       5.288   6.143  27.527  0.62 16.36           C
+ATOM    114  CZ APHE A   7       6.542   6.235  28.116  0.62 19.21           C
+ATOM    115  H  APHE A   7       8.104   5.352  23.623  0.62 22.82           H
+ATOM    116  HA APHE A   7       5.950   4.147  22.511  0.62 21.33           H
+ATOM    117  HB2APHE A   7       5.091   3.562  24.539  0.62 24.09           H
+ATOM    118  HB3APHE A   7       6.615   3.117  24.608  0.62 24.09           H
+ATOM    119  HD1APHE A   7       8.161   4.339  26.051  0.62 23.53           H
+ATOM    120  HD2APHE A   7       4.278   5.308  26.001  0.62 21.39           H
+ATOM    121  HE1APHE A   7       8.454   5.605  27.966  0.62 23.89           H
+ATOM    122  HE2APHE A   7       4.565   6.598  27.894  0.62 19.66           H
+ATOM    123  HZ APHE A   7       6.662   6.755  28.878  0.62 23.08           H
+ATOM    124  N  BPHE A   7       7.698   4.941  23.038  0.38 18.76           N
+ATOM    125  CA BPHE A   7       6.324   4.678  23.440  0.38 18.53           C
+ATOM    126  C  BPHE A   7       5.532   5.976  23.479  0.38 16.91           C
+ATOM    127  O  BPHE A   7       6.053   7.019  23.897  0.38 16.66           O
+ATOM    128  CB BPHE A   7       6.249   3.973  24.820  0.38 20.05           C
+ATOM    129  CG BPHE A   7       6.654   4.842  25.984  0.38 20.96           C
+ATOM    130  CD1BPHE A   7       5.715   5.620  26.641  0.38 16.17           C
+ATOM    131  CD2BPHE A   7       7.966   4.870  26.432  0.38 20.75           C
+ATOM    132  CE1BPHE A   7       6.074   6.425  27.710  0.38 18.61           C
+ATOM    133  CE2BPHE A   7       8.329   5.672  27.501  0.38 20.78           C
+ATOM    134  CZ BPHE A   7       7.378   6.453  28.138  0.38 17.31           C
+ATOM    135  H  BPHE A   7       8.086   5.559  23.492  0.38 22.53           H
+ATOM    136  HA BPHE A   7       5.914   4.095  22.782  0.38 22.26           H
+ATOM    137  HB2BPHE A   7       5.335   3.687  24.973  0.38 24.09           H
+ATOM    138  HB3BPHE A   7       6.840   3.205  24.808  0.38 24.09           H
+ATOM    139  HD1BPHE A   7       4.829   5.601  26.361  0.38 19.43           H
+ATOM    140  HD2BPHE A   7       8.608   4.346  26.010  0.38 24.92           H
+ATOM    141  HE1BPHE A   7       5.433   6.946  28.137  0.38 22.36           H
+ATOM    142  HE2BPHE A   7       9.212   5.686  27.792  0.38 24.95           H
+ATOM    143  HZ BPHE A   7       7.623   6.994  28.853  0.38 20.79           H
+ATOM    144  N   PHE A   8       4.270   5.907  23.040  1.00 16.72           N
+ATOM    145  CA  PHE A   8       3.298   6.971  23.270  1.00 15.85           C
+ATOM    146  C   PHE A   8       2.190   6.382  24.131  1.00 16.53           C
+ATOM    147  O   PHE A   8       1.648   5.320  23.794  1.00 17.96           O
+ATOM    148  CB  PHE A   8       2.585   7.434  21.971  1.00 16.27           C
+ATOM    149  CG  PHE A   8       3.421   8.238  20.984  1.00 15.80           C
+ATOM    150  CD1 PHE A   8       4.694   8.684  21.249  1.00 15.74           C
+ATOM    151  CD2 PHE A   8       2.849   8.563  19.771  1.00 18.31           C
+ATOM    152  CE1 PHE A   8       5.398   9.422  20.266  1.00 16.54           C
+ATOM    153  CE2 PHE A   8       3.532   9.307  18.825  1.00 17.57           C
+ATOM    154  CZ  PHE A   8       4.793   9.718  19.083  1.00 18.03           C
+ATOM    155  HA  PHE A   8       3.763   7.719  23.676  1.00 19.04           H
+ATOM    156  HB2 PHE A   8       2.274   6.644  21.501  1.00 19.54           H
+ATOM    157  HB3 PHE A   8       1.831   7.989  22.223  1.00 19.54           H
+ATOM    158  HD1 PHE A   8       5.091   8.502  22.070  1.00 18.92           H
+ATOM    159  HD2 PHE A   8       1.985   8.275  19.585  1.00 22.00           H
+ATOM    160  HE1 PHE A   8       6.270   9.703  20.429  1.00 19.87           H
+ATOM    161  HE2 PHE A   8       3.125   9.523  18.017  1.00 21.11           H
+ATOM    162  HZ  PHE A   8       5.255  10.210  18.443  1.00 21.66           H
+ATOM    163  H  APHE A   8       3.910   5.205  22.698  0.62 20.08           H
+ATOM    164  H  BPHE A   8       3.953   5.240  22.600  0.38 20.08           H
+ATOM    165  N   ASP A   9       1.808   7.090  25.200  1.00 16.57           N
+ATOM    166  CA  ASP A   9       0.603   6.790  25.964  1.00 16.37           C
+ATOM    167  C   ASP A   9      -0.480   7.735  25.458  1.00 17.12           C
+ATOM    168  O   ASP A   9      -0.303   8.959  25.523  1.00 18.91           O
+ATOM    169  CB  ASP A   9       0.840   6.973  27.462  1.00 17.75           C
+ATOM    170  CG  ASP A   9       1.617   5.819  28.084  1.00 21.33           C
+ATOM    171  OD1 ASP A   9       1.678   4.747  27.473  1.00 22.22           O
+ATOM    172  OD2 ASP A   9       2.175   5.992  29.182  1.00 25.63           O
+ATOM    173  H   ASP A   9       2.245   7.765  25.505  1.00 19.90           H
+ATOM    174  HA  ASP A   9       0.326   5.870  25.831  1.00 19.67           H
+ATOM    175  HB2 ASP A   9       1.348   7.787  27.604  1.00 21.33           H
+ATOM    176  HB3 ASP A   9      -0.017   7.034  27.912  1.00 21.33           H
+ATOM    177  N   ILE A  10      -1.547   7.199  24.932  1.00 16.33           N
+ATOM    178  CA  ILE A  10      -2.591   7.954  24.243  1.00 16.84           C
+ATOM    179  C   ILE A  10      -3.748   8.198  25.200  1.00 19.79           C
+ATOM    180  O   ILE A  10      -4.161   7.296  25.951  1.00 19.02           O
+ATOM    181  CB  ILE A  10      -3.085   7.201  22.994  1.00 16.73           C
+ATOM    182  CG1 ILE A  10      -1.927   6.865  22.053  1.00 20.51           C
+ATOM    183  CG2 ILE A  10      -4.156   7.981  22.269  1.00 19.61           C
+ATOM    184  CD1 ILE A  10      -1.192   8.042  21.497  1.00 21.64           C
+ATOM    185  H   ILE A  10      -1.711   6.355  24.956  1.00 19.61           H
+ATOM    186  HA  ILE A  10      -2.225   8.810  23.973  1.00 20.23           H
+ATOM    187  HB  ILE A  10      -3.475   6.367  23.298  1.00 20.10           H
+ATOM    188 HG12 ILE A  10      -1.284   6.325  22.539  1.00 24.63           H
+ATOM    189 HG13 ILE A  10      -2.280   6.363  21.301  1.00 24.63           H
+ATOM    190 HG21 ILE A  10      -4.399   7.506  21.459  1.00 23.56           H
+ATOM    191 HG22 ILE A  10      -4.930   8.066  22.847  1.00 23.56           H
+ATOM    192 HG23 ILE A  10      -3.811   8.859  22.046  1.00 23.56           H
+ATOM    193 HD11 ILE A  10      -0.502   7.727  20.893  1.00 25.99           H
+ATOM    194 HD12 ILE A  10      -1.818   8.607  21.017  1.00 25.99           H
+ATOM    195 HD13 ILE A  10      -0.792   8.538  22.228  1.00 25.99           H
+ATOM    196  N   ALA A  11      -4.322   9.391  25.135  1.00 17.95           N
+ATOM    197  CA  ALA A  11      -5.511   9.740  25.900  1.00 17.17           C
+ATOM    198  C   ALA A  11      -6.574  10.303  24.969  1.00 17.96           C
+ATOM    199  O   ALA A  11      -6.270  10.893  23.919  1.00 18.86           O
+ATOM    200  CB  ALA A  11      -5.208  10.767  26.983  1.00 21.60           C
+ATOM    201  H   ALA A  11      -4.033  10.033  24.642  1.00 21.57           H
+ATOM    202  HA  ALA A  11      -5.859   8.940  26.323  1.00 20.63           H
+ATOM    203  HB1 ALA A  11      -6.025  10.967  27.466  1.00 25.94           H
+ATOM    204  HB2 ALA A  11      -4.546  10.400  27.590  1.00 25.94           H
+ATOM    205  HB3 ALA A  11      -4.864  11.573  26.567  1.00 25.94           H
+ATOM    206  N   VAL A  12      -7.828  10.128  25.356  1.00 18.96           N
+ATOM    207  CA  VAL A  12      -8.977  10.560  24.577  1.00 20.78           C
+ATOM    208  C   VAL A  12      -9.800  11.445  25.502  1.00 24.40           C
+ATOM    209  O   VAL A  12     -10.353  10.956  26.494  1.00 24.61           O
+ATOM    210  CB  VAL A  12      -9.804   9.370  24.078  1.00 24.57           C
+ATOM    211  CG1 VAL A  12     -11.020   9.840  23.300  1.00 25.69           C
+ATOM    212  CG2 VAL A  12      -8.946   8.456  23.240  1.00 22.17           C
+ATOM    213  H   VAL A  12      -8.046   9.747  26.096  1.00 22.78           H
+ATOM    214  HA  VAL A  12      -8.695  11.078  23.806  1.00 24.96           H
+ATOM    215  HB  VAL A  12     -10.127   8.868  24.842  1.00 29.51           H
+ATOM    216 HG11 VAL A  12     -11.503   9.066  22.971  1.00 30.86           H
+ATOM    217 HG12 VAL A  12     -11.589  10.361  23.888  1.00 30.86           H
+ATOM    218 HG13 VAL A  12     -10.726  10.388  22.555  1.00 30.86           H
+ATOM    219 HG21 VAL A  12      -9.493   7.730  22.903  1.00 26.63           H
+ATOM    220 HG22 VAL A  12      -8.574   8.961  22.501  1.00 26.63           H
+ATOM    221 HG23 VAL A  12      -8.230   8.101  23.792  1.00 26.63           H
+ATOM    222  N   ASP A  13      -9.852  12.743  25.208  1.00 21.78           N
+ATOM    223  CA  ASP A  13     -10.466  13.725  26.104  1.00 25.20           C
+ATOM    224  C   ASP A  13      -9.954  13.548  27.531  1.00 28.74           C
+ATOM    225  O   ASP A  13     -10.714  13.616  28.503  1.00 30.23           O
+ATOM    226  CB  ASP A  13     -11.989  13.652  26.048  1.00 27.12           C
+ATOM    227  CG  ASP A  13     -12.571  14.334  24.824  1.00 33.25           C
+ATOM    228  OD1 ASP A  13     -11.859  15.133  24.173  1.00 29.72           O
+ATOM    229  OD2 ASP A  13     -13.759  14.087  24.528  1.00 42.51           O
+ATOM    230  H   ASP A  13      -9.535  13.085  24.486  1.00 26.16           H
+ATOM    231  HA  ASP A  13     -10.209  14.612  25.809  1.00 30.26           H
+ATOM    232  HB2 ASP A  13     -12.260  12.721  26.028  1.00 32.57           H
+ATOM    233  HB3 ASP A  13     -12.355  14.087  26.834  1.00 32.57           H
+ATOM    234  N  AGLY A  14      -8.660  13.275  27.664  0.53 22.98           N
+ATOM    235  CA AGLY A  14      -8.055  13.068  28.958  0.53 27.16           C
+ATOM    236  C  AGLY A  14      -8.253  11.689  29.556  0.53 20.97           C
+ATOM    237  O  AGLY A  14      -7.658  11.399  30.603  0.53 34.36           O
+ATOM    238  H  AGLY A  14      -8.110  13.206  27.006  0.53 27.60           H
+ATOM    239  HA2AGLY A  14      -7.100  13.219  28.880  0.53 32.62           H
+ATOM    240  HA3AGLY A  14      -8.427  13.713  29.580  0.53 32.62           H
+ATOM    241  N  BGLY A  14      -8.642  13.336  27.656  0.47 23.27           N
+ATOM    242  CA BGLY A  14      -7.969  13.290  28.933  0.47 25.56           C
+ATOM    243  C  BGLY A  14      -7.906  11.925  29.582  0.47 25.19           C
+ATOM    244  O  BGLY A  14      -7.166  11.756  30.560  0.47 29.69           O
+ATOM    245  H  BGLY A  14      -8.113  13.214  26.989  0.47 27.95           H
+ATOM    246  HA2BGLY A  14      -7.058  13.601  28.813  0.47 30.70           H
+ATOM    247  HA3BGLY A  14      -8.428  13.885  29.546  0.47 30.70           H
+ATOM    248  N  AGLU A  15      -9.070  10.818  28.934  0.53 23.05           N
+ATOM    249  CA AGLU A  15      -9.242   9.462  29.452  0.53 19.53           C
+ATOM    250  C  AGLU A  15      -8.155   8.559  28.878  0.53 23.20           C
+ATOM    251  O  AGLU A  15      -7.937   8.563  27.659  0.53 22.28           O
+ATOM    252  CB AGLU A  15     -10.596   8.905  29.042  0.53 21.30           C
+ATOM    253  CG AGLU A  15     -11.790   9.533  29.740  0.53 46.02           C
+ATOM    254  CD AGLU A  15     -11.957   9.051  31.171  0.53 61.36           C
+ATOM    255  OE1AGLU A  15     -11.680   7.860  31.442  0.53 57.77           O
+ATOM    256  OE2AGLU A  15     -12.364   9.867  32.026  0.53 59.03           O
+ATOM    257  H  AGLU A  15      -9.523  10.991  28.224  0.53 27.68           H
+ATOM    258  HA AGLU A  15      -9.182   9.470  30.420  0.53 23.46           H
+ATOM    259  HB2AGLU A  15     -10.709   9.046  28.089  0.53 25.58           H
+ATOM    260  HB3AGLU A  15     -10.609   7.956  29.241  0.53 25.58           H
+ATOM    261  HG2AGLU A  15     -11.673  10.496  29.759  0.53 55.25           H
+ATOM    262  HG3AGLU A  15     -12.596   9.307  29.251  0.53 55.25           H
+ATOM    263  N  BGLU A  15      -8.623  10.949  29.063  0.47 22.01           N
+ATOM    264  CA BGLU A  15      -8.701   9.665  29.745  0.47 23.85           C
+ATOM    265  C  BGLU A  15      -7.830   8.638  29.036  0.47 20.25           C
+ATOM    266  O  BGLU A  15      -7.876   8.536  27.797  0.47 23.06           O
+ATOM    267  CB BGLU A  15     -10.149   9.188  29.778  0.47 24.25           C
+ATOM    268  CG BGLU A  15     -11.043  10.033  30.706  0.47 43.64           C
+ATOM    269  CD BGLU A  15     -10.580  10.019  32.162  0.47 42.24           C
+ATOM    270  OE1BGLU A  15     -10.539   8.927  32.765  0.47 47.34           O
+ATOM    271  OE2BGLU A  15     -10.247  11.097  32.699  0.47 43.07           O
+ATOM    272  HA BGLU A  15      -8.379   9.753  30.656  0.47 28.64           H
+ATOM    273  HB2BGLU A  15     -10.517   9.237  28.882  0.47 29.12           H
+ATOM    274  HB3BGLU A  15     -10.171   8.271  30.096  0.47 29.12           H
+ATOM    275  HG2BGLU A  15     -11.034  10.954  30.400  0.47 52.40           H
+ATOM    276  HG3BGLU A  15     -11.947   9.683  30.678  0.47 52.40           H
+ATOM    277  N  APRO A  16      -7.474   7.754  29.688  0.53 21.05           N
+ATOM    278  CA APRO A  16      -6.426   6.893  29.132  0.53 20.95           C
+ATOM    279  C  APRO A  16      -7.013   5.935  28.117  0.53 25.26           C
+ATOM    280  O  APRO A  16      -8.108   5.402  28.301  0.53 25.10           O
+ATOM    281  CB APRO A  16      -5.891   6.137  30.354  0.53 23.48           C
+ATOM    282  CG APRO A  16      -6.390   6.852  31.528  0.53 23.15           C
+ATOM    283  CD APRO A  16      -7.655   7.535  31.133  0.53 20.35           C
+ATOM    284  HA APRO A  16      -5.716   7.422  28.736  0.53 25.17           H
+ATOM    285  HB2APRO A  16      -6.221   5.225  30.343  0.53 28.19           H
+ATOM    286  HB3APRO A  16      -4.921   6.139  30.338  0.53 28.19           H
+ATOM    287  HG2APRO A  16      -6.558   6.218  32.242  0.53 27.80           H
+ATOM    288  HG3APRO A  16      -5.729   7.503  31.811  0.53 27.80           H
+ATOM    289  HD2APRO A  16      -8.423   6.968  31.305  0.53 24.45           H
+ATOM    290  HD3APRO A  16      -7.754   8.379  31.602  0.53 24.45           H
+ATOM    291  N  BPRO A  16      -7.022   7.869  29.766  0.47 18.85           N
+ATOM    292  CA BPRO A  16      -6.092   6.944  29.105  0.47 24.02           C
+ATOM    293  C  BPRO A  16      -6.799   5.899  28.249  0.47 22.94           C
+ATOM    294  O  BPRO A  16      -7.778   5.278  28.668  0.47 26.18           O
+ATOM    295  CB BPRO A  16      -5.339   6.310  30.283  0.47 23.88           C
+ATOM    296  CG BPRO A  16      -5.420   7.329  31.365  0.47 28.71           C
+ATOM    297  CD BPRO A  16      -6.779   7.942  31.220  0.47 19.32           C
+ATOM    298  HA BPRO A  16      -5.480   7.439  28.539  0.47 28.84           H
+ATOM    299  HB2BPRO A  16      -5.771   5.484  30.548  0.47 28.68           H
+ATOM    300  HB3BPRO A  16      -4.417   6.137  30.034  0.47 28.68           H
+ATOM    301  HG2BPRO A  16      -5.323   6.901  32.230  0.47 34.47           H
+ATOM    302  HG3BPRO A  16      -4.725   7.995  31.245  0.47 34.47           H
+ATOM    303  HD2BPRO A  16      -7.444   7.431  31.709  0.47 23.21           H
+ATOM    304  HD3BPRO A  16      -6.779   8.863  31.526  0.47 23.21           H
+ATOM    305  N   LEU A  17      -6.280   5.712  27.031  1.00 21.39           N
+ATOM    306  CA  LEU A  17      -6.711   4.727  26.050  1.00 19.52           C
+ATOM    307  C   LEU A  17      -5.774   3.529  26.044  1.00 23.35           C
+ATOM    308  O   LEU A  17      -6.204   2.386  26.229  1.00 25.13           O
+ATOM    309  CB  LEU A  17      -6.771   5.361  24.649  1.00 22.44           C
+ATOM    310  CG  LEU A  17      -7.203   4.423  23.526  1.00 22.77           C
+ATOM    311  CD1 LEU A  17      -8.609   3.927  23.709  1.00 30.61           C
+ATOM    312  CD2 LEU A  17      -7.084   5.122  22.187  1.00 25.57           C
+ATOM    313  HA  LEU A  17      -7.608   4.425  26.261  1.00 23.45           H
+ATOM    314  HB2 LEU A  17      -7.404   6.096  24.673  1.00 26.95           H
+ATOM    315  HB3 LEU A  17      -5.887   5.693  24.426  1.00 26.95           H
+ATOM    316  HG  LEU A  17      -6.616   3.651  23.545  1.00 27.34           H
+ATOM    317 HD11 LEU A  17      -8.855   3.387  22.942  1.00 36.75           H
+ATOM    318 HD12 LEU A  17      -8.652   3.393  24.517  1.00 36.75           H
+ATOM    319 HD13 LEU A  17      -9.205   4.688  23.783  1.00 36.75           H
+ATOM    320 HD21 LEU A  17      -7.345   4.506  21.485  1.00 30.70           H
+ATOM    321 HD22 LEU A  17      -7.669   5.896  22.182  1.00 30.70           H
+ATOM    322 HD23 LEU A  17      -6.164   5.402  22.058  1.00 30.70           H
+ATOM    323  H  ALEU A  17      -5.543   6.113  26.845  0.53 25.69           H
+ATOM    324  H  BLEU A  17      -5.627   6.184  26.731  0.47 25.69           H
+ATOM    325  N   GLY A  18      -4.483   3.769  25.885  1.00 18.90           N
+ATOM    326  CA  GLY A  18      -3.516   2.696  25.875  1.00 18.01           C
+ATOM    327  C   GLY A  18      -2.188   3.195  25.344  1.00 17.85           C
+ATOM    328  O   GLY A  18      -2.018   4.388  25.072  1.00 19.76           O
+ATOM    329  H   GLY A  18      -4.141   4.552  25.779  1.00 22.71           H
+ATOM    330  HA2 GLY A  18      -3.388   2.359  26.776  1.00 21.64           H
+ATOM    331  HA3 GLY A  18      -3.830   1.973  25.309  1.00 21.64           H
+ATOM    332  N  AARG A  19      -1.269   2.263  25.149  0.71 16.53           N
+ATOM    333  CA AARG A  19       0.109   2.542  24.788  0.71 15.70           C
+ATOM    334  C  AARG A  19       0.440   1.945  23.434  0.71 17.17           C
+ATOM    335  O  AARG A  19       0.184   0.762  23.177  0.71 17.54           O
+ATOM    336  CB AARG A  19       1.035   1.941  25.835  0.71 16.39           C
+ATOM    337  CG AARG A  19       2.480   2.036  25.483  0.71 17.33           C
+ATOM    338  CD AARG A  19       3.375   1.627  26.636  0.71 18.90           C
+ATOM    339  NE AARG A  19       3.450   2.646  27.669  0.71 19.27           N
+ATOM    340  CZ AARG A  19       4.344   2.658  28.646  0.71 21.07           C
+ATOM    341  NH1AARG A  19       5.227   1.682  28.784  0.71 23.62           N
+ATOM    342  NH2AARG A  19       4.358   3.681  29.494  0.71 20.53           N
+ATOM    343  H  AARG A  19      -1.428   1.421  25.223  0.71 19.86           H
+ATOM    344  HA AARG A  19       0.237   3.501  24.726  0.71 18.87           H
+ATOM    345  HB2AARG A  19       0.903   2.409  26.674  0.71 19.69           H
+ATOM    346  HB3AARG A  19       0.818   1.001  25.941  0.71 19.69           H
+ATOM    347  HG2AARG A  19       2.665   1.450  24.733  0.71 20.82           H
+ATOM    348  HG3AARG A  19       2.691   2.953  25.248  0.71 20.82           H
+ATOM    349  HD2AARG A  19       3.024   0.816  27.038  0.71 22.70           H
+ATOM    350  HD3AARG A  19       4.272   1.470  26.302  0.71 22.70           H
+ATOM    351  HE AARG A  19       2.875   3.285  27.644  0.71 23.14           H
+ATOM    352 HH11AARG A  19       5.228   1.022  28.233  0.71 28.36           H
+ATOM    353 HH12AARG A  19       5.800   1.707  29.426  0.71 28.36           H
+ATOM    354 HH21AARG A  19       3.793   4.323  29.403  0.71 24.66           H
+ATOM    355 HH22AARG A  19       4.933   3.702  30.133  0.71 24.66           H
+ATOM    356  N  BARG A  19      -1.262   2.257  25.192  0.29 16.49           N
+ATOM    357  CA BARG A  19       0.098   2.529  24.764  0.29 15.37           C
+ATOM    358  C  BARG A  19       0.373   1.927  23.393  0.29 17.17           C
+ATOM    359  O  BARG A  19      -0.228   0.915  22.990  0.29 14.07           O
+ATOM    360  CB BARG A  19       1.100   1.974  25.780  0.29 16.15           C
+ATOM    361  CG BARG A  19       2.556   2.135  25.390  0.29 18.12           C
+ATOM    362  CD BARG A  19       3.480   1.734  26.531  0.29 18.83           C
+ATOM    363  NE BARG A  19       3.314   2.586  27.702  0.29 19.39           N
+ATOM    364  CZ BARG A  19       4.059   2.509  28.795  0.29 21.24           C
+ATOM    365  NH1BARG A  19       5.013   1.599  28.918  0.29 23.76           N
+ATOM    366  NH2BARG A  19       3.845   3.370  29.787  0.29 23.77           N
+ATOM    367  H  BARG A  19      -1.406   1.422  25.338  0.29 19.81           H
+ATOM    368  HA BARG A  19       0.221   3.489  24.689  0.29 18.47           H
+ATOM    369  HB2BARG A  19       0.971   2.435  26.624  0.29 19.41           H
+ATOM    370  HB3BARG A  19       0.932   1.025  25.891  0.29 19.41           H
+ATOM    371  HG2BARG A  19       2.750   1.570  24.626  0.29 21.77           H
+ATOM    372  HG3BARG A  19       2.729   3.064  25.168  0.29 21.77           H
+ATOM    373  HD2BARG A  19       3.285   0.821  26.792  0.29 22.61           H
+ATOM    374  HD3BARG A  19       4.401   1.805  26.235  0.29 22.61           H
+ATOM    375  HE BARG A  19       2.690   3.178  27.682  0.29 23.29           H
+ATOM    376 HH11BARG A  19       5.160   1.041  28.280  0.29 28.53           H
+ATOM    377 HH12BARG A  19       5.486   1.566  29.636  0.29 28.53           H
+ATOM    378 HH21BARG A  19       3.229   3.966  29.713  0.29 28.55           H
+ATOM    379 HH22BARG A  19       4.322   3.330  30.501  0.29 28.55           H
+ATOM    380  N  AVAL A  20       0.986   2.772  22.553  0.71 15.03           N
+ATOM    381  CA AVAL A  20       1.552   2.311  21.297  0.71 16.30           C
+ATOM    382  C  AVAL A  20       3.061   2.397  21.415  0.71 15.92           C
+ATOM    383  O  AVAL A  20       3.592   3.393  21.918  0.71 18.44           O
+ATOM    384  CB AVAL A  20       1.068   3.173  20.120  0.71 18.74           C
+ATOM    385  CG1AVAL A  20       1.518   2.541  18.810  0.71 16.25           C
+ATOM    386  CG2AVAL A  20      -0.411   3.359  20.161  0.71 19.58           C
+ATOM    387  H  AVAL A  20       1.041   3.623  22.665  0.71 18.06           H
+ATOM    388  HA AVAL A  20       1.289   1.391  21.138  0.71 19.59           H
+ATOM    389  HB AVAL A  20       1.461   4.058  20.184  0.71 22.51           H
+ATOM    390 HG11AVAL A  20       1.240   3.108  18.073  0.71 19.53           H
+ATOM    391 HG12AVAL A  20       2.485   2.457  18.815  0.71 19.53           H
+ATOM    392 HG13AVAL A  20       1.110   1.665  18.725  0.71 19.53           H
+ATOM    393 HG21AVAL A  20      -0.683   3.899  19.403  0.71 23.52           H
+ATOM    394 HG22AVAL A  20      -0.840   2.490  20.120  0.71 23.52           H
+ATOM    395 HG23AVAL A  20      -0.651   3.807  20.988  0.71 23.52           H
+ATOM    396  N  BVAL A  20       1.279   2.595  22.675  0.29 17.35           N
+ATOM    397  CA BVAL A  20       1.777   2.156  21.378  0.29 15.39           C
+ATOM    398  C  BVAL A  20       3.278   2.413  21.353  0.29 17.19           C
+ATOM    399  O  BVAL A  20       3.736   3.494  21.734  0.29 17.80           O
+ATOM    400  CB BVAL A  20       1.065   2.868  20.209  0.29 17.18           C
+ATOM    401  CG1BVAL A  20      -0.374   2.431  20.115  0.29 26.75           C
+ATOM    402  CG2BVAL A  20       1.134   4.372  20.360  0.29 17.75           C
+ATOM    403  H  BVAL A  20       1.631   3.336  22.933  0.29 20.85           H
+ATOM    404  HA BVAL A  20       1.626   1.204  21.270  0.29 18.50           H
+ATOM    405  HB BVAL A  20       1.520   2.622  19.388  0.29 20.64           H
+ATOM    406 HG11BVAL A  20      -0.774   2.828  19.326  0.29 32.12           H
+ATOM    407 HG12BVAL A  20      -0.407   1.464  20.052  0.29 32.12           H
+ATOM    408 HG13BVAL A  20      -0.846   2.727  20.909  0.29 32.12           H
+ATOM    409 HG21BVAL A  20       0.702   4.787  19.597  0.29 21.33           H
+ATOM    410 HG22BVAL A  20       0.678   4.629  21.177  0.29 21.33           H
+ATOM    411 HG23BVAL A  20       2.064   4.643  20.401  0.29 21.33           H
+ATOM    412  N  ASER A  21       3.761   1.373  20.943  0.71 16.95           N
+ATOM    413  CA ASER A  21       5.209   1.445  20.852  0.71 14.89           C
+ATOM    414  C  ASER A  21       5.664   1.297  19.404  0.71 16.54           C
+ATOM    415  O  ASER A  21       4.968   0.708  18.574  0.71 16.06           O
+ATOM    416  CB ASER A  21       5.899   0.417  21.748  0.71 20.89           C
+ATOM    417  OG ASER A  21       5.753  -0.875  21.217  0.71 24.08           O
+ATOM    418  H  ASER A  21       3.419   0.632  20.671  0.71 20.36           H
+ATOM    419  HA ASER A  21       5.492   2.322  21.156  0.71 17.89           H
+ATOM    420  HB2ASER A  21       6.843   0.630  21.807  0.71 25.10           H
+ATOM    421  HB3ASER A  21       5.497   0.444  22.630  0.71 25.10           H
+ATOM    422  HG ASER A  21       6.211  -1.421  21.662  0.71 28.91           H
+ATOM    423  N  BSER A  21       4.044   1.423  20.914  0.29 15.04           N
+ATOM    424  CA BSER A  21       5.494   1.519  20.866  0.29 18.62           C
+ATOM    425  C  BSER A  21       5.965   1.281  19.440  0.29 16.04           C
+ATOM    426  O  BSER A  21       5.490   0.367  18.768  0.29 16.81           O
+ATOM    427  CB BSER A  21       6.125   0.508  21.824  0.29 19.81           C
+ATOM    428  OG BSER A  21       5.630   0.705  23.144  0.29 20.61           O
+ATOM    429  H  BSER A  21       3.739   0.669  20.634  0.29 18.07           H
+ATOM    430  HA BSER A  21       5.788   2.405  21.129  0.29 22.37           H
+ATOM    431  HB2BSER A  21       5.902  -0.390  21.532  0.29 23.79           H
+ATOM    432  HB3BSER A  21       7.088   0.627  21.825  0.29 23.79           H
+ATOM    433  HG BSER A  21       5.852   0.060  23.634  0.29 24.76           H
+ATOM    434  N  APHE A  22       6.851   1.843  19.122  0.71 15.87           N
+ATOM    435  CA APHE A  22       7.392   1.937  17.776  0.71 17.26           C
+ATOM    436  C  APHE A  22       8.843   1.491  17.776  0.71 16.48           C
+ATOM    437  O  APHE A  22       9.619   1.879  18.654  0.71 19.61           O
+ATOM    438  CB APHE A  22       7.430   3.399  17.289  0.71 17.02           C
+ATOM    439  CG APHE A  22       6.115   4.112  17.364  0.71 17.15           C
+ATOM    440  CD1APHE A  22       5.190   3.975  16.359  0.71 16.75           C
+ATOM    441  CD2APHE A  22       5.808   4.906  18.446  0.71 19.66           C
+ATOM    442  CE1APHE A  22       3.971   4.640  16.411  0.71 20.05           C
+ATOM    443  CE2APHE A  22       4.594   5.572  18.519  0.71 20.62           C
+ATOM    444  CZ APHE A  22       3.683   5.438  17.485  0.71 19.05           C
+ATOM    445  H  APHE A  22       7.374   2.175  19.718  0.71 19.07           H
+ATOM    446  HA APHE A  22       6.847   1.382  17.198  0.71 20.73           H
+ATOM    447  HB2APHE A  22       8.062   3.891  17.836  0.71 20.44           H
+ATOM    448  HB3APHE A  22       7.717   3.408  16.362  0.71 20.44           H
+ATOM    449  HD1APHE A  22       5.382   3.429  15.631  0.71 20.13           H
+ATOM    450  HD2APHE A  22       6.423   4.997  19.138  0.71 23.61           H
+ATOM    451  HE1APHE A  22       3.355   4.543  15.721  0.71 24.09           H
+ATOM    452  HE2APHE A  22       4.394   6.104  19.255  0.71 24.77           H
+ATOM    453  HZ APHE A  22       2.873   5.893  17.521  0.71 22.89           H
+ATOM    454  N  BPHE A  22       6.896   2.107  18.977  0.29 17.76           N
+ATOM    455  CA BPHE A  22       7.379   2.039  17.607  0.29 17.47           C
+ATOM    456  C  BPHE A  22       8.855   1.676  17.607  0.29 17.90           C
+ATOM    457  O  BPHE A  22       9.648   2.260  18.356  0.29 17.50           O
+ATOM    458  CB BPHE A  22       7.216   3.382  16.886  0.29 17.73           C
+ATOM    459  CG BPHE A  22       5.919   4.083  17.171  0.29 16.00           C
+ATOM    460  CD1BPHE A  22       4.784   3.803  16.433  0.29 18.21           C
+ATOM    461  CD2BPHE A  22       5.844   5.033  18.170  0.29 17.99           C
+ATOM    462  CE1BPHE A  22       3.592   4.460  16.691  0.29 14.97           C
+ATOM    463  CE2BPHE A  22       4.657   5.691  18.437  0.29 20.77           C
+ATOM    464  CZ BPHE A  22       3.533   5.404  17.691  0.29 21.72           C
+ATOM    465  H  BPHE A  22       7.267   2.725  19.446  0.29 21.34           H
+ATOM    466  HA BPHE A  22       6.873   1.357  17.137  0.29 20.98           H
+ATOM    467  HB2BPHE A  22       7.935   3.971  17.163  0.29 21.30           H
+ATOM    468  HB3BPHE A  22       7.263   3.228  15.930  0.29 21.30           H
+ATOM    469  HD1BPHE A  22       4.821   3.167  15.755  0.29 21.87           H
+ATOM    470  HD2BPHE A  22       6.602   5.234  18.670  0.29 21.62           H
+ATOM    471  HE1BPHE A  22       2.834   4.264  16.190  0.29 17.99           H
+ATOM    472  HE2BPHE A  22       4.617   6.324  19.117  0.29 24.95           H
+ATOM    473  HZ BPHE A  22       2.734   5.848  17.864  0.29 26.08           H
+ATOM    474  N   GLU A  23       9.221   0.729  16.757  1.00 18.13           N
+ATOM    475  CA  GLU A  23      10.618   0.517  16.436  1.00 19.23           C
+ATOM    476  C   GLU A  23      11.034   1.593  15.440  1.00 17.73           C
+ATOM    477  O   GLU A  23      10.338   1.818  14.451  1.00 18.94           O
+ATOM    478  CB  GLU A  23      10.802  -0.864  15.816  1.00 21.99           C
+ATOM    479  CG  GLU A  23      12.241  -1.114  15.394  1.00 25.35           C
+ATOM    480  CD  GLU A  23      12.472  -2.453  14.709  1.00 31.39           C
+ATOM    481  OE1 GLU A  23      11.546  -3.275  14.627  1.00 34.27           O
+ATOM    482  OE2 GLU A  23      13.606  -2.652  14.227  1.00 34.50           O
+ATOM    483  HA  GLU A  23      11.172   0.571  17.231  1.00 23.10           H
+ATOM    484  HB2 GLU A  23      10.555  -1.540  16.466  1.00 26.41           H
+ATOM    485  HB3 GLU A  23      10.239  -0.937  15.030  1.00 26.41           H
+ATOM    486  HG2 GLU A  23      12.507  -0.417  14.773  1.00 30.45           H
+ATOM    487  HG3 GLU A  23      12.804  -1.087  16.183  1.00 30.45           H
+ATOM    488  H  AGLU A  23       8.676   0.320  16.232  0.71 21.78           H
+ATOM    489  H  BGLU A  23       8.678   0.197  16.354  0.29 21.78           H
+ATOM    490  N   LEU A  24      12.134   2.264  15.699  1.00 17.96           N
+ATOM    491  CA  LEU A  24      12.670   3.262  14.785  1.00 17.49           C
+ATOM    492  C   LEU A  24      13.862   2.678  14.041  1.00 20.57           C
+ATOM    493  O   LEU A  24      14.774   2.131  14.667  1.00 20.52           O
+ATOM    494  CB  LEU A  24      13.094   4.494  15.565  1.00 17.44           C
+ATOM    495  CG  LEU A  24      12.046   5.078  16.497  1.00 18.10           C
+ATOM    496  CD1 LEU A  24      12.623   6.294  17.231  1.00 22.61           C
+ATOM    497  CD2 LEU A  24      10.763   5.444  15.726  1.00 20.40           C
+ATOM    498  H   LEU A  24      12.603   2.161  16.412  1.00 21.58           H
+ATOM    499  HA  LEU A  24      11.999   3.514  14.132  1.00 21.01           H
+ATOM    500  HB2 LEU A  24      13.864   4.260  16.107  1.00 20.95           H
+ATOM    501  HB3 LEU A  24      13.334   5.187  14.930  1.00 20.95           H
+ATOM    502  HG  LEU A  24      11.797   4.415  17.159  1.00 21.75           H
+ATOM    503 HD11 LEU A  24      11.946   6.655  17.824  1.00 27.16           H
+ATOM    504 HD12 LEU A  24      13.397   6.015  17.744  1.00 27.16           H
+ATOM    505 HD13 LEU A  24      12.883   6.963  16.579  1.00 27.16           H
+ATOM    506 HD21 LEU A  24      10.119   5.820  16.346  1.00 24.50           H
+ATOM    507 HD22 LEU A  24      10.981   6.093  15.040  1.00 24.50           H
+ATOM    508 HD23 LEU A  24      10.400   4.641  15.319  1.00 24.50           H
+ATOM    509  N   PHE A  25      13.866   2.817  12.718  1.00 18.65           N
+ATOM    510  CA  PHE A  25      14.854   2.145  11.872  1.00 19.29           C
+ATOM    511  C   PHE A  25      16.123   2.991  11.776  1.00 21.44           C
+ATOM    512  O   PHE A  25      16.499   3.497  10.718  1.00 22.55           O
+ATOM    513  CB  PHE A  25      14.255   1.866  10.500  1.00 22.40           C
+ATOM    514  CG  PHE A  25      13.041   1.008  10.531  1.00 20.85           C
+ATOM    515  CD1 PHE A  25      12.981  -0.131  11.310  1.00 26.40           C
+ATOM    516  CD2 PHE A  25      11.939   1.352   9.770  1.00 24.95           C
+ATOM    517  CE1 PHE A  25      11.845  -0.912  11.316  1.00 30.15           C
+ATOM    518  CE2 PHE A  25      10.812   0.564   9.774  1.00 25.08           C
+ATOM    519  CZ  PHE A  25      10.763  -0.556  10.544  1.00 26.52           C
+ATOM    520  H   PHE A  25      13.304   3.300  12.281  1.00 22.40           H
+ATOM    521  HA  PHE A  25      15.096   1.301  12.284  1.00 23.17           H
+ATOM    522  HB2 PHE A  25      14.008   2.710  10.091  1.00 26.90           H
+ATOM    523  HB3 PHE A  25      14.920   1.415   9.957  1.00 26.90           H
+ATOM    524  HD1 PHE A  25      13.711  -0.372  11.833  1.00 31.71           H
+ATOM    525  HD2 PHE A  25      11.959   2.124   9.251  1.00 29.96           H
+ATOM    526  HE1 PHE A  25      11.810  -1.679  11.842  1.00 36.21           H
+ATOM    527  HE2 PHE A  25      10.081   0.798   9.249  1.00 30.11           H
+ATOM    528  HZ  PHE A  25       9.997  -1.082  10.548  1.00 31.84           H
+ATOM    529  N   ALA A  26      16.796   3.137  12.918  1.00 21.15           N
+ATOM    530  CA  ALA A  26      18.029   3.906  12.967  1.00 22.39           C
+ATOM    531  C   ALA A  26      19.132   3.266  12.130  1.00 24.42           C
+ATOM    532  O   ALA A  26      20.049   3.965  11.698  1.00 26.80           O
+ATOM    533  CB  ALA A  26      18.481   4.037  14.418  1.00 27.58           C
+ATOM    534  H   ALA A  26      16.558   2.802  13.673  1.00 25.40           H
+ATOM    535  HA  ALA A  26      17.871   4.795  12.615  1.00 26.90           H
+ATOM    536  HB1 ALA A  26      19.301   4.554  14.448  1.00 33.12           H
+ATOM    537  HB2 ALA A  26      17.787   4.487  14.925  1.00 33.12           H
+ATOM    538  HB3 ALA A  26      18.635   3.151  14.782  1.00 33.12           H
+ATOM    539  N   ASP A  27      19.029   1.969  11.856  1.00 24.40           N
+ATOM    540  CA  ASP A  27      20.023   1.320  11.008  1.00 26.35           C
+ATOM    541  C   ASP A  27      19.950   1.798   9.562  1.00 35.15           C
+ATOM    542  O   ASP A  27      20.975   1.825   8.877  1.00 34.02           O
+ATOM    543  CB  ASP A  27      19.894  -0.203  11.115  1.00 30.81           C
+ATOM    544  CG  ASP A  27      18.515  -0.727  10.719  1.00 39.65           C
+ATOM    545  OD1 ASP A  27      17.518   0.028  10.756  1.00 32.71           O
+ATOM    546  OD2 ASP A  27      18.423  -1.924  10.381  1.00 47.04           O
+ATOM    547  H   ASP A  27      18.405   1.452  12.143  1.00 29.30           H
+ATOM    548  HA  ASP A  27      20.908   1.554  11.328  1.00 31.65           H
+ATOM    549  HB2 ASP A  27      20.547  -0.615  10.527  1.00 37.00           H
+ATOM    550  HB3 ASP A  27      20.060  -0.468  12.033  1.00 37.00           H
+ATOM    551  N  ALYS A  28      18.780   2.261   9.109  0.77 25.35           N
+ATOM    552  CA ALYS A  28      18.593   2.673   7.723  0.77 24.28           C
+ATOM    553  C  ALYS A  28      18.337   4.164   7.532  0.77 22.64           C
+ATOM    554  O  ALYS A  28      18.722   4.705   6.493  0.77 22.76           O
+ATOM    555  CB ALYS A  28      17.482   1.840   7.072  0.77 30.25           C
+ATOM    556  CG ALYS A  28      17.928   0.384   6.844  0.77 37.98           C
+ATOM    557  CD ALYS A  28      16.777  -0.569   6.613  0.77 53.47           C
+ATOM    558  CE ALYS A  28      17.261  -2.016   6.625  0.77 57.41           C
+ATOM    559  NZ ALYS A  28      16.135  -2.991   6.651  0.77 84.81           N
+ATOM    560  H  ALYS A  28      18.074   2.345   9.595  0.77 30.44           H
+ATOM    561  HA ALYS A  28      19.407   2.487   7.229  0.77 29.16           H
+ATOM    562  HB2ALYS A  28      16.704   1.835   7.651  0.77 36.32           H
+ATOM    563  HB3ALYS A  28      17.254   2.228   6.212  0.77 36.32           H
+ATOM    564  HG2ALYS A  28      18.502   0.350   6.063  0.77 45.60           H
+ATOM    565  HG3ALYS A  28      18.414   0.078   7.626  0.77 45.60           H
+ATOM    566  HD2ALYS A  28      16.119  -0.459   7.318  0.77 64.18           H
+ATOM    567  HD3ALYS A  28      16.373  -0.387   5.751  0.77 64.18           H
+ATOM    568  HE2ALYS A  28      17.785  -2.182   5.826  0.77 68.91           H
+ATOM    569  HE3ALYS A  28      17.805  -2.162   7.415  0.77 68.91           H
+ATOM    570  HZ1ALYS A  28      16.452  -3.822   6.639  0.77101.80           H
+ATOM    571  HZ2ALYS A  28      15.651  -2.877   7.389  0.77101.80           H
+ATOM    572  HZ3ALYS A  28      15.612  -2.870   5.941  0.77101.80           H
+ATOM    573  N  BLYS A  28      18.758   2.108   9.060  0.23 25.45           N
+ATOM    574  CA BLYS A  28      18.612   2.554   7.681  0.23 24.62           C
+ATOM    575  C  BLYS A  28      18.440   4.054   7.560  0.23 22.91           C
+ATOM    576  O  BLYS A  28      18.863   4.642   6.560  0.23 23.51           O
+ATOM    577  CB BLYS A  28      17.407   1.872   7.031  0.23 30.39           C
+ATOM    578  CG BLYS A  28      17.723   0.500   6.474  0.23 39.42           C
+ATOM    579  CD BLYS A  28      16.520  -0.409   6.550  0.23 52.37           C
+ATOM    580  CE BLYS A  28      16.843  -1.788   6.012  0.23 62.43           C
+ATOM    581  NZ BLYS A  28      15.711  -2.732   6.209  0.23 86.51           N
+ATOM    582  H  BLYS A  28      18.019   2.069   9.499  0.23 30.57           H
+ATOM    583  HA BLYS A  28      19.406   2.298   7.186  0.23 29.57           H
+ATOM    584  HB2BLYS A  28      16.708   1.770   7.696  0.23 36.49           H
+ATOM    585  HB3BLYS A  28      17.090   2.425   6.300  0.23 36.49           H
+ATOM    586  HG2BLYS A  28      17.986   0.583   5.544  0.23 47.32           H
+ATOM    587  HG3BLYS A  28      18.442   0.101   6.988  0.23 47.32           H
+ATOM    588  HD2BLYS A  28      16.240  -0.498   7.474  0.23 62.86           H
+ATOM    589  HD3BLYS A  28      15.798  -0.035   6.020  0.23 62.86           H
+ATOM    590  HE2BLYS A  28      17.028  -1.727   5.062  0.23 74.94           H
+ATOM    591  HE3BLYS A  28      17.618  -2.140   6.478  0.23 74.94           H
+ATOM    592  HZ1BLYS A  28      15.918  -3.530   5.873  0.23103.83           H
+ATOM    593  HZ2BLYS A  28      15.536  -2.821   7.077  0.23103.83           H
+ATOM    594  HZ3BLYS A  28      14.984  -2.425   5.797  0.23103.83           H
+ATOM    595  N  AVAL A  29      17.716   4.842   8.498  0.77 21.49           N
+ATOM    596  CA AVAL A  29      17.493   6.289   8.435  0.77 20.55           C
+ATOM    597  C  AVAL A  29      17.892   6.916   9.767  0.77 23.03           C
+ATOM    598  O  AVAL A  29      17.047   7.423  10.529  0.77 19.18           O
+ATOM    599  CB AVAL A  29      16.049   6.669   8.046  0.77 18.48           C
+ATOM    600  CG1AVAL A  29      15.865   6.689   6.559  0.77 20.29           C
+ATOM    601  CG2AVAL A  29      15.065   5.742   8.655  0.77 25.56           C
+ATOM    602  HA AVAL A  29      18.072   6.640   7.740  0.77 24.69           H
+ATOM    603  HB AVAL A  29      15.887   7.562   8.387  0.77 22.20           H
+ATOM    604 HG11AVAL A  29      14.940   6.901   6.358  0.77 24.38           H
+ATOM    605 HG12AVAL A  29      16.449   7.363   6.178  0.77 24.38           H
+ATOM    606 HG13AVAL A  29      16.089   5.816   6.201  0.77 24.38           H
+ATOM    607 HG21AVAL A  29      14.169   6.040   8.431  0.77 30.69           H
+ATOM    608 HG22AVAL A  29      15.214   4.849   8.306  0.77 30.69           H
+ATOM    609 HG23AVAL A  29      15.183   5.744   9.618  0.77 30.69           H
+ATOM    610  N  BVAL A  29      17.843   4.685   8.561  0.23 21.21           N
+ATOM    611  CA BVAL A  29      17.487   6.095   8.464  0.23 19.95           C
+ATOM    612  C  BVAL A  29      17.903   6.769   9.766  0.23 22.30           C
+ATOM    613  O  BVAL A  29      17.052   7.172  10.573  0.23 19.99           O
+ATOM    614  CB BVAL A  29      16.000   6.245   8.098  0.23 18.62           C
+ATOM    615  CG1BVAL A  29      15.100   5.654   9.169  0.23 24.85           C
+ATOM    616  CG2BVAL A  29      15.672   7.682   7.825  0.23 25.37           C
+ATOM    617  HA BVAL A  29      17.981   6.546   7.761  0.23 23.97           H
+ATOM    618  HB BVAL A  29      15.829   5.743   7.286  0.23 22.36           H
+ATOM    619 HG11BVAL A  29      14.178   5.873   8.962  0.23 29.85           H
+ATOM    620 HG12BVAL A  29      15.216   4.691   9.182  0.23 29.85           H
+ATOM    621 HG13BVAL A  29      15.344   6.029  10.029  0.23 29.85           H
+ATOM    622 HG21BVAL A  29      14.708   7.785   7.789  0.23 30.47           H
+ATOM    623 HG22BVAL A  29      16.037   8.230   8.536  0.23 30.47           H
+ATOM    624 HG23BVAL A  29      16.063   7.939   6.975  0.23 30.47           H
+ATOM    625  N  APRO A  30      19.178   6.924  10.090  0.77 19.69           N
+ATOM    626  CA APRO A  30      19.578   7.373  11.429  0.77 19.41           C
+ATOM    627  C  APRO A  30      19.228   8.812  11.757  0.77 19.96           C
+ATOM    628  O  APRO A  30      18.884   9.111  12.908  0.77 20.18           O
+ATOM    629  CB APRO A  30      21.101   7.131  11.437  0.77 23.42           C
+ATOM    630  CG APRO A  30      21.478   6.966   9.983  0.77 23.69           C
+ATOM    631  CD APRO A  30      20.291   6.357   9.313  0.77 21.54           C
+ATOM    632  HA APRO A  30      19.150   6.804  12.088  0.77 23.31           H
+ATOM    633  HB2APRO A  30      21.555   7.894  11.829  0.77 28.13           H
+ATOM    634  HB3APRO A  30      21.305   6.328  11.942  0.77 28.13           H
+ATOM    635  HG2APRO A  30      21.682   7.832   9.598  0.77 28.45           H
+ATOM    636  HG3APRO A  30      22.249   6.381   9.911  0.77 28.45           H
+ATOM    637  HD2APRO A  30      20.239   6.624   8.382  0.77 25.87           H
+ATOM    638  HD3APRO A  30      20.308   5.390   9.380  0.77 25.87           H
+ATOM    639  N  BPRO A  30      19.209   6.928  10.001  0.23 19.82           N
+ATOM    640  CA BPRO A  30      19.661   7.376  11.330  0.23 19.75           C
+ATOM    641  C  BPRO A  30      19.199   8.768  11.711  0.23 19.85           C
+ATOM    642  O  BPRO A  30      18.721   8.977  12.833  0.23 21.27           O
+ATOM    643  CB BPRO A  30      21.195   7.290  11.216  0.23 21.16           C
+ATOM    644  CG BPRO A  30      21.471   7.416   9.742  0.23 20.98           C
+ATOM    645  CD BPRO A  30      20.335   6.693   9.078  0.23 20.96           C
+ATOM    646  HA BPRO A  30      19.342   6.749  11.998  0.23 23.73           H
+ATOM    647  HB2BPRO A  30      21.606   8.015  11.711  0.23 25.41           H
+ATOM    648  HB3BPRO A  30      21.506   6.437  11.557  0.23 25.41           H
+ATOM    649  HG2BPRO A  30      21.485   8.351   9.486  0.23 25.19           H
+ATOM    650  HG3BPRO A  30      22.320   7.000   9.527  0.23 25.19           H
+ATOM    651  HD2BPRO A  30      20.150   7.069   8.203  0.23 25.17           H
+ATOM    652  HD3BPRO A  30      20.526   5.745   8.998  0.23 25.17           H
+ATOM    653  N   LYS A  31      19.352   9.736  10.806  1.00 18.60           N
+ATOM    654  CA  LYS A  31      19.065  11.120  11.128  1.00 19.27           C
+ATOM    655  C   LYS A  31      17.574  11.313  11.402  1.00 18.40           C
+ATOM    656  O   LYS A  31      17.188  12.037  12.331  1.00 18.97           O
+ATOM    657  CB  LYS A  31      19.528  12.008   9.984  1.00 23.05           C
+ATOM    658  CG  LYS A  31      19.399  13.457  10.272  1.00 21.11           C
+ATOM    659  CD  LYS A  31      20.113  14.312   9.229  1.00 25.85           C
+ATOM    660  CE  LYS A  31      19.894  15.783   9.477  1.00 24.65           C
+ATOM    661  NZ  LYS A  31      20.742  16.619   8.575  1.00 27.57           N
+ATOM    662  HA  LYS A  31      19.551  11.381  11.926  1.00 23.14           H
+ATOM    663  HB2 LYS A  31      20.463  11.823   9.802  1.00 27.69           H
+ATOM    664  HB3 LYS A  31      18.993  11.812   9.199  1.00 27.69           H
+ATOM    665  HG2 LYS A  31      18.460  13.701  10.271  1.00 25.35           H
+ATOM    666  HG3 LYS A  31      19.790  13.647  11.139  1.00 25.35           H
+ATOM    667  HD2 LYS A  31      21.066  14.135   9.267  1.00 31.05           H
+ATOM    668  HD3 LYS A  31      19.771  14.097   8.348  1.00 31.05           H
+ATOM    669  HE2 LYS A  31      18.964  16.001   9.312  1.00 29.60           H
+ATOM    670  HE3 LYS A  31      20.127  15.992  10.395  1.00 29.60           H
+ATOM    671  HZ1 LYS A  31      20.625  17.482   8.761  1.00 33.10           H
+ATOM    672  HZ2 LYS A  31      21.600  16.414   8.686  1.00 33.10           H
+ATOM    673  HZ3 LYS A  31      20.518  16.474   7.726  1.00 33.10           H
+ATOM    674  H  ALYS A  31      19.594   9.587   9.995  0.77 22.34           H
+ATOM    675  H  BLYS A  31      19.622   9.611   9.999  0.23 22.34           H
+ATOM    676  N   THR A  32      16.730  10.672  10.599  1.00 17.66           N
+ATOM    677  CA  THR A  32      15.292  10.829  10.770  1.00 18.29           C
+ATOM    678  C   THR A  32      14.817  10.105  12.021  1.00 18.05           C
+ATOM    679  O   THR A  32      13.992  10.631  12.780  1.00 16.56           O
+ATOM    680  CB  THR A  32      14.603  10.268   9.531  1.00 17.66           C
+ATOM    681  OG1 THR A  32      15.119  10.908   8.365  1.00 16.70           O
+ATOM    682  CG2 THR A  32      13.104  10.513   9.564  1.00 16.32           C
+ATOM    683  H   THR A  32      16.961  10.148   9.957  1.00 21.21           H
+ATOM    684  HA  THR A  32      15.062  11.767  10.865  1.00 21.98           H
+ATOM    685  HB  THR A  32      14.763   9.312   9.502  1.00 21.21           H
+ATOM    686  HG1 THR A  32      15.913  10.667   8.232  1.00 20.06           H
+ATOM    687 HG21 THR A  32      12.688  10.134   8.774  1.00 19.61           H
+ATOM    688 HG22 THR A  32      12.718  10.100  10.352  1.00 19.61           H
+ATOM    689 HG23 THR A  32      12.924  11.466   9.587  1.00 19.61           H
+ATOM    690  N   ALA A  33      15.363   8.912  12.277  1.00 15.90           N
+ATOM    691  CA  ALA A  33      15.039   8.192  13.504  1.00 15.86           C
+ATOM    692  C   ALA A  33      15.436   8.980  14.741  1.00 18.10           C
+ATOM    693  O   ALA A  33      14.679   9.028  15.720  1.00 17.83           O
+ATOM    694  CB  ALA A  33      15.732   6.828  13.501  1.00 21.36           C
+ATOM    695  H   ALA A  33      15.917   8.504  11.761  1.00 19.10           H
+ATOM    696  HA  ALA A  33      14.079   8.054  13.536  1.00 19.05           H
+ATOM    697  HB1 ALA A  33      15.497   6.353  14.314  1.00 25.66           H
+ATOM    698  HB2 ALA A  33      15.435   6.325  12.726  1.00 25.66           H
+ATOM    699  HB3 ALA A  33      16.692   6.962  13.461  1.00 25.66           H
+ATOM    700  N   GLU A  34      16.606   9.618  14.723  1.00 17.97           N
+ATOM    701  CA  GLU A  34      17.061  10.334  15.907  1.00 17.97           C
+ATOM    702  C   GLU A  34      16.173  11.538  16.212  1.00 19.12           C
+ATOM    703  O   GLU A  34      15.927  11.855  17.373  1.00 19.86           O
+ATOM    704  CB  GLU A  34      18.519  10.770  15.706  1.00 21.88           C
+ATOM    705  CG  GLU A  34      19.095  11.615  16.840  1.00 25.59           C
+ATOM    706  CD  GLU A  34      19.178  10.903  18.188  1.00 21.99           C
+ATOM    707  OE1 GLU A  34      18.968   9.682  18.274  1.00 23.87           O
+ATOM    708  OE2 GLU A  34      19.454  11.608  19.178  1.00 31.58           O
+ATOM    709  H   GLU A  34      17.142   9.649  14.052  1.00 21.59           H
+ATOM    710  HA  GLU A  34      17.019   9.741  16.673  1.00 21.59           H
+ATOM    711  HB2 GLU A  34      19.070   9.975  15.625  1.00 26.28           H
+ATOM    712  HB3 GLU A  34      18.574  11.296  14.892  1.00 26.28           H
+ATOM    713  HG2 GLU A  34      19.995  11.885  16.597  1.00 30.73           H
+ATOM    714  HG3 GLU A  34      18.534  12.398  16.957  1.00 30.73           H
+ATOM    715  N   ASN A  35      15.691  12.234  15.173  1.00 17.09           N
+ATOM    716  CA  ASN A  35      14.774  13.350  15.384  1.00 16.26           C
+ATOM    717  C   ASN A  35      13.529  12.889  16.153  1.00 16.98           C
+ATOM    718  O   ASN A  35      13.144  13.487  17.166  1.00 18.15           O
+ATOM    719  CB  ASN A  35      14.387  13.926  14.017  1.00 17.18           C
+ATOM    720  CG  ASN A  35      13.444  15.101  14.111  1.00 15.66           C
+ATOM    721  OD1 ASN A  35      13.742  16.121  14.717  1.00 19.59           O
+ATOM    722  ND2 ASN A  35      12.282  14.968  13.482  1.00 17.68           N
+ATOM    723  H   ASN A  35      15.879  12.079  14.349  1.00 20.53           H
+ATOM    724  HA  ASN A  35      15.205  14.044  15.907  1.00 19.53           H
+ATOM    725  HB2 ASN A  35      15.190  14.225  13.563  1.00 20.64           H
+ATOM    726  HB3 ASN A  35      13.949  13.234  13.497  1.00 20.64           H
+ATOM    727 HD21 ASN A  35      11.707  15.606  13.502  1.00 21.24           H
+ATOM    728 HD22 ASN A  35      12.106  14.243  13.053  1.00 21.24           H
+ATOM    729  N   PHE A  36      12.902  11.805  15.698  1.00 16.06           N
+ATOM    730  CA  PHE A  36      11.709  11.305  16.371  1.00 15.58           C
+ATOM    731  C   PHE A  36      12.037  10.812  17.775  1.00 16.51           C
+ATOM    732  O   PHE A  36      11.254  11.034  18.705  1.00 17.21           O
+ATOM    733  CB  PHE A  36      11.082  10.216  15.499  1.00 16.67           C
+ATOM    734  CG  PHE A  36       9.707   9.788  15.919  1.00 14.17           C
+ATOM    735  CD1 PHE A  36       8.576  10.380  15.357  1.00 17.61           C
+ATOM    736  CD2 PHE A  36       9.530   8.764  16.825  1.00 17.79           C
+ATOM    737  CE1 PHE A  36       7.315   9.960  15.728  1.00 16.43           C
+ATOM    738  CE2 PHE A  36       8.270   8.356  17.196  1.00 19.73           C
+ATOM    739  CZ  PHE A  36       7.160   8.947  16.626  1.00 19.14           C
+ATOM    740  H   PHE A  36      13.144  11.348  15.011  1.00 19.29           H
+ATOM    741  HA  PHE A  36      11.053  12.011  16.478  1.00 18.72           H
+ATOM    742  HB2 PHE A  36      11.019  10.548  14.590  1.00 20.03           H
+ATOM    743  HB3 PHE A  36      11.653   9.432  15.528  1.00 20.03           H
+ATOM    744  HD1 PHE A  36       8.672  11.060  14.729  1.00 21.15           H
+ATOM    745  HD2 PHE A  36      10.274   8.342  17.190  1.00 21.37           H
+ATOM    746  HE1 PHE A  36       6.565  10.372  15.363  1.00 19.74           H
+ATOM    747  HE2 PHE A  36       8.165   7.684  17.830  1.00 23.69           H
+ATOM    748  HZ  PHE A  36       6.308   8.654  16.855  1.00 22.99           H
+ATOM    749  N   ARG A  37      13.155  10.100  17.939  1.00 16.64           N
+ATOM    750  CA  ARG A  37      13.520   9.605  19.263  1.00 17.38           C
+ATOM    751  C   ARG A  37      13.682  10.754  20.245  1.00 19.30           C
+ATOM    752  O   ARG A  37      13.126  10.729  21.356  1.00 18.87           O
+ATOM    753  CB  ARG A  37      14.817   8.798  19.165  1.00 18.78           C
+ATOM    754  CG  ARG A  37      15.159   8.080  20.471  1.00 20.12           C
+ATOM    755  CD  ARG A  37      16.622   7.707  20.559  1.00 21.33           C
+ATOM    756  NE  ARG A  37      17.453   8.895  20.597  1.00 21.88           N
+ATOM    757  CZ  ARG A  37      17.592   9.679  21.656  1.00 24.39           C
+ATOM    758  NH1 ARG A  37      17.028   9.377  22.820  1.00 26.97           N
+ATOM    759  NH2 ARG A  37      18.282  10.808  21.539  1.00 24.83           N
+ATOM    760  H   ARG A  37      13.706   9.895  17.312  1.00 19.99           H
+ATOM    761  HA  ARG A  37      12.818   9.022  19.591  1.00 20.88           H
+ATOM    762  HB2 ARG A  37      14.723   8.129  18.469  1.00 22.56           H
+ATOM    763  HB3 ARG A  37      15.549   9.399  18.951  1.00 22.56           H
+ATOM    764  HG2 ARG A  37      14.952   8.663  21.218  1.00 24.17           H
+ATOM    765  HG3 ARG A  37      14.637   7.265  20.531  1.00 24.17           H
+ATOM    766  HD2 ARG A  37      16.778   7.195  21.369  1.00 25.62           H
+ATOM    767  HD3 ARG A  37      16.870   7.181  19.783  1.00 25.62           H
+ATOM    768  HE  ARG A  37      17.886   9.104  19.884  1.00 26.28           H
+ATOM    769 HH11 ARG A  37      16.561   8.659  22.897  1.00 32.39           H
+ATOM    770 HH12 ARG A  37      17.129   9.899  23.495  1.00 32.39           H
+ATOM    771 HH21 ARG A  37      18.632  11.021  20.784  1.00 29.82           H
+ATOM    772 HH22 ARG A  37      18.378  11.325  22.220  1.00 29.82           H
+ATOM    773  N   ALA A  38      14.436  11.782  19.850  1.00 17.86           N
+ATOM    774  CA  ALA A  38      14.699  12.892  20.754  1.00 18.32           C
+ATOM    775  C   ALA A  38      13.445  13.692  21.049  1.00 18.47           C
+ATOM    776  O   ALA A  38      13.276  14.186  22.168  1.00 20.37           O
+ATOM    777  CB  ALA A  38      15.804  13.782  20.198  1.00 22.00           C
+ATOM    778  H   ALA A  38      14.800  11.856  19.074  1.00 21.45           H
+ATOM    779  HA  ALA A  38      15.013  12.529  21.597  1.00 22.00           H
+ATOM    780  HB1 ALA A  38      15.944  14.527  20.802  1.00 26.42           H
+ATOM    781  HB2 ALA A  38      16.620  13.262  20.120  1.00 26.42           H
+ATOM    782  HB3 ALA A  38      15.537  14.109  19.325  1.00 26.42           H
+ATOM    783  N   LEU A  39      12.560  13.858  20.057  1.00 18.34           N
+ATOM    784  CA  LEU A  39      11.297  14.547  20.315  1.00 16.86           C
+ATOM    785  C   LEU A  39      10.409  13.741  21.243  1.00 15.66           C
+ATOM    786  O   LEU A  39       9.608  14.316  21.995  1.00 18.24           O
+ATOM    787  CB  LEU A  39      10.574  14.837  18.998  1.00 18.17           C
+ATOM    788  CG  LEU A  39      11.283  15.845  18.095  1.00 18.06           C
+ATOM    789  CD1 LEU A  39      10.562  15.924  16.743  1.00 19.17           C
+ATOM    790  CD2 LEU A  39      11.351  17.229  18.718  1.00 20.30           C
+ATOM    791  H   LEU A  39      12.666  13.586  19.248  1.00 22.03           H
+ATOM    792  HA  LEU A  39      11.484  15.398  20.740  1.00 20.26           H
+ATOM    793  HB2 LEU A  39      10.490  14.007  18.503  1.00 21.83           H
+ATOM    794  HB3 LEU A  39       9.694  15.193  19.202  1.00 21.83           H
+ATOM    795  HG  LEU A  39      12.196  15.543  17.966  1.00 21.70           H
+ATOM    796 HD11 LEU A  39      11.068  16.500  16.148  1.00 23.03           H
+ATOM    797 HD12 LEU A  39      10.499  15.033  16.366  1.00 23.03           H
+ATOM    798 HD13 LEU A  39       9.674  16.289  16.880  1.00 23.03           H
+ATOM    799 HD21 LEU A  39      11.798  17.831  18.102  1.00 24.39           H
+ATOM    800 HD22 LEU A  39      10.449  17.543  18.890  1.00 24.39           H
+ATOM    801 HD23 LEU A  39      11.847  17.177  19.549  1.00 24.39           H
+ATOM    802  N   SER A  40      10.556  12.419  21.233  1.00 16.99           N
+ATOM    803  CA  SER A  40       9.780  11.577  22.136  1.00 17.34           C
+ATOM    804  C   SER A  40      10.290  11.614  23.568  1.00 20.32           C
+ATOM    805  O   SER A  40       9.488  11.473  24.488  1.00 21.95           O
+ATOM    806  CB  SER A  40       9.770  10.126  21.652  1.00 17.96           C
+ATOM    807  OG  SER A  40       9.131  10.040  20.381  1.00 19.75           O
+ATOM    808  H   SER A  40      11.094  11.988  20.719  1.00 20.41           H
+ATOM    809  HA  SER A  40       8.870  11.913  22.128  1.00 20.83           H
+ATOM    810  HB2 SER A  40      10.684   9.810  21.571  1.00 21.57           H
+ATOM    811  HB3 SER A  40       9.285   9.579  22.290  1.00 21.57           H
+ATOM    812  HG  SER A  40       8.922  10.808  20.112  1.00 23.73           H
+ATOM    813  N   THR A  41      11.592  11.783  23.782  1.00 20.57           N
+ATOM    814  CA  THR A  41      12.097  11.866  25.147  1.00 19.95           C
+ATOM    815  C   THR A  41      12.051  13.283  25.670  1.00 25.55           C
+ATOM    816  O   THR A  41      12.069  13.481  26.887  1.00 28.73           O
+ATOM    817  CB  THR A  41      13.548  11.399  25.227  1.00 24.02           C
+ATOM    818  OG1 THR A  41      14.361  12.302  24.486  1.00 23.42           O
+ATOM    819  CG2 THR A  41      13.713  10.007  24.678  1.00 24.73           C
+ATOM    820  H   THR A  41      12.190  11.850  23.167  1.00 24.71           H
+ATOM    821  HA  THR A  41      11.561  11.282  25.707  1.00 23.96           H
+ATOM    822  HB  THR A  41      13.829  11.377  26.155  1.00 28.85           H
+ATOM    823  HG1 THR A  41      15.126  11.974  24.373  1.00 28.13           H
+ATOM    824 HG21 THR A  41      14.641   9.732  24.745  1.00 29.70           H
+ATOM    825 HG22 THR A  41      13.163   9.385  25.180  1.00 29.70           H
+ATOM    826 HG23 THR A  41      13.445   9.983  23.746  1.00 29.70           H
+ATOM    827  N   GLY A  42      12.025  14.263  24.777  1.00 21.91           N
+ATOM    828  CA  GLY A  42      12.046  15.658  25.149  1.00 23.18           C
+ATOM    829  C   GLY A  42      13.400  16.160  25.575  1.00 24.82           C
+ATOM    830  O   GLY A  42      13.485  17.262  26.120  1.00 28.53           O
+ATOM    831  H   GLY A  42      11.994  14.138  23.927  1.00 26.32           H
+ATOM    832  HA2 GLY A  42      11.756  16.189  24.390  1.00 27.84           H
+ATOM    833  HA3 GLY A  42      11.430  15.796  25.885  1.00 27.84           H
+ATOM    834  N   GLU A  43      14.467  15.414  25.288  1.00 23.82           N
+ATOM    835  CA  GLU A  43      15.766  15.711  25.893  1.00 27.76           C
+ATOM    836  C   GLU A  43      16.378  17.011  25.389  1.00 34.93           C
+ATOM    837  O   GLU A  43      17.276  17.543  26.052  1.00 34.47           O
+ATOM    838  CB  GLU A  43      16.711  14.533  25.683  1.00 28.41           C
+ATOM    839  CG  GLU A  43      17.075  14.274  24.238  1.00 33.66           C
+ATOM    840  CD  GLU A  43      17.699  12.922  24.053  1.00 34.45           C
+ATOM    841  OE1 GLU A  43      17.059  11.910  24.404  1.00 28.93           O
+ATOM    842  OE2 GLU A  43      18.844  12.862  23.560  1.00 34.55           O
+ATOM    843  H   GLU A  43      14.467  14.741  24.753  1.00 28.61           H
+ATOM    844  HA  GLU A  43      15.648  15.824  26.850  1.00 33.34           H
+ATOM    845  HB2 GLU A  43      17.534  14.707  26.166  1.00 34.12           H
+ATOM    846  HB3 GLU A  43      16.287  13.731  26.027  1.00 34.12           H
+ATOM    847  HG2 GLU A  43      16.272  14.316  23.694  1.00 40.42           H
+ATOM    848  HG3 GLU A  43      17.710  14.946  23.943  1.00 40.42           H
+ATOM    849  N   LYS A  44      15.926  17.542  24.254  1.00 30.32           N
+ATOM    850  CA  LYS A  44      16.402  18.825  23.750  1.00 29.96           C
+ATOM    851  C   LYS A  44      15.607  20.003  24.287  1.00 29.58           C
+ATOM    852  O   LYS A  44      15.894  21.145  23.913  1.00 36.57           O
+ATOM    853  CB  LYS A  44      16.334  18.872  22.221  1.00 33.54           C
+ATOM    854  CG  LYS A  44      17.080  17.765  21.517  1.00 37.17           C
+ATOM    855  CD  LYS A  44      18.578  17.936  21.618  1.00 51.58           C
+ATOM    856  CE  LYS A  44      19.309  16.733  21.047  1.00 62.66           C
+ATOM    857  NZ  LYS A  44      20.753  16.737  21.425  1.00 71.25           N
+ATOM    858  H   LYS A  44      15.334  17.171  23.752  1.00 36.41           H
+ATOM    859  HA  LYS A  44      17.330  18.916  24.020  1.00 35.98           H
+ATOM    860  HB2 LYS A  44      15.404  18.812  21.953  1.00 40.27           H
+ATOM    861  HB3 LYS A  44      16.712  19.714  21.923  1.00 40.27           H
+ATOM    862  HG2 LYS A  44      16.845  16.915  21.920  1.00 44.62           H
+ATOM    863  HG3 LYS A  44      16.838  17.765  20.578  1.00 44.62           H
+ATOM    864  HD2 LYS A  44      18.847  18.722  21.119  1.00 61.92           H
+ATOM    865  HD3 LYS A  44      18.829  18.032  22.550  1.00 61.92           H
+ATOM    866  HE2 LYS A  44      18.907  15.920  21.390  1.00 75.22           H
+ATOM    867  HE3 LYS A  44      19.248  16.750  20.079  1.00 75.22           H
+ATOM    868  HZ1 LYS A  44      21.161  16.027  21.077  1.00 85.52           H
+ATOM    869  HZ2 LYS A  44      21.145  17.475  21.120  1.00 85.52           H
+ATOM    870  HZ3 LYS A  44      20.835  16.711  22.311  1.00 85.52           H
+ATOM    871  N   GLY A  45      14.600  19.760  25.121  1.00 27.12           N
+ATOM    872  CA  GLY A  45      13.806  20.825  25.686  1.00 32.47           C
+ATOM    873  C   GLY A  45      12.456  21.034  25.047  1.00 40.87           C
+ATOM    874  O   GLY A  45      11.707  21.913  25.493  1.00 31.90           O
+ATOM    875  H   GLY A  45      14.360  18.973  25.373  1.00 32.57           H
+ATOM    876  HA2 GLY A  45      13.660  20.636  26.626  1.00 38.99           H
+ATOM    877  HA3 GLY A  45      14.301  21.655  25.604  1.00 38.99           H
+ATOM    878  N   PHE A  46      12.121  20.260  24.019  1.00 27.28           N
+ATOM    879  CA  PHE A  46      10.818  20.348  23.382  1.00 24.58           C
+ATOM    880  C   PHE A  46      10.527  18.989  22.761  1.00 20.65           C
+ATOM    881  O   PHE A  46      11.413  18.143  22.638  1.00 23.11           O
+ATOM    882  CB  PHE A  46      10.772  21.439  22.311  1.00 25.47           C
+ATOM    883  CG  PHE A  46      11.891  21.364  21.304  1.00 25.73           C
+ATOM    884  CD1 PHE A  46      11.750  20.648  20.122  1.00 23.32           C
+ATOM    885  CD2 PHE A  46      13.084  22.026  21.535  1.00 30.92           C
+ATOM    886  CE1 PHE A  46      12.781  20.585  19.200  1.00 31.62           C
+ATOM    887  CE2 PHE A  46      14.118  21.970  20.619  1.00 31.71           C
+ATOM    888  CZ  PHE A  46      13.973  21.247  19.446  1.00 34.84           C
+ATOM    889  H   PHE A  46      12.640  19.669  23.670  1.00 32.76           H
+ATOM    890  HA  PHE A  46      10.145  20.560  24.048  1.00 29.52           H
+ATOM    891  HB2 PHE A  46       9.935  21.364  21.826  1.00 30.58           H
+ATOM    892  HB3 PHE A  46      10.826  22.304  22.747  1.00 30.58           H
+ATOM    893  HD1 PHE A  46      10.951  20.205  19.948  1.00 28.01           H
+ATOM    894  HD2 PHE A  46      13.192  22.516  22.318  1.00 37.12           H
+ATOM    895  HE1 PHE A  46      12.673  20.097  18.415  1.00 37.97           H
+ATOM    896  HE2 PHE A  46      14.914  22.419  20.790  1.00 38.08           H
+ATOM    897  HZ  PHE A  46      14.668  21.207  18.830  1.00 41.83           H
+ATOM    898  N   GLY A  47       9.273  18.778  22.389  1.00 20.92           N
+ATOM    899  CA  GLY A  47       8.927  17.501  21.789  1.00 20.48           C
+ATOM    900  C   GLY A  47       7.441  17.194  21.907  1.00 18.59           C
+ATOM    901  O   GLY A  47       6.604  18.082  22.043  1.00 18.88           O
+ATOM    902  H   GLY A  47       8.627  19.340  22.470  1.00 25.12           H
+ATOM    903  HA2 GLY A  47       9.163  17.513  20.848  1.00 24.60           H
+ATOM    904  HA3 GLY A  47       9.422  16.793  22.230  1.00 24.60           H
+ATOM    905  N   TYR A  48       7.138  15.907  21.817  1.00 16.76           N
+ATOM    906  CA  TYR A  48       5.766  15.481  21.569  1.00 15.48           C
+ATOM    907  C   TYR A  48       4.862  15.407  22.799  1.00 14.30           C
+ATOM    908  O   TYR A  48       3.640  15.336  22.636  1.00 15.68           O
+ATOM    909  CB  TYR A  48       5.795  14.104  20.921  1.00 16.19           C
+ATOM    910  CG  TYR A  48       6.393  14.037  19.523  1.00 14.80           C
+ATOM    911  CD1 TYR A  48       6.088  14.981  18.543  1.00 15.42           C
+ATOM    912  CD2 TYR A  48       7.252  13.011  19.190  1.00 16.30           C
+ATOM    913  CE1 TYR A  48       6.631  14.892  17.257  1.00 14.86           C
+ATOM    914  CE2 TYR A  48       7.781  12.907  17.907  1.00 15.92           C
+ATOM    915  CZ  TYR A  48       7.463  13.851  16.957  1.00 14.90           C
+ATOM    916  OH  TYR A  48       8.009  13.727  15.685  1.00 16.49           O
+ATOM    917  H   TYR A  48       7.703  15.264  21.896  1.00 20.14           H
+ATOM    918  HA  TYR A  48       5.367  16.138  20.978  1.00 18.60           H
+ATOM    919  HB2 TYR A  48       6.318  13.514  21.485  1.00 19.46           H
+ATOM    920  HB3 TYR A  48       4.882  13.780  20.858  1.00 19.46           H
+ATOM    921  HD1 TYR A  48       5.513  15.683  18.748  1.00 18.53           H
+ATOM    922  HD2 TYR A  48       7.481  12.378  19.832  1.00 19.58           H
+ATOM    923  HE1 TYR A  48       6.429  15.533  16.615  1.00 17.85           H
+ATOM    924  HE2 TYR A  48       8.347  12.202  17.691  1.00 19.13           H
+ATOM    925  HH  TYR A  48       8.063  14.482  15.320  1.00 19.81           H
+ATOM    926  N   LYS A  49       5.412  15.371  24.020  1.00 15.96           N
+ATOM    927  CA  LYS A  49       4.544  15.157  25.173  1.00 17.10           C
+ATOM    928  C   LYS A  49       3.496  16.261  25.278  1.00 16.92           C
+ATOM    929  O   LYS A  49       3.827  17.455  25.263  1.00 19.29           O
+ATOM    930  CB  LYS A  49       5.400  15.114  26.425  1.00 18.45           C
+ATOM    931  CG  LYS A  49       4.572  14.818  27.648  1.00 21.31           C
+ATOM    932  CD  LYS A  49       5.442  14.569  28.874  1.00 27.32           C
+ATOM    933  CE  LYS A  49       4.567  14.336  30.107  1.00 30.82           C
+ATOM    934  NZ  LYS A  49       5.388  14.055  31.324  1.00 56.27           N
+ATOM    935  H   LYS A  49       6.249  15.464  24.195  1.00 19.18           H
+ATOM    936  HA  LYS A  49       4.070  14.316  25.080  1.00 20.55           H
+ATOM    937  HB2 LYS A  49       6.069  14.418  26.332  1.00 22.17           H
+ATOM    938  HB3 LYS A  49       5.831  15.974  26.548  1.00 22.17           H
+ATOM    939  HG2 LYS A  49       3.995  15.575  27.834  1.00 25.60           H
+ATOM    940  HG3 LYS A  49       4.038  14.025  27.488  1.00 25.60           H
+ATOM    941  HD2 LYS A  49       5.990  13.782  28.729  1.00 32.81           H
+ATOM    942  HD3 LYS A  49       6.006  15.341  29.035  1.00 32.81           H
+ATOM    943  HE2 LYS A  49       4.034  15.128  30.276  1.00 37.00           H
+ATOM    944  HE3 LYS A  49       3.987  13.574  29.949  1.00 37.00           H
+ATOM    945  HZ1 LYS A  49       4.857  13.902  32.021  1.00 67.54           H
+ATOM    946  HZ2 LYS A  49       5.900  13.340  31.188  1.00 67.54           H
+ATOM    947  HZ3 LYS A  49       5.910  14.753  31.506  1.00 67.54           H
+ATOM    948  N   GLY A  50       2.226  15.872  25.382  1.00 15.98           N
+ATOM    949  CA  GLY A  50       1.129  16.810  25.480  1.00 16.70           C
+ATOM    950  C   GLY A  50       0.510  17.229  24.171  1.00 18.27           C
+ATOM    951  O   GLY A  50      -0.542  17.878  24.174  1.00 21.81           O
+ATOM    952  H   GLY A  50       1.976  15.050  25.398  1.00 19.20           H
+ATOM    953  HA2 GLY A  50       0.429  16.410  26.020  1.00 20.06           H
+ATOM    954  HA3 GLY A  50       1.448  17.612  25.922  1.00 20.06           H
+ATOM    955  N   SER A  51       1.105  16.847  23.049  1.00 15.61           N
+ATOM    956  CA  SER A  51       0.621  17.264  21.748  1.00 16.40           C
+ATOM    957  C   SER A  51      -0.496  16.348  21.268  1.00 16.52           C
+ATOM    958  O   SER A  51      -0.752  15.296  21.840  1.00 17.46           O
+ATOM    959  CB  SER A  51       1.769  17.298  20.742  1.00 17.08           C
+ATOM    960  OG  SER A  51       2.284  16.014  20.442  1.00 16.46           O
+ATOM    961  H   SER A  51       1.800  16.341  23.017  1.00 18.76           H
+ATOM    962  HA  SER A  51       0.255  18.160  21.817  1.00 19.70           H
+ATOM    963  HB2 SER A  51       1.443  17.698  19.920  1.00 20.52           H
+ATOM    964  HB3 SER A  51       2.485  17.838  21.112  1.00 20.52           H
+ATOM    965  HG  SER A  51       1.778  15.421  20.755  1.00 19.78           H
+ATOM    966  N   CYS A  52      -1.212  16.773  20.236  1.00 15.94           N
+ATOM    967  CA  CYS A  52      -2.384  16.052  19.781  1.00 16.97           C
+ATOM    968  C   CYS A  52      -2.191  15.441  18.396  1.00 17.04           C
+ATOM    969  O   CYS A  52      -1.278  15.794  17.647  1.00 16.92           O
+ATOM    970  CB  CYS A  52      -3.610  16.962  19.761  1.00 18.40           C
+ATOM    971  SG  CYS A  52      -3.705  18.126  18.398  1.00 23.09           S
+ATOM    972  H   CYS A  52      -1.034  17.482  19.782  1.00 19.15           H
+ATOM    973  HA  CYS A  52      -2.534  15.319  20.398  1.00 20.39           H
+ATOM    974  HB2 CYS A  52      -4.401  16.403  19.715  1.00 22.10           H
+ATOM    975  HB3 CYS A  52      -3.616  17.480  20.581  1.00 22.10           H
+ATOM    976  HG  CYS A  52      -3.739  17.517  17.365  1.00 27.73           H
+ATOM    977  N   PHE A  53      -3.052  14.495  18.073  1.00 15.39           N
+ATOM    978  CA  PHE A  53      -3.218  14.025  16.703  1.00 14.81           C
+ATOM    979  C   PHE A  53      -4.323  14.860  16.081  1.00 15.96           C
+ATOM    980  O   PHE A  53      -5.499  14.702  16.435  1.00 20.27           O
+ATOM    981  CB  PHE A  53      -3.602  12.545  16.706  1.00 16.35           C
+ATOM    982  CG  PHE A  53      -2.449  11.623  16.916  1.00 16.91           C
+ATOM    983  CD1 PHE A  53      -1.966  11.335  18.186  1.00 19.11           C
+ATOM    984  CD2 PHE A  53      -1.829  11.054  15.816  1.00 17.68           C
+ATOM    985  CE1 PHE A  53      -0.881  10.494  18.341  1.00 17.97           C
+ATOM    986  CE2 PHE A  53      -0.760  10.217  15.967  1.00 19.83           C
+ATOM    987  CZ  PHE A  53      -0.283   9.943  17.231  1.00 18.88           C
+ATOM    988  H   PHE A  53      -3.565  14.098  18.638  1.00 18.49           H
+ATOM    989  HA  PHE A  53      -2.398  14.134  16.197  1.00 17.79           H
+ATOM    990  HB2 PHE A  53      -4.238  12.390  17.422  1.00 19.65           H
+ATOM    991  HB3 PHE A  53      -4.004  12.326  15.851  1.00 19.65           H
+ATOM    992  HD1 PHE A  53      -2.374  11.709  18.934  1.00 22.95           H
+ATOM    993  HD2 PHE A  53      -2.146  11.244  14.963  1.00 21.24           H
+ATOM    994  HE1 PHE A  53      -0.557  10.301  19.191  1.00 21.58           H
+ATOM    995  HE2 PHE A  53      -0.356   9.835  15.222  1.00 23.82           H
+ATOM    996  HZ  PHE A  53       0.451   9.381  17.335  1.00 22.69           H
+ATOM    997  N   HIS A  54      -3.958  15.729  15.162  1.00 15.80           N
+ATOM    998  CA  HIS A  54      -4.904  16.697  14.648  1.00 17.44           C
+ATOM    999  C   HIS A  54      -5.685  16.231  13.431  1.00 18.88           C
+ATOM   1000  O   HIS A  54      -6.689  16.869  13.093  1.00 20.36           O
+ATOM   1001  CB  HIS A  54      -4.186  18.009  14.328  1.00 18.78           C
+ATOM   1002  CG  HIS A  54      -3.203  17.888  13.219  1.00 18.76           C
+ATOM   1003  ND1 HIS A  54      -1.925  17.420  13.415  1.00 19.56           N
+ATOM   1004  CD2 HIS A  54      -3.325  18.113  11.890  1.00 19.57           C
+ATOM   1005  CE1 HIS A  54      -1.290  17.393  12.256  1.00 19.94           C
+ATOM   1006  NE2 HIS A  54      -2.118  17.824  11.320  1.00 20.60           N
+ATOM   1007  H   HIS A  54      -3.170  15.779  14.820  1.00 18.98           H
+ATOM   1008  HA  HIS A  54      -5.558  16.870  15.344  1.00 20.95           H
+ATOM   1009  HB2 HIS A  54      -4.846  18.673  14.071  1.00 22.56           H
+ATOM   1010  HB3 HIS A  54      -3.708  18.306  15.119  1.00 22.56           H
+ATOM   1011  HD2 HIS A  54      -4.088  18.409  11.447  1.00 23.51           H
+ATOM   1012  HE1 HIS A  54      -0.411  17.118  12.122  1.00 23.95           H
+ATOM   1013  N  AARG A  55      -5.242  15.177  12.750  0.57 14.83           N
+ATOM   1014  CA AARG A  55      -5.897  14.693  11.549  0.57 15.61           C
+ATOM   1015  C  AARG A  55      -5.934  13.176  11.632  0.57 16.50           C
+ATOM   1016  O  AARG A  55      -4.896  12.535  11.783  0.57 15.39           O
+ATOM   1017  CB AARG A  55      -5.114  15.172  10.324  0.57 19.35           C
+ATOM   1018  CG AARG A  55      -5.723  14.861   8.969  0.57 21.97           C
+ATOM   1019  CD AARG A  55      -4.966  15.646   7.878  0.57 19.23           C
+ATOM   1020  NE AARG A  55      -5.457  15.389   6.529  0.57 39.62           N
+ATOM   1021  CZ AARG A  55      -4.861  14.592   5.650  0.57 56.17           C
+ATOM   1022  NH1AARG A  55      -3.759  13.924   5.953  0.57 76.67           N
+ATOM   1023  NH2AARG A  55      -5.383  14.465   4.434  0.57 65.58           N
+ATOM   1024  H  AARG A  55      -4.549  14.719  12.973  0.57 17.82           H
+ATOM   1025  HA AARG A  55      -6.811  15.011  11.479  0.57 18.75           H
+ATOM   1026  HB2AARG A  55      -5.025  16.136  10.381  0.57 23.24           H
+ATOM   1027  HB3AARG A  55      -4.238  14.756  10.344  0.57 23.24           H
+ATOM   1028  HG2AARG A  55      -5.647  13.912   8.783  0.57 26.39           H
+ATOM   1029  HG3AARG A  55      -6.656  15.128   8.958  0.57 26.39           H
+ATOM   1030  HD2AARG A  55      -5.061  16.596   8.052  0.57 23.10           H
+ATOM   1031  HD3AARG A  55      -4.029  15.396   7.906  0.57 23.10           H
+ATOM   1032  HE AARG A  55      -6.183  15.780   6.286  0.57 47.57           H
+ATOM   1033 HH11AARG A  55      -3.412  14.001   6.736  0.57 92.02           H
+ATOM   1034 HH12AARG A  55      -3.391  13.414   5.367  0.57 92.02           H
+ATOM   1035 HH21AARG A  55      -6.098  14.895   4.226  0.57 78.72           H
+ATOM   1036 HH22AARG A  55      -5.006  13.952   3.856  0.57 78.72           H
+ATOM   1037  N  BARG A  55      -5.279  15.151  12.756  0.43 14.74           N
+ATOM   1038  CA BARG A  55      -5.939  14.725  11.524  0.43 15.59           C
+ATOM   1039  C  BARG A  55      -5.941  13.202  11.451  0.43 16.92           C
+ATOM   1040  O  BARG A  55      -4.887  12.588  11.259  0.43 16.54           O
+ATOM   1041  CB BARG A  55      -5.229  15.338  10.316  0.43 18.60           C
+ATOM   1042  CG BARG A  55      -5.911  15.127   8.974  0.43 23.83           C
+ATOM   1043  CD BARG A  55      -5.448  16.195   7.976  0.43 28.55           C
+ATOM   1044  NE BARG A  55      -5.639  15.814   6.581  0.43 39.56           N
+ATOM   1045  CZ BARG A  55      -6.811  15.792   5.965  0.43 36.23           C
+ATOM   1046  NH1BARG A  55      -7.936  16.056   6.609  0.43 57.97           N
+ATOM   1047  NH2BARG A  55      -6.858  15.488   4.670  0.43 19.61           N
+ATOM   1048  H  BARG A  55      -4.622  14.650  12.994  0.43 17.72           H
+ATOM   1049  HA BARG A  55      -6.867  15.007  11.536  0.43 18.73           H
+ATOM   1050  HB2BARG A  55      -5.160  16.295  10.457  0.43 22.34           H
+ATOM   1051  HB3BARG A  55      -4.343  14.947  10.253  0.43 22.34           H
+ATOM   1052  HG2BARG A  55      -5.680  14.253   8.624  0.43 28.62           H
+ATOM   1053  HG3BARG A  55      -6.873  15.198   9.082  0.43 28.62           H
+ATOM   1054  HD2BARG A  55      -5.952  17.009   8.132  0.43 34.29           H
+ATOM   1055  HD3BARG A  55      -4.501  16.360   8.111  0.43 34.29           H
+ATOM   1056  HE BARG A  55      -4.944  15.587   6.129  0.43 47.50           H
+ATOM   1057 HH11BARG A  55      -7.916  16.247   7.447  0.43 69.59           H
+ATOM   1058 HH12BARG A  55      -8.686  16.036   6.190  0.43 69.59           H
+ATOM   1059 HH21BARG A  55      -6.133  15.309   4.244  0.43 23.56           H
+ATOM   1060 HH22BARG A  55      -7.614  15.470   4.260  0.43 23.56           H
+ATOM   1061  N   ILE A  56      -7.122  12.594  11.579  1.00 15.02           N
+ATOM   1062  CA  ILE A  56      -7.276  11.144  11.579  1.00 14.51           C
+ATOM   1063  C   ILE A  56      -8.312  10.804  10.519  1.00 15.00           C
+ATOM   1064  O   ILE A  56      -9.471  11.225  10.644  1.00 16.44           O
+ATOM   1065  CB  ILE A  56      -7.689  10.591  12.952  1.00 16.70           C
+ATOM   1066  CG1 ILE A  56      -6.600  10.905  13.975  1.00 16.13           C
+ATOM   1067  CG2 ILE A  56      -7.909   9.106  12.861  1.00 17.87           C
+ATOM   1068  CD1 ILE A  56      -6.900  10.341  15.354  1.00 20.06           C
+ATOM   1069  HA  ILE A  56      -6.434  10.726  11.340  1.00 17.43           H
+ATOM   1070  HB  ILE A  56      -8.517  11.012  13.232  1.00 20.07           H
+ATOM   1071 HG12 ILE A  56      -5.762  10.522  13.671  1.00 19.38           H
+ATOM   1072 HG13 ILE A  56      -6.514  11.868  14.058  1.00 19.38           H
+ATOM   1073 HG21 ILE A  56      -8.159   8.769  13.736  1.00 21.47           H
+ATOM   1074 HG22 ILE A  56      -8.619   8.931  12.224  1.00 21.47           H
+ATOM   1075 HG23 ILE A  56      -7.088   8.682  12.566  1.00 21.47           H
+ATOM   1076 HD11 ILE A  56      -6.289  10.735  15.996  1.00 24.10           H
+ATOM   1077 HD12 ILE A  56      -7.815  10.558  15.591  1.00 24.10           H
+ATOM   1078 HD13 ILE A  56      -6.782   9.379  15.333  1.00 24.10           H
+ATOM   1079  H  AILE A  56      -7.867  13.023  11.541  0.57 18.04           H
+ATOM   1080  H  BILE A  56      -7.867  13.015  11.669  0.43 18.04           H
+ATOM   1081  N   ILE A  57      -7.910  10.051   9.500  1.00 14.75           N
+ATOM   1082  CA  ILE A  57      -8.791   9.646   8.408  1.00 15.54           C
+ATOM   1083  C   ILE A  57      -8.850   8.133   8.446  1.00 17.12           C
+ATOM   1084  O   ILE A  57      -7.872   7.457   8.107  1.00 17.64           O
+ATOM   1085  CB  ILE A  57      -8.290  10.166   7.059  1.00 16.32           C
+ATOM   1086  CG1 ILE A  57      -8.233  11.684   7.088  1.00 19.99           C
+ATOM   1087  CG2 ILE A  57      -9.256   9.691   5.950  1.00 19.42           C
+ATOM   1088  CD1 ILE A  57      -7.576  12.277   5.892  1.00 24.42           C
+ATOM   1089  H   ILE A  57      -7.108   9.752   9.415  1.00 17.72           H
+ATOM   1090  HA  ILE A  57      -9.681  10.010   8.533  1.00 18.67           H
+ATOM   1091  HB  ILE A  57      -7.399   9.823   6.883  1.00 19.60           H
+ATOM   1092 HG12 ILE A  57      -9.138  12.029   7.131  1.00 24.01           H
+ATOM   1093 HG13 ILE A  57      -7.733  11.963   7.871  1.00 24.01           H
+ATOM   1094 HG21 ILE A  57      -8.959  10.047   5.098  1.00 23.32           H
+ATOM   1095 HG22 ILE A  57      -9.253   8.721   5.922  1.00 23.32           H
+ATOM   1096 HG23 ILE A  57     -10.149  10.012   6.150  1.00 23.32           H
+ATOM   1097 HD11 ILE A  57      -7.531  13.240   6.001  1.00 29.33           H
+ATOM   1098 HD12 ILE A  57      -6.681  11.912   5.809  1.00 29.33           H
+ATOM   1099 HD13 ILE A  57      -8.097  12.058   5.103  1.00 29.33           H
+ATOM   1100  N   PRO A  58      -9.982   7.563   8.858  1.00 17.72           N
+ATOM   1101  CA  PRO A  58     -10.075   6.114   8.958  1.00 18.49           C
+ATOM   1102  C   PRO A  58      -9.855   5.457   7.610  1.00 19.60           C
+ATOM   1103  O   PRO A  58     -10.333   5.933   6.571  1.00 21.43           O
+ATOM   1104  CB  PRO A  58     -11.504   5.892   9.485  1.00 20.61           C
+ATOM   1105  CG  PRO A  58     -11.875   7.178  10.149  1.00 20.02           C
+ATOM   1106  CD  PRO A  58     -11.190   8.246   9.349  1.00 20.07           C
+ATOM   1107  HA  PRO A  58      -9.435   5.762   9.597  1.00 22.21           H
+ATOM   1108  HB2 PRO A  58     -12.102   5.697   8.747  1.00 24.75           H
+ATOM   1109  HB3 PRO A  58     -11.512   5.159  10.120  1.00 24.75           H
+ATOM   1110  HG2 PRO A  58     -12.838   7.294  10.128  1.00 24.05           H
+ATOM   1111  HG3 PRO A  58     -11.561   7.179  11.067  1.00 24.05           H
+ATOM   1112  HD2 PRO A  58     -11.748   8.538   8.611  1.00 24.11           H
+ATOM   1113  HD3 PRO A  58     -10.958   9.003   9.908  1.00 24.11           H
+ATOM   1114  N   GLY A  59      -9.101   4.366   7.641  1.00 20.33           N
+ATOM   1115  CA  GLY A  59      -8.721   3.675   6.426  1.00 23.84           C
+ATOM   1116  C   GLY A  59      -7.584   4.332   5.676  1.00 24.44           C
+ATOM   1117  O   GLY A  59      -7.346   4.003   4.508  1.00 23.50           O
+ATOM   1118  H   GLY A  59      -8.797   4.006   8.360  1.00 24.42           H
+ATOM   1119  HA2 GLY A  59      -8.449   2.772   6.651  1.00 28.63           H
+ATOM   1120  HA3 GLY A  59      -9.488   3.636   5.834  1.00 28.63           H
+ATOM   1121  N  APHE A  60      -6.921   5.298   6.291  0.63 18.25           N
+ATOM   1122  CA APHE A  60      -5.832   6.014   5.643  0.63 15.18           C
+ATOM   1123  C  APHE A  60      -4.709   6.201   6.665  0.63 14.03           C
+ATOM   1124  O  APHE A  60      -3.746   5.419   6.675  0.63 14.44           O
+ATOM   1125  CB APHE A  60      -6.368   7.329   5.062  0.63 17.60           C
+ATOM   1126  CG APHE A  60      -5.344   8.171   4.364  0.63 12.16           C
+ATOM   1127  CD1APHE A  60      -4.119   7.649   3.966  0.63 15.39           C
+ATOM   1128  CD2APHE A  60      -5.615   9.494   4.105  0.63 17.26           C
+ATOM   1129  CE1APHE A  60      -3.194   8.438   3.331  0.63 17.95           C
+ATOM   1130  CE2APHE A  60      -4.694  10.285   3.487  0.63 16.45           C
+ATOM   1131  CZ APHE A  60      -3.483   9.759   3.086  0.63 18.25           C
+ATOM   1132  H  APHE A  60      -7.083   5.562   7.093  0.63 21.93           H
+ATOM   1133  HA APHE A  60      -5.456   5.529   4.892  0.63 18.24           H
+ATOM   1134  HB2APHE A  60      -7.062   7.121   4.417  0.63 21.14           H
+ATOM   1135  HB3APHE A  60      -6.736   7.859   5.786  0.63 21.14           H
+ATOM   1136  HD1APHE A  60      -3.925   6.755   4.131  0.63 18.49           H
+ATOM   1137  HD2APHE A  60      -6.436   9.853   4.354  0.63 20.73           H
+ATOM   1138  HE1APHE A  60      -2.376   8.082   3.069  0.63 21.56           H
+ATOM   1139  HE2APHE A  60      -4.883  11.183   3.335  0.63 19.76           H
+ATOM   1140  HZ APHE A  60      -2.863  10.299   2.650  0.63 21.92           H
+ATOM   1141  N  BPHE A  60      -6.840   5.237   6.314  0.37 18.05           N
+ATOM   1142  CA BPHE A  60      -5.693   5.863   5.656  0.37 15.57           C
+ATOM   1143  C  BPHE A  60      -4.541   6.119   6.628  0.37 13.62           C
+ATOM   1144  O  BPHE A  60      -3.445   5.580   6.434  0.37 13.86           O
+ATOM   1145  CB BPHE A  60      -6.123   7.150   4.935  0.37 12.73           C
+ATOM   1146  CG BPHE A  60      -4.999   7.898   4.248  0.37 16.92           C
+ATOM   1147  CD1BPHE A  60      -3.865   7.249   3.783  0.37 16.72           C
+ATOM   1148  CD2BPHE A  60      -5.092   9.265   4.074  0.37 16.54           C
+ATOM   1149  CE1BPHE A  60      -2.855   7.962   3.158  0.37 21.95           C
+ATOM   1150  CE2BPHE A  60      -4.090   9.976   3.461  0.37 18.98           C
+ATOM   1151  CZ BPHE A  60      -2.969   9.327   3.002  0.37 20.88           C
+ATOM   1152  H  BPHE A  60      -6.979   5.503   7.120  0.37 21.69           H
+ATOM   1153  HA BPHE A  60      -5.351   5.251   4.986  0.37 18.71           H
+ATOM   1154  HB2BPHE A  60      -6.777   6.919   4.257  0.37 15.30           H
+ATOM   1155  HB3BPHE A  60      -6.518   7.751   5.587  0.37 15.30           H
+ATOM   1156  HD1BPHE A  60      -3.782   6.329   3.891  0.37 20.09           H
+ATOM   1157  HD2BPHE A  60      -5.849   9.712   4.378  0.37 19.87           H
+ATOM   1158  HE1BPHE A  60      -2.100   7.519   2.844  0.37 26.36           H
+ATOM   1159  HE2BPHE A  60      -4.170  10.897   3.356  0.37 22.79           H
+ATOM   1160  HZ BPHE A  60      -2.289   9.807   2.587  0.37 25.08           H
+ATOM   1161  N  AMET A  61      -4.821   7.210   7.543  0.63 12.52           N
+ATOM   1162  CA AMET A  61      -3.707   7.514   8.436  0.63 13.05           C
+ATOM   1163  C  AMET A  61      -4.150   8.292   9.656  0.63 14.44           C
+ATOM   1164  O  AMET A  61      -5.198   8.940   9.669  0.63 15.66           O
+ATOM   1165  CB AMET A  61      -2.643   8.318   7.693  0.63 15.57           C
+ATOM   1166  CG AMET A  61      -3.205   9.534   6.997  0.63 16.30           C
+ATOM   1167  SD AMET A  61      -1.946  10.833   6.840  0.63 27.75           S
+ATOM   1168  CE AMET A  61      -0.970  10.329   5.425  0.63 56.81           C
+ATOM   1169  H  AMET A  61      -5.513   7.713   7.635  0.63 15.05           H
+ATOM   1170  HA AMET A  61      -3.351   6.667   8.747  0.63 15.69           H
+ATOM   1171  HB2AMET A  61      -1.975   8.619   8.329  0.63 18.70           H
+ATOM   1172  HB3AMET A  61      -2.231   7.752   7.022  0.63 18.70           H
+ATOM   1173  HG2AMET A  61      -3.505   9.287   6.108  0.63 19.59           H
+ATOM   1174  HG3AMET A  61      -3.948   9.886   7.512  0.63 19.59           H
+ATOM   1175  HE1AMET A  61      -0.196  10.910   5.352  0.63 68.19           H
+ATOM   1176  HE2AMET A  61      -0.683   9.411   5.550  0.63 68.19           H
+ATOM   1177  HE3AMET A  61      -1.513  10.400   4.625  0.63 68.19           H
+ATOM   1178  N  BMET A  61      -4.748   6.931   7.668  0.37 15.47           N
+ATOM   1179  CA BMET A  61      -3.639   7.245   8.571  0.37 14.45           C
+ATOM   1180  C  BMET A  61      -4.107   8.168   9.689  0.37 14.26           C
+ATOM   1181  O  BMET A  61      -5.209   8.719   9.655  0.37 16.27           O
+ATOM   1182  CB BMET A  61      -2.476   7.889   7.801  0.37 14.44           C
+ATOM   1183  CG BMET A  61      -2.835   9.200   7.093  0.37 16.95           C
+ATOM   1184  SD BMET A  61      -2.832  10.691   8.120  0.37 16.03           S
+ATOM   1185  CE BMET A  61      -1.267  10.520   8.936  0.37 30.97           C
+ATOM   1186  H  BMET A  61      -5.499   7.302   7.865  0.37 18.59           H
+ATOM   1187  HA BMET A  61      -3.347   6.418   8.986  0.37 17.36           H
+ATOM   1188  HB2BMET A  61      -1.759   8.079   8.426  0.37 17.35           H
+ATOM   1189  HB3BMET A  61      -2.169   7.264   7.124  0.37 17.35           H
+ATOM   1190  HG2BMET A  61      -2.195   9.345   6.379  0.37 20.36           H
+ATOM   1191  HG3BMET A  61      -3.728   9.110   6.724  0.37 20.36           H
+ATOM   1192  HE1BMET A  61      -1.057  11.349   9.394  0.37 37.18           H
+ATOM   1193  HE2BMET A  61      -1.322   9.793   9.576  0.37 37.18           H
+ATOM   1194  HE3BMET A  61      -0.585  10.326   8.273  0.37 37.18           H
+ATOM   1195  N  ACYS A  62      -3.297   8.239  10.680  0.63 12.98           N
+ATOM   1196  CA ACYS A  62      -3.346   9.154  11.807  0.63 14.37           C
+ATOM   1197  C  ACYS A  62      -2.139  10.072  11.700  0.63 15.40           C
+ATOM   1198  O  ACYS A  62      -1.013   9.588  11.544  0.63 15.21           O
+ATOM   1199  CB ACYS A  62      -3.251   8.398  13.131  0.63 10.53           C
+ATOM   1200  SG ACYS A  62      -4.569   7.177  13.359  0.63 13.93           S
+ATOM   1201  H  ACYS A  62      -2.662   7.662  10.740  0.63 15.60           H
+ATOM   1202  HA ACYS A  62      -4.174   9.660  11.791  0.63 17.27           H
+ATOM   1203  HB2ACYS A  62      -2.402   7.929  13.163  0.63 12.66           H
+ATOM   1204  HB3ACYS A  62      -3.306   9.035  13.860  0.63 12.66           H
+ATOM   1205  HG ACYS A  62      -4.472   6.697  14.455  0.63 16.74           H
+ATOM   1206  N  BCYS A  62      -3.239   8.335  10.688  0.37 12.72           N
+ATOM   1207  CA BCYS A  62      -3.467   9.300  11.758  0.37 15.20           C
+ATOM   1208  C  BCYS A  62      -2.226  10.166  11.915  0.37 12.95           C
+ATOM   1209  O  BCYS A  62      -1.122   9.649  12.173  0.37 12.73           O
+ATOM   1210  CB BCYS A  62      -3.833   8.624  13.080  0.37 25.62           C
+ATOM   1211  SG BCYS A  62      -2.708   7.343  13.611  0.37 47.73           S
+ATOM   1212  H  BCYS A  62      -2.504   7.896  10.766  0.37 15.28           H
+ATOM   1213  HA BCYS A  62      -4.209   9.872  11.508  0.37 18.27           H
+ATOM   1214  HB2BCYS A  62      -3.853   9.301  13.775  0.37 30.77           H
+ATOM   1215  HB3BCYS A  62      -4.710   8.220  12.985  0.37 30.77           H
+ATOM   1216  HG BCYS A  62      -3.134   6.840  14.614  0.37 57.30           H
+ATOM   1217  N  AGLN A  63      -2.352  11.379  11.806  0.63 14.19           N
+ATOM   1218  CA AGLN A  63      -1.260  12.340  11.702  0.63 14.89           C
+ATOM   1219  C  AGLN A  63      -1.154  13.212  12.946  0.63 13.35           C
+ATOM   1220  O  AGLN A  63      -2.151  13.772  13.434  0.63 13.22           O
+ATOM   1221  CB AGLN A  63      -1.409  13.232  10.473  0.63 12.83           C
+ATOM   1222  CG AGLN A  63      -0.327  14.303  10.379  0.63 16.09           C
+ATOM   1223  CD AGLN A  63      -0.246  14.948   9.001  0.63 18.94           C
+ATOM   1224  OE1AGLN A  63      -0.775  14.422   8.018  0.63 22.68           O
+ATOM   1225  NE2AGLN A  63       0.425  16.093   8.926  0.63 19.15           N
+ATOM   1226  H  AGLN A  63      -3.124  11.735  11.938  0.63 17.05           H
+ATOM   1227  HA AGLN A  63      -0.438  11.830  11.634  0.63 17.89           H
+ATOM   1228  HB2AGLN A  63      -1.355  12.681   9.676  0.63 15.41           H
+ATOM   1229  HB3AGLN A  63      -2.269  13.677  10.510  0.63 15.41           H
+ATOM   1230  HG2AGLN A  63      -0.519  15.002  11.025  0.63 19.33           H
+ATOM   1231  HG3AGLN A  63       0.534  13.900  10.572  0.63 19.33           H
+ATOM   1232 HE21AGLN A  63       0.501  16.498   8.171  0.63 23.00           H
+ATOM   1233 HE22AGLN A  63       0.783  16.429   9.632  0.63 23.00           H
+ATOM   1234  N  BGLN A  63      -2.413  11.472  11.727  0.37 14.54           N
+ATOM   1235  CA BGLN A  63      -1.344  12.455  11.702  0.37 15.19           C
+ATOM   1236  C  BGLN A  63      -1.179  13.117  13.059  0.37 13.61           C
+ATOM   1237  O  BGLN A  63      -2.161  13.444  13.737  0.37 13.77           O
+ATOM   1238  CB BGLN A  63      -1.685  13.558  10.700  0.37 18.25           C
+ATOM   1239  CG BGLN A  63      -0.475  14.296  10.172  0.37 17.09           C
+ATOM   1240  CD BGLN A  63      -0.827  15.225   9.033  0.37 16.13           C
+ATOM   1241  OE1BGLN A  63      -1.697  14.921   8.226  0.37 16.71           O
+ATOM   1242  NE2BGLN A  63      -0.144  16.360   8.959  0.37 20.01           N
+ATOM   1243  H  BGLN A  63      -3.188  11.825  11.606  0.37 17.47           H
+ATOM   1244  HA BGLN A  63      -0.516  12.008  11.465  0.37 18.25           H
+ATOM   1245  HB2BGLN A  63      -2.143  13.161   9.943  0.37 21.93           H
+ATOM   1246  HB3BGLN A  63      -2.261  14.207  11.134  0.37 21.93           H
+ATOM   1247  HG2BGLN A  63      -0.089  14.826  10.887  0.37 20.54           H
+ATOM   1248  HG3BGLN A  63       0.174  13.652   9.849  0.37 20.54           H
+ATOM   1249 HE21BGLN A  63      -0.309  16.921   8.328  0.37 24.04           H
+ATOM   1250 HE22BGLN A  63       0.463  16.535   9.542  0.37 24.04           H
+ATOM   1251  N   GLY A  64       0.069  13.356  13.429  1.00 13.05           N
+ATOM   1252  CA  GLY A  64       0.364  14.170  14.581  1.00 14.51           C
+ATOM   1253  C   GLY A  64       1.722  14.834  14.500  1.00 12.44           C
+ATOM   1254  O   GLY A  64       2.304  14.970  13.421  1.00 14.23           O
+ATOM   1255  HA2 GLY A  64      -0.309  14.864  14.663  1.00 17.43           H
+ATOM   1256  HA3 GLY A  64       0.344  13.616  15.377  1.00 17.43           H
+ATOM   1257  H  AGLY A  64       0.765  12.979  13.092  0.63 15.68           H
+ATOM   1258  H  BGLY A  64       0.764  13.055  13.022  0.37 15.68           H
+ATOM   1259  N   GLY A  65       2.197  15.328  15.634  1.00 13.39           N
+ATOM   1260  CA  GLY A  65       3.510  15.898  15.749  1.00 14.45           C
+ATOM   1261  C   GLY A  65       3.592  17.404  15.655  1.00 14.28           C
+ATOM   1262  O   GLY A  65       4.709  17.930  15.741  1.00 14.98           O
+ATOM   1263  H   GLY A  65       1.756  15.340  16.372  1.00 16.10           H
+ATOM   1264  HA2 GLY A  65       3.881  15.639  16.607  1.00 17.36           H
+ATOM   1265  HA3 GLY A  65       4.064  15.533  15.042  1.00 17.36           H
+ATOM   1266  N   ASP A  66       2.482  18.108  15.499  1.00 13.76           N
+ATOM   1267  CA  ASP A  66       2.525  19.576  15.474  1.00 14.43           C
+ATOM   1268  C   ASP A  66       2.384  20.072  16.909  1.00 13.05           C
+ATOM   1269  O   ASP A  66       1.274  20.384  17.360  1.00 15.76           O
+ATOM   1270  CB  ASP A  66       1.450  20.164  14.586  1.00 13.60           C
+ATOM   1271  CG  ASP A  66       1.489  21.676  14.552  1.00 14.73           C
+ATOM   1272  OD1 ASP A  66       2.366  22.231  15.250  1.00 15.90           O
+ATOM   1273  OD2 ASP A  66       0.654  22.226  13.804  1.00 16.43           O
+ATOM   1274  H   ASP A  66       1.697  17.769  15.406  1.00 16.54           H
+ATOM   1275  HA  ASP A  66       3.385  19.849  15.118  1.00 17.34           H
+ATOM   1276  HB2 ASP A  66       1.573  19.839  13.680  1.00 16.34           H
+ATOM   1277  HB3 ASP A  66       0.580  19.893  14.920  1.00 16.34           H
+ATOM   1278  N   PHE A  67       3.504  20.151  17.604  1.00 14.07           N
+ATOM   1279  CA  PHE A  67       3.499  20.542  19.004  1.00 15.90           C
+ATOM   1280  C   PHE A  67       3.583  22.047  19.184  1.00 19.37           C
+ATOM   1281  O   PHE A  67       3.559  22.491  20.340  1.00 18.17           O
+ATOM   1282  CB  PHE A  67       4.613  19.814  19.784  1.00 16.49           C
+ATOM   1283  CG  PHE A  67       5.999  20.057  19.267  1.00 16.82           C
+ATOM   1284  CD1 PHE A  67       6.712  21.174  19.660  1.00 21.98           C
+ATOM   1285  CD2 PHE A  67       6.624  19.165  18.407  1.00 19.18           C
+ATOM   1286  CE1 PHE A  67       8.007  21.400  19.188  1.00 25.23           C
+ATOM   1287  CE2 PHE A  67       7.898  19.412  17.932  1.00 20.15           C
+ATOM   1288  CZ  PHE A  67       8.585  20.508  18.322  1.00 21.90           C
+ATOM   1289  H   PHE A  67       4.286  19.982  17.287  1.00 16.91           H
+ATOM   1290  HA  PHE A  67       2.666  20.254  19.410  1.00 19.10           H
+ATOM   1291  HB2 PHE A  67       4.589  20.112  20.707  1.00 19.82           H
+ATOM   1292  HB3 PHE A  67       4.448  18.860  19.739  1.00 19.82           H
+ATOM   1293  HD1 PHE A  67       6.324  21.783  20.246  1.00 26.40           H
+ATOM   1294  HD2 PHE A  67       6.180  18.391  18.147  1.00 23.04           H
+ATOM   1295  HE1 PHE A  67       8.476  22.154  19.461  1.00 30.30           H
+ATOM   1296  HE2 PHE A  67       8.288  18.815  17.336  1.00 24.21           H
+ATOM   1297  HZ  PHE A  67       9.446  20.657  18.004  1.00 26.30           H
+ATOM   1298  N   THR A  68       3.630  22.852  18.117  1.00 17.33           N
+ATOM   1299  CA  THR A  68       3.648  24.310  18.290  1.00 17.94           C
+ATOM   1300  C   THR A  68       2.353  24.984  17.900  1.00 20.54           C
+ATOM   1301  O   THR A  68       2.014  25.997  18.515  1.00 20.15           O
+ATOM   1302  CB  THR A  68       4.806  24.981  17.545  1.00 20.19           C
+ATOM   1303  OG1 THR A  68       4.605  24.845  16.133  1.00 20.62           O
+ATOM   1304  CG2 THR A  68       6.156  24.413  17.999  1.00 21.38           C
+ATOM   1305  H   THR A  68       3.653  22.584  17.301  1.00 20.81           H
+ATOM   1306  HA  THR A  68       3.808  24.482  19.231  1.00 21.55           H
+ATOM   1307  HB  THR A  68       4.835  25.929  17.749  1.00 24.25           H
+ATOM   1308  HG1 THR A  68       5.190  25.281  15.717  1.00 24.77           H
+ATOM   1309 HG21 THR A  68       6.880  24.902  17.579  1.00 25.67           H
+ATOM   1310 HG22 THR A  68       6.241  24.489  18.962  1.00 25.67           H
+ATOM   1311 HG23 THR A  68       6.222  23.477  17.751  1.00 25.67           H
+ATOM   1312  N   ARG A  69       1.585  24.450  16.965  1.00 16.69           N
+ATOM   1313  CA  ARG A  69       0.335  25.055  16.527  1.00 17.98           C
+ATOM   1314  C   ARG A  69      -0.865  24.129  16.586  1.00 16.55           C
+ATOM   1315  O   ARG A  69      -2.001  24.598  16.442  1.00 17.72           O
+ATOM   1316  CB  ARG A  69       0.482  25.670  15.130  1.00 19.68           C
+ATOM   1317  CG  ARG A  69       1.567  26.738  15.149  1.00 23.53           C
+ATOM   1318  CD  ARG A  69       1.677  27.488  13.839  1.00 28.46           C
+ATOM   1319  NE  ARG A  69       0.439  28.191  13.552  1.00 27.60           N
+ATOM   1320  CZ  ARG A  69       0.040  29.290  14.183  1.00 46.12           C
+ATOM   1321  NH1 ARG A  69       0.799  29.886  15.098  1.00 35.39           N
+ATOM   1322  NH2 ARG A  69      -1.155  29.794  13.899  1.00 37.88           N
+ATOM   1323  H   ARG A  69       1.769  23.716  16.556  1.00 20.05           H
+ATOM   1324  HA  ARG A  69       0.128  25.794  17.121  1.00 21.60           H
+ATOM   1325  HB2 ARG A  69       0.731  24.981  14.494  1.00 23.63           H
+ATOM   1326  HB3 ARG A  69      -0.356  26.080  14.864  1.00 23.63           H
+ATOM   1327  HG2 ARG A  69       1.366  27.381  15.846  1.00 28.26           H
+ATOM   1328  HG3 ARG A  69       2.423  26.315  15.324  1.00 28.26           H
+ATOM   1329  HD2 ARG A  69       2.396  28.137  13.896  1.00 34.18           H
+ATOM   1330  HD3 ARG A  69       1.852  26.862  13.119  1.00 34.18           H
+ATOM   1331  HE  ARG A  69      -0.069  27.875  12.934  1.00 33.14           H
+ATOM   1332 HH11 ARG A  69       1.570  29.560  15.295  1.00 42.49           H
+ATOM   1333 HH12 ARG A  69       0.518  30.596  15.493  1.00 42.49           H
+ATOM   1334 HH21 ARG A  69      -1.656  29.410  13.316  1.00 45.48           H
+ATOM   1335 HH22 ARG A  69      -1.427  30.505  14.299  1.00 45.48           H
+ATOM   1336  N   HIS A  70      -0.660  22.825  16.803  1.00 16.55           N
+ATOM   1337  CA  HIS A  70      -1.727  21.878  17.143  1.00 16.40           C
+ATOM   1338  C   HIS A  70      -2.725  21.656  16.020  1.00 17.44           C
+ATOM   1339  O   HIS A  70      -3.832  21.163  16.261  1.00 20.43           O
+ATOM   1340  CB  HIS A  70      -2.453  22.298  18.429  1.00 15.69           C
+ATOM   1341  CG  HIS A  70      -1.556  22.981  19.403  1.00 16.64           C
+ATOM   1342  ND1 HIS A  70      -0.509  22.344  20.027  1.00 17.40           N
+ATOM   1343  CD2 HIS A  70      -1.483  24.283  19.789  1.00 17.26           C
+ATOM   1344  CE1 HIS A  70       0.161  23.213  20.768  1.00 18.79           C
+ATOM   1345  NE2 HIS A  70      -0.415  24.397  20.635  1.00 19.66           N
+ATOM   1346  H   HIS A  70       0.115  22.455  16.757  1.00 19.88           H
+ATOM   1347  HA  HIS A  70      -1.309  21.017  17.302  1.00 19.70           H
+ATOM   1348  HB2 HIS A  70      -3.170  22.909  18.201  1.00 18.85           H
+ATOM   1349  HB3 HIS A  70      -2.815  21.507  18.859  1.00 18.85           H
+ATOM   1350  HD2 HIS A  70      -2.054  24.968  19.526  1.00 20.74           H
+ATOM   1351  HE1 HIS A  70       0.907  23.024  21.291  1.00 22.58           H
+ATOM   1352  N   ASN A  71      -2.352  21.995  14.783  1.00 17.56           N
+ATOM   1353  CA  ASN A  71      -3.306  21.912  13.682  1.00 18.25           C
+ATOM   1354  C   ASN A  71      -2.706  21.549  12.334  1.00 18.05           C
+ATOM   1355  O   ASN A  71      -3.440  21.599  11.338  1.00 21.06           O
+ATOM   1356  CB  ASN A  71      -4.079  23.228  13.525  1.00 19.76           C
+ATOM   1357  CG  ASN A  71      -3.196  24.392  13.163  1.00 20.27           C
+ATOM   1358  OD1 ASN A  71      -2.022  24.262  12.853  1.00 20.44           O
+ATOM   1359  ND2 ASN A  71      -3.797  25.579  13.180  1.00 27.51           N
+ATOM   1360  H   ASN A  71      -1.568  22.269  14.561  1.00 21.09           H
+ATOM   1361  HA  ASN A  71      -3.925  21.205  13.921  1.00 21.93           H
+ATOM   1362  HB2 ASN A  71      -4.739  23.123  12.821  1.00 23.73           H
+ATOM   1363  HB3 ASN A  71      -4.519  23.436  14.364  1.00 23.73           H
+ATOM   1364 HD21 ASN A  71      -3.353  26.288  12.983  1.00 33.04           H
+ATOM   1365 HD22 ASN A  71      -4.630  25.636  13.387  1.00 33.04           H
+ATOM   1366  N   GLY A  72      -1.418  21.228  12.237  1.00 16.50           N
+ATOM   1367  CA  GLY A  72      -0.811  20.855  10.986  1.00 17.54           C
+ATOM   1368  C   GLY A  72       0.020  21.932  10.343  1.00 18.84           C
+ATOM   1369  O   GLY A  72       0.668  21.670   9.330  1.00 22.92           O
+ATOM   1370  H   GLY A  72      -0.873  21.222  12.901  1.00 19.82           H
+ATOM   1371  HA2 GLY A  72      -0.237  20.088  11.136  1.00 21.07           H
+ATOM   1372  HA3 GLY A  72      -1.511  20.609  10.362  1.00 21.07           H
+ATOM   1373  N   THR A  73       0.035  23.139  10.911  1.00 20.33           N
+ATOM   1374  CA  THR A  73       0.830  24.232  10.361  1.00 19.62           C
+ATOM   1375  C   THR A  73       2.146  24.474  11.090  1.00 21.77           C
+ATOM   1376  O   THR A  73       2.913  25.341  10.664  1.00 25.47           O
+ATOM   1377  CB  THR A  73       0.026  25.546  10.362  1.00 22.66           C
+ATOM   1378  OG1 THR A  73      -0.230  25.977  11.701  1.00 23.38           O
+ATOM   1379  CG2 THR A  73      -1.281  25.381   9.631  1.00 25.25           C
+ATOM   1380  H   THR A  73      -0.408  23.348  11.617  1.00 24.42           H
+ATOM   1381  HA  THR A  73       1.036  23.993   9.444  1.00 23.57           H
+ATOM   1382  HB  THR A  73       0.547  26.226   9.906  1.00 27.21           H
+ATOM   1383  HG1 THR A  73      -0.848  25.518  12.037  1.00 28.08           H
+ATOM   1384 HG21 THR A  73      -1.746  26.231   9.585  1.00 30.32           H
+ATOM   1385 HG22 THR A  73      -1.120  25.061   8.730  1.00 30.32           H
+ATOM   1386 HG23 THR A  73      -1.843  24.741  10.096  1.00 30.32           H
+ATOM   1387  N   GLY A  74       2.437  23.744  12.171  1.00 18.13           N
+ATOM   1388  CA  GLY A  74       3.629  23.979  12.947  1.00 17.96           C
+ATOM   1389  C   GLY A  74       4.553  22.789  13.124  1.00 17.88           C
+ATOM   1390  O   GLY A  74       4.576  21.873  12.286  1.00 20.60           O
+ATOM   1391  H   GLY A  74       1.947  23.103  12.469  1.00 21.78           H
+ATOM   1392  HA2 GLY A  74       4.141  24.682  12.518  1.00 21.58           H
+ATOM   1393  HA3 GLY A  74       3.365  24.275  13.832  1.00 21.58           H
+ATOM   1394  N   GLY A  75       5.312  22.789  14.193  1.00 18.70           N
+ATOM   1395  CA  GLY A  75       6.327  21.798  14.461  1.00 19.23           C
+ATOM   1396  C   GLY A  75       7.700  22.270  14.025  1.00 19.57           C
+ATOM   1397  O   GLY A  75       7.856  23.210  13.248  1.00 24.65           O
+ATOM   1398  H   GLY A  75       5.258  23.383  14.812  1.00 22.47           H
+ATOM   1399  HA2 GLY A  75       6.354  21.610  15.413  1.00 23.09           H
+ATOM   1400  HA3 GLY A  75       6.116  20.980  13.984  1.00 23.09           H
+ATOM   1401  N   LYS A  76       8.713  21.604  14.553  1.00 19.04           N
+ATOM   1402  CA  LYS A  76      10.093  21.824  14.147  1.00 21.61           C
+ATOM   1403  C   LYS A  76      10.902  20.599  14.533  1.00 19.48           C
+ATOM   1404  O   LYS A  76      10.529  19.845  15.433  1.00 19.93           O
+ATOM   1405  CB  LYS A  76      10.682  23.092  14.787  1.00 28.40           C
+ATOM   1406  CG  LYS A  76      10.709  23.073  16.295  1.00 27.48           C
+ATOM   1407  CD  LYS A  76      11.314  24.367  16.865  1.00 37.56           C
+ATOM   1408  CE  LYS A  76      11.461  24.296  18.383  1.00 53.49           C
+ATOM   1409  NZ  LYS A  76      12.152  25.487  18.956  1.00 63.95           N
+ATOM   1410  H   LYS A  76       8.627  21.004  15.163  1.00 22.88           H
+ATOM   1411  HA  LYS A  76      10.134  21.932  13.184  1.00 25.95           H
+ATOM   1412  HB2 LYS A  76      11.595  23.199  14.478  1.00 34.10           H
+ATOM   1413  HB3 LYS A  76      10.148  23.854  14.513  1.00 34.10           H
+ATOM   1414  HG2 LYS A  76       9.804  22.985  16.632  1.00 33.00           H
+ATOM   1415  HG3 LYS A  76      11.249  22.325  16.597  1.00 33.00           H
+ATOM   1416  HD2 LYS A  76      12.193  24.508  16.480  1.00 45.10           H
+ATOM   1417  HD3 LYS A  76      10.734  25.115  16.649  1.00 45.10           H
+ATOM   1418  HE2 LYS A  76      10.579  24.241  18.783  1.00 64.22           H
+ATOM   1419  HE3 LYS A  76      11.979  23.509  18.614  1.00 64.22           H
+ATOM   1420  HZ1 LYS A  76      12.220  25.403  19.839  1.00 76.76           H
+ATOM   1421  HZ2 LYS A  76      12.967  25.562  18.608  1.00 76.76           H
+ATOM   1422  HZ3 LYS A  76      11.690  26.225  18.770  1.00 76.76           H
+ATOM   1423  N   SER A  77      12.015  20.405  13.840  1.00 19.90           N
+ATOM   1424  CA  SER A  77      12.907  19.295  14.113  1.00 17.99           C
+ATOM   1425  C   SER A  77      13.989  19.700  15.104  1.00 21.46           C
+ATOM   1426  O   SER A  77      14.147  20.871  15.444  1.00 22.29           O
+ATOM   1427  CB  SER A  77      13.554  18.805  12.814  1.00 19.25           C
+ATOM   1428  OG  SER A  77      14.716  19.573  12.442  1.00 21.23           O
+ATOM   1429  H   SER A  77      12.277  20.912  13.196  1.00 23.91           H
+ATOM   1430  HA  SER A  77      12.393  18.570  14.501  1.00 21.61           H
+ATOM   1431  HB2 SER A  77      13.822  17.881  12.934  1.00 23.13           H
+ATOM   1432  HB3 SER A  77      12.900  18.872  12.101  1.00 23.13           H
+ATOM   1433  HG  SER A  77      14.634  20.366  12.708  1.00 25.50           H
+ATOM   1434  N   ILE A  78      14.752  18.707  15.552  1.00 19.72           N
+ATOM   1435  CA  ILE A  78      15.888  18.972  16.432  1.00 19.50           C
+ATOM   1436  C   ILE A  78      17.053  19.591  15.674  1.00 23.21           C
+ATOM   1437  O   ILE A  78      18.040  19.988  16.304  1.00 29.74           O
+ATOM   1438  CB  ILE A  78      16.357  17.692  17.153  1.00 21.57           C
+ATOM   1439  CG1 ILE A  78      16.905  16.661  16.169  1.00 23.37           C
+ATOM   1440  CG2 ILE A  78      15.208  17.112  18.008  1.00 25.08           C
+ATOM   1441  CD1 ILE A  78      17.633  15.523  16.838  1.00 22.48           C
+ATOM   1442  H   ILE A  78      14.635  17.876  15.363  1.00 23.69           H
+ATOM   1443  HA  ILE A  78      15.595  19.593  17.117  1.00 23.42           H
+ATOM   1444  HB  ILE A  78      17.089  17.928  17.744  1.00 25.91           H
+ATOM   1445 HG12 ILE A  78      16.166  16.286  15.664  1.00 28.06           H
+ATOM   1446 HG13 ILE A  78      17.527  17.100  15.568  1.00 28.06           H
+ATOM   1447 HG21 ILE A  78      15.527  16.323  18.474  1.00 30.12           H
+ATOM   1448 HG22 ILE A  78      14.922  17.781  18.649  1.00 30.12           H
+ATOM   1449 HG23 ILE A  78      14.469  16.875  17.426  1.00 30.12           H
+ATOM   1450 HD11 ILE A  78      18.006  14.942  16.157  1.00 27.00           H
+ATOM   1451 HD12 ILE A  78      18.344  15.885  17.390  1.00 27.00           H
+ATOM   1452 HD13 ILE A  78      17.006  15.028  17.389  1.00 27.00           H
+ATOM   1453  N   TYR A  79      16.978  19.651  14.342  1.00 22.26           N
+ATOM   1454  CA  TYR A  79      18.041  20.171  13.495  1.00 24.66           C
+ATOM   1455  C   TYR A  79      17.733  21.566  12.981  1.00 30.01           C
+ATOM   1456  O   TYR A  79      18.529  22.113  12.211  1.00 39.49           O
+ATOM   1457  CB  TYR A  79      18.249  19.249  12.288  1.00 27.05           C
+ATOM   1458  CG  TYR A  79      18.396  17.796  12.639  1.00 22.78           C
+ATOM   1459  CD1 TYR A  79      19.463  17.347  13.393  1.00 23.99           C
+ATOM   1460  CD2 TYR A  79      17.456  16.854  12.211  1.00 22.24           C
+ATOM   1461  CE1 TYR A  79      19.597  16.014  13.726  1.00 25.49           C
+ATOM   1462  CE2 TYR A  79      17.580  15.539  12.527  1.00 21.64           C
+ATOM   1463  CZ  TYR A  79      18.660  15.105  13.290  1.00 21.55           C
+ATOM   1464  OH  TYR A  79      18.803  13.794  13.631  1.00 23.18           O
+ATOM   1465  H   TYR A  79      16.294  19.385  13.894  1.00 26.74           H
+ATOM   1466  HA  TYR A  79      18.862  20.197  14.010  1.00 29.61           H
+ATOM   1467  HB2 TYR A  79      17.483  19.333  11.699  1.00 32.48           H
+ATOM   1468  HB3 TYR A  79      19.056  19.522  11.825  1.00 32.48           H
+ATOM   1469  HD1 TYR A  79      20.104  17.956  13.682  1.00 28.81           H
+ATOM   1470  HD2 TYR A  79      16.731  17.133  11.700  1.00 26.71           H
+ATOM   1471  HE1 TYR A  79      20.317  15.732  14.243  1.00 30.62           H
+ATOM   1472  HE2 TYR A  79      16.943  14.928  12.234  1.00 26.00           H
+ATOM   1473  HH  TYR A  79      18.610  13.304  12.976  1.00 27.84           H
+ATOM   1474  N   GLY A  80      16.607  22.146  13.365  1.00 25.94           N
+ATOM   1475  CA  GLY A  80      16.126  23.390  12.809  1.00 28.20           C
+ATOM   1476  C   GLY A  80      14.703  23.252  12.328  1.00 26.50           C
+ATOM   1477  O   GLY A  80      14.045  22.224  12.521  1.00 27.75           O
+ATOM   1478  H   GLY A  80      16.088  21.822  13.970  1.00 31.15           H
+ATOM   1479  HA2 GLY A  80      16.161  24.086  13.484  1.00 33.86           H
+ATOM   1480  HA3 GLY A  80      16.684  23.650  12.059  1.00 33.86           H
+ATOM   1481  N   GLU A  81      14.222  24.295  11.660  1.00 25.35           N
+ATOM   1482  CA  GLU A  81      12.843  24.313  11.198  1.00 26.63           C
+ATOM   1483  C   GLU A  81      12.548  23.125  10.297  1.00 24.26           C
+ATOM   1484  O   GLU A  81      11.470  22.525  10.377  1.00 30.30           O
+ATOM   1485  CB  GLU A  81      12.587  25.605  10.423  1.00 33.50           C
+ATOM   1486  CG  GLU A  81      12.684  26.858  11.269  1.00 74.61           C
+ATOM   1487  CD  GLU A  81      11.422  27.101  12.068  1.00 97.50           C
+ATOM   1488  OE1 GLU A  81      10.375  27.372  11.440  1.00 90.40           O
+ATOM   1489  OE2 GLU A  81      11.472  27.000  13.314  1.00 93.96           O
+ATOM   1490  H   GLU A  81      14.671  25.002  11.462  1.00 30.44           H
+ATOM   1491  HA  GLU A  81      12.254  24.272  11.968  1.00 31.98           H
+ATOM   1492  HB2 GLU A  81      13.243  25.677   9.712  1.00 40.22           H
+ATOM   1493  HB3 GLU A  81      11.694  25.571  10.047  1.00 40.22           H
+ATOM   1494  HG2 GLU A  81      13.423  26.767  11.891  1.00 89.55           H
+ATOM   1495  HG3 GLU A  81      12.829  27.623  10.691  1.00 89.55           H
+ATOM   1496  N   LYS A  82      13.500  22.760   9.441  1.00 23.18           N
+ATOM   1497  CA  LYS A  82      13.284  21.686   8.479  1.00 22.45           C
+ATOM   1498  C   LYS A  82      14.605  20.978   8.225  1.00 22.25           C
+ATOM   1499  O   LYS A  82      15.687  21.521   8.482  1.00 26.03           O
+ATOM   1500  CB  LYS A  82      12.697  22.202   7.162  1.00 26.65           C
+ATOM   1501  CG  LYS A  82      13.568  23.204   6.434  1.00 40.72           C
+ATOM   1502  CD  LYS A  82      12.838  23.829   5.249  1.00 70.36           C
+ATOM   1503  CE  LYS A  82      13.730  24.799   4.469  1.00 88.71           C
+ATOM   1504  NZ  LYS A  82      14.885  24.131   3.790  1.00103.31           N
+ATOM   1505  H   LYS A  82      14.280  23.119   9.399  1.00 27.84           H
+ATOM   1506  HA  LYS A  82      12.658  21.048   8.856  1.00 26.96           H
+ATOM   1507  HB2 LYS A  82      12.560  21.448   6.568  1.00 32.01           H
+ATOM   1508  HB3 LYS A  82      11.849  22.635   7.350  1.00 32.01           H
+ATOM   1509  HG2 LYS A  82      13.820  23.914   7.045  1.00 48.89           H
+ATOM   1510  HG3 LYS A  82      14.362  22.756   6.100  1.00 48.89           H
+ATOM   1511  HD2 LYS A  82      12.553  23.127   4.644  1.00 84.45           H
+ATOM   1512  HD3 LYS A  82      12.067  24.321   5.573  1.00 84.45           H
+ATOM   1513  HE2 LYS A  82      13.196  25.236   3.787  1.00106.48           H
+ATOM   1514  HE3 LYS A  82      14.088  25.459   5.084  1.00106.48           H
+ATOM   1515  HZ1 LYS A  82      15.377  24.736   3.362  1.00123.99           H
+ATOM   1516  HZ2 LYS A  82      15.394  23.718   4.392  1.00123.99           H
+ATOM   1517  HZ3 LYS A  82      14.588  23.532   3.203  1.00123.99           H
+ATOM   1518  N   PHE A  83      14.513  19.732   7.760  1.00 18.40           N
+ATOM   1519  CA  PHE A  83      15.679  18.960   7.354  1.00 18.07           C
+ATOM   1520  C   PHE A  83      15.339  18.135   6.116  1.00 17.85           C
+ATOM   1521  O   PHE A  83      14.174  17.999   5.715  1.00 17.84           O
+ATOM   1522  CB  PHE A  83      16.310  18.132   8.489  1.00 17.79           C
+ATOM   1523  CG  PHE A  83      15.494  16.970   8.970  1.00 18.01           C
+ATOM   1524  CD1 PHE A  83      14.431  17.151   9.848  1.00 18.15           C
+ATOM   1525  CD2 PHE A  83      15.843  15.678   8.622  1.00 18.42           C
+ATOM   1526  CE1 PHE A  83      13.707  16.042  10.315  1.00 18.13           C
+ATOM   1527  CE2 PHE A  83      15.118  14.594   9.086  1.00 20.76           C
+ATOM   1528  CZ  PHE A  83      14.069  14.781   9.927  1.00 19.45           C
+ATOM   1529  H   PHE A  83      13.771  19.307   7.670  1.00 22.10           H
+ATOM   1530  HA  PHE A  83      16.382  19.574   7.089  1.00 21.71           H
+ATOM   1531  HB2 PHE A  83      17.157  17.779   8.175  1.00 21.37           H
+ATOM   1532  HB3 PHE A  83      16.455  18.717   9.249  1.00 21.37           H
+ATOM   1533  HD1 PHE A  83      14.199  18.008  10.126  1.00 21.80           H
+ATOM   1534  HD2 PHE A  83      16.576  15.535   8.068  1.00 22.12           H
+ATOM   1535  HE1 PHE A  83      12.983  16.165  10.886  1.00 21.78           H
+ATOM   1536  HE2 PHE A  83      15.351  13.733   8.821  1.00 24.93           H
+ATOM   1537  HZ  PHE A  83      13.593  14.047  10.242  1.00 23.36           H
+ATOM   1538  N   GLU A  84      16.396  17.641   5.470  1.00 17.70           N
+ATOM   1539  CA  GLU A  84      16.296  17.013   4.169  1.00 17.25           C
+ATOM   1540  C   GLU A  84      15.660  15.629   4.242  1.00 16.69           C
+ATOM   1541  O   GLU A  84      15.601  14.985   5.293  1.00 17.16           O
+ATOM   1542  CB  GLU A  84      17.710  16.903   3.564  1.00 18.08           C
+ATOM   1543  CG  GLU A  84      18.661  15.898   4.262  1.00 18.59           C
+ATOM   1544  CD  GLU A  84      19.418  16.429   5.479  1.00 21.51           C
+ATOM   1545  OE1 GLU A  84      19.074  17.483   6.028  1.00 22.26           O
+ATOM   1546  OE2 GLU A  84      20.387  15.749   5.879  1.00 25.30           O
+ATOM   1547  H   GLU A  84      17.199  17.660   5.778  1.00 21.26           H
+ATOM   1548  HA  GLU A  84      15.728  17.551   3.596  1.00 20.72           H
+ATOM   1549  HB2 GLU A  84      17.625  16.624   2.639  1.00 21.72           H
+ATOM   1550  HB3 GLU A  84      18.130  17.776   3.610  1.00 21.72           H
+ATOM   1551  HG2 GLU A  84      18.135  15.139   4.560  1.00 22.33           H
+ATOM   1552  HG3 GLU A  84      19.325  15.609   3.616  1.00 22.33           H
+ATOM   1553  N   ASP A  85      15.170  15.170   3.098  1.00 15.58           N
+ATOM   1554  CA  ASP A  85      14.762  13.784   2.916  1.00 15.35           C
+ATOM   1555  C   ASP A  85      16.005  12.903   2.931  1.00 17.92           C
+ATOM   1556  O   ASP A  85      16.860  12.990   2.035  1.00 18.81           O
+ATOM   1557  CB  ASP A  85      13.989  13.611   1.611  1.00 15.42           C
+ATOM   1558  CG  ASP A  85      12.681  14.385   1.579  1.00 15.18           C
+ATOM   1559  OD1 ASP A  85      11.921  14.328   2.578  1.00 16.68           O
+ATOM   1560  OD2 ASP A  85      12.397  15.026   0.556  1.00 15.85           O
+ATOM   1561  H   ASP A  85      15.062  15.653   2.394  1.00 18.72           H
+ATOM   1562  HA  ASP A  85      14.174  13.525   3.642  1.00 18.44           H
+ATOM   1563  HB2 ASP A  85      14.539  13.926   0.876  1.00 18.53           H
+ATOM   1564  HB3 ASP A  85      13.782  12.671   1.491  1.00 18.53           H
+ATOM   1565  N   GLU A  86      16.116  12.048   3.933  1.00 15.49           N
+ATOM   1566  CA  GLU A  86      17.368  11.328   4.156  1.00 16.61           C
+ATOM   1567  C   GLU A  86      17.591  10.273   3.089  1.00 20.09           C
+ATOM   1568  O   GLU A  86      18.667  10.201   2.476  1.00 21.62           O
+ATOM   1569  CB  GLU A  86      17.322  10.719   5.549  1.00 18.99           C
+ATOM   1570  CG  GLU A  86      18.609  10.049   5.965  1.00 18.97           C
+ATOM   1571  CD  GLU A  86      18.615   9.677   7.419  1.00 22.64           C
+ATOM   1572  OE1 GLU A  86      17.555   9.749   8.089  1.00 18.82           O
+ATOM   1573  OE2 GLU A  86      19.700   9.331   7.937  1.00 21.71           O
+ATOM   1574  H   GLU A  86      15.492  11.864   4.495  1.00 18.61           H
+ATOM   1575  HA  GLU A  86      18.122  11.937   4.108  1.00 19.96           H
+ATOM   1576  HB2 GLU A  86      17.134  11.423   6.191  1.00 22.81           H
+ATOM   1577  HB3 GLU A  86      16.619  10.052   5.574  1.00 22.81           H
+ATOM   1578  HG2 GLU A  86      18.726   9.238   5.446  1.00 22.78           H
+ATOM   1579  HG3 GLU A  86      19.349  10.655   5.806  1.00 22.78           H
+ATOM   1580  N   ASN A  87      16.607   9.427   2.867  1.00 17.08           N
+ATOM   1581  CA  ASN A  87      16.593   8.487   1.764  1.00 18.40           C
+ATOM   1582  C   ASN A  87      15.180   7.929   1.664  1.00 20.06           C
+ATOM   1583  O   ASN A  87      14.331   8.205   2.521  1.00 18.57           O
+ATOM   1584  CB  ASN A  87      17.621   7.370   1.990  1.00 18.69           C
+ATOM   1585  CG  ASN A  87      17.299   6.506   3.195  1.00 20.37           C
+ATOM   1586  OD1 ASN A  87      16.236   5.884   3.281  1.00 21.34           O
+ATOM   1587  ND2 ASN A  87      18.253   6.405   4.108  1.00 21.91           N
+ATOM   1588  H   ASN A  87      15.905   9.375   3.361  1.00 20.51           H
+ATOM   1589  HA  ASN A  87      16.806   8.934   0.930  1.00 22.10           H
+ATOM   1590  HB2 ASN A  87      17.642   6.797   1.208  1.00 22.45           H
+ATOM   1591  HB3 ASN A  87      18.494   7.769   2.133  1.00 22.45           H
+ATOM   1592 HD21 ASN A  87      18.126   5.928   4.813  1.00 26.31           H
+ATOM   1593 HD22 ASN A  87      19.000   6.817   3.997  1.00 26.31           H
+ATOM   1594  N   PHE A  88      14.929   7.137   0.620  1.00 17.97           N
+ATOM   1595  CA  PHE A  88      13.649   6.479   0.404  1.00 16.14           C
+ATOM   1596  C   PHE A  88      13.793   4.960   0.298  1.00 20.14           C
+ATOM   1597  O   PHE A  88      13.101   4.306  -0.479  1.00 22.09           O
+ATOM   1598  CB  PHE A  88      12.923   7.068  -0.793  1.00 18.28           C
+ATOM   1599  CG  PHE A  88      12.630   8.527  -0.662  1.00 17.92           C
+ATOM   1600  CD1 PHE A  88      11.611   8.972   0.172  1.00 17.65           C
+ATOM   1601  CD2 PHE A  88      13.379   9.474  -1.341  1.00 19.05           C
+ATOM   1602  CE1 PHE A  88      11.344  10.298   0.305  1.00 17.50           C
+ATOM   1603  CE2 PHE A  88      13.115  10.823  -1.207  1.00 20.19           C
+ATOM   1604  CZ  PHE A  88      12.083  11.242  -0.391  1.00 17.68           C
+ATOM   1605  H   PHE A  88      15.506   6.963   0.007  1.00 21.58           H
+ATOM   1606  HA  PHE A  88      13.095   6.643   1.184  1.00 19.39           H
+ATOM   1607  HB2 PHE A  88      13.473   6.947  -1.582  1.00 21.96           H
+ATOM   1608  HB3 PHE A  88      12.077   6.605  -0.903  1.00 21.96           H
+ATOM   1609  HD1 PHE A  88      11.104   8.353   0.646  1.00 21.21           H
+ATOM   1610  HD2 PHE A  88      14.072   9.196  -1.895  1.00 22.88           H
+ATOM   1611  HE1 PHE A  88      10.658  10.575   0.869  1.00 21.02           H
+ATOM   1612  HE2 PHE A  88      13.631  11.447  -1.665  1.00 24.26           H
+ATOM   1613  HZ  PHE A  88      11.885  12.147  -0.309  1.00 21.24           H
+ATOM   1614  N  AILE A  89      14.669   4.379   1.127  0.45 19.28           N
+ATOM   1615  CA AILE A  89      14.893   2.929   1.101  0.45 23.06           C
+ATOM   1616  C  AILE A  89      13.615   2.185   1.469  0.45 22.06           C
+ATOM   1617  O  AILE A  89      13.241   1.195   0.828  0.45 23.66           O
+ATOM   1618  CB AILE A  89      16.052   2.541   2.042  0.45 25.51           C
+ATOM   1619  CG1AILE A  89      17.411   2.715   1.365  0.45 28.74           C
+ATOM   1620  CG2AILE A  89      15.947   1.072   2.497  0.45 29.05           C
+ATOM   1621  CD1AILE A  89      18.087   3.996   1.673  0.45 42.67           C
+ATOM   1622  H  AILE A  89      15.142   4.799   1.710  0.45 23.16           H
+ATOM   1623  HA AILE A  89      15.140   2.678   0.198  0.45 27.69           H
+ATOM   1624  HB AILE A  89      15.980   3.135   2.805  0.45 30.63           H
+ATOM   1625 HG12AILE A  89      17.996   1.998   1.655  0.45 34.51           H
+ATOM   1626 HG13AILE A  89      17.286   2.673   0.404  0.45 34.51           H
+ATOM   1627 HG21AILE A  89      16.692   0.869   3.083  0.45 34.88           H
+ATOM   1628 HG22AILE A  89      15.110   0.948   2.971  0.45 34.88           H
+ATOM   1629 HG23AILE A  89      15.974   0.497   1.716  0.45 34.88           H
+ATOM   1630 HD11AILE A  89      18.958   4.005   1.247  0.45 51.23           H
+ATOM   1631 HD12AILE A  89      17.546   4.728   1.335  0.45 51.23           H
+ATOM   1632 HD13AILE A  89      18.188   4.077   2.634  0.45 51.23           H
+ATOM   1633  N  BILE A  89      14.690   4.390   1.101  0.55 19.19           N
+ATOM   1634  CA BILE A  89      14.943   2.951   1.032  0.55 23.06           C
+ATOM   1635  C  BILE A  89      13.680   2.174   1.365  0.55 21.35           C
+ATOM   1636  O  BILE A  89      13.333   1.195   0.694  0.55 24.15           O
+ATOM   1637  CB BILE A  89      16.101   2.568   1.974  0.55 25.42           C
+ATOM   1638  CG1BILE A  89      17.389   3.306   1.598  0.55 30.01           C
+ATOM   1639  CG2BILE A  89      16.326   1.056   1.955  0.55 27.74           C
+ATOM   1640  CD1BILE A  89      17.859   3.071   0.177  0.55 42.85           C
+ATOM   1641  H  BILE A  89      15.160   4.807   1.687  0.55 23.06           H
+ATOM   1642  HA BILE A  89      15.203   2.729   0.124  0.55 27.69           H
+ATOM   1643  HB BILE A  89      15.854   2.837   2.872  0.55 30.53           H
+ATOM   1644 HG12BILE A  89      17.241   4.259   1.702  0.55 36.04           H
+ATOM   1645 HG13BILE A  89      18.098   3.014   2.192  0.55 36.04           H
+ATOM   1646 HG21BILE A  89      17.103   0.846   2.496  0.55 33.31           H
+ATOM   1647 HG22BILE A  89      15.541   0.616   2.318  0.55 33.31           H
+ATOM   1648 HG23BILE A  89      16.473   0.770   1.040  0.55 33.31           H
+ATOM   1649 HD11BILE A  89      18.709   3.519   0.048  0.55 51.45           H
+ATOM   1650 HD12BILE A  89      17.963   2.117   0.033  0.55 51.45           H
+ATOM   1651 HD13BILE A  89      17.199   3.428  -0.437  0.55 51.45           H
+ATOM   1652  N  ALEU A  90      12.940   2.639   2.523  0.45 19.01           N
+ATOM   1653  CA ALEU A  90      11.798   1.932   3.081  0.45 18.02           C
+ATOM   1654  C  ALEU A  90      10.522   2.438   2.424  0.45 19.47           C
+ATOM   1655  O  ALEU A  90      10.408   3.619   2.093  0.45 19.95           O
+ATOM   1656  CB ALEU A  90      11.743   2.123   4.600  0.45 17.22           C
+ATOM   1657  CG ALEU A  90      12.926   1.538   5.385  0.45 23.47           C
+ATOM   1658  CD1ALEU A  90      14.214   2.318   5.227  0.45 36.16           C
+ATOM   1659  CD2ALEU A  90      12.587   1.496   6.834  0.45 29.46           C
+ATOM   1660  H  ALEU A  90      13.130   3.367   2.939  0.45 22.83           H
+ATOM   1661  HA ALEU A  90      11.871   0.981   2.909  0.45 21.65           H
+ATOM   1662  HB2ALEU A  90      11.715   3.074   4.786  0.45 20.69           H
+ATOM   1663  HB3ALEU A  90      10.937   1.696   4.931  0.45 20.69           H
+ATOM   1664  HG ALEU A  90      13.085   0.650   5.026  0.45 28.18           H
+ATOM   1665 HD11ALEU A  90      14.936   1.825   5.647  0.45 43.42           H
+ATOM   1666 HD12ALEU A  90      14.398   2.435   4.282  0.45 43.42           H
+ATOM   1667 HD13ALEU A  90      14.113   3.184   5.653  0.45 43.42           H
+ATOM   1668 HD21ALEU A  90      13.326   1.098   7.320  0.45 35.38           H
+ATOM   1669 HD22ALEU A  90      12.432   2.400   7.149  0.45 35.38           H
+ATOM   1670 HD23ALEU A  90      11.786   0.962   6.956  0.45 35.38           H
+ATOM   1671  N  BLEU A  90      12.965   2.601   2.399  0.55 18.92           N
+ATOM   1672  CA BLEU A  90      11.831   1.855   2.912  0.55 19.04           C
+ATOM   1673  C  BLEU A  90      10.532   2.377   2.307  0.55 19.34           C
+ATOM   1674  O  BLEU A  90      10.423   3.543   1.925  0.55 19.26           O
+ATOM   1675  CB BLEU A  90      11.812   1.929   4.437  0.55 19.11           C
+ATOM   1676  CG BLEU A  90      13.008   1.275   5.129  0.55 23.51           C
+ATOM   1677  CD1BLEU A  90      13.029   1.652   6.598  0.55 38.54           C
+ATOM   1678  CD2BLEU A  90      12.962  -0.224   4.944  0.55 23.08           C
+ATOM   1679  H  BLEU A  90      13.122   3.331   2.824  0.55 22.73           H
+ATOM   1680  HA BLEU A  90      11.894   0.920   2.662  0.55 22.87           H
+ATOM   1681  HB2BLEU A  90      11.798   2.863   4.698  0.55 22.95           H
+ATOM   1682  HB3BLEU A  90      11.011   1.483   4.755  0.55 22.95           H
+ATOM   1683  HG BLEU A  90      13.833   1.593   4.731  0.55 28.24           H
+ATOM   1684 HD11BLEU A  90      13.799   1.238   7.019  0.55 46.27           H
+ATOM   1685 HD12BLEU A  90      13.089   2.617   6.676  0.55 46.27           H
+ATOM   1686 HD13BLEU A  90      12.213   1.337   7.017  0.55 46.27           H
+ATOM   1687 HD21BLEU A  90      13.683  -0.627   5.453  0.55 27.72           H
+ATOM   1688 HD22BLEU A  90      12.108  -0.555   5.261  0.55 27.72           H
+ATOM   1689 HD23BLEU A  90      13.068  -0.429   4.002  0.55 27.72           H
+ATOM   1690  N  ALYS A  91       9.579   1.528   2.206  0.45 19.74           N
+ATOM   1691  CA ALYS A  91       8.342   1.812   1.492  0.45 18.70           C
+ATOM   1692  C  ALYS A  91       7.147   1.695   2.432  0.45 16.93           C
+ATOM   1693  O  ALYS A  91       7.236   1.151   3.540  0.45 18.57           O
+ATOM   1694  CB ALYS A  91       8.163   0.860   0.303  0.45 25.42           C
+ATOM   1695  CG ALYS A  91       9.276   0.950  -0.739  0.45 26.11           C
+ATOM   1696  CD ALYS A  91       9.021   0.023  -1.927  0.45 35.92           C
+ATOM   1697  CE ALYS A  91      10.300  -0.255  -2.717  0.45 57.99           C
+ATOM   1698  NZ ALYS A  91      11.130  -1.326  -2.092  0.45 65.60           N
+ATOM   1699  H  ALYS A  91       9.635   0.712   2.473  0.45 23.71           H
+ATOM   1700  HA ALYS A  91       8.374   2.721   1.153  0.45 22.47           H
+ATOM   1701  HB2ALYS A  91       8.143  -0.051   0.636  0.45 30.53           H
+ATOM   1702  HB3ALYS A  91       7.326   1.071  -0.140  0.45 30.53           H
+ATOM   1703  HG2ALYS A  91       9.330   1.860  -1.070  0.45 31.36           H
+ATOM   1704  HG3ALYS A  91      10.118   0.695  -0.331  0.45 31.36           H
+ATOM   1705  HD2ALYS A  91       8.674  -0.823  -1.604  0.45 43.13           H
+ATOM   1706  HD3ALYS A  91       8.379   0.439  -2.525  0.45 43.13           H
+ATOM   1707  HE2ALYS A  91      10.064  -0.540  -3.614  0.45 69.61           H
+ATOM   1708  HE3ALYS A  91      10.832   0.555  -2.755  0.45 69.61           H
+ATOM   1709  HZ1ALYS A  91      11.860  -1.469  -2.581  0.45 78.75           H
+ATOM   1710  HZ2ALYS A  91      11.374  -1.083  -1.272  0.45 78.75           H
+ATOM   1711  HZ3ALYS A  91      10.663  -2.083  -2.042  0.45 78.75           H
+ATOM   1712  N  BLYS A  91       9.557   1.482   2.190  0.55 19.87           N
+ATOM   1713  CA BLYS A  91       8.321   1.743   1.471  0.55 18.44           C
+ATOM   1714  C  BLYS A  91       7.139   1.683   2.432  0.55 16.85           C
+ATOM   1715  O  BLYS A  91       7.233   1.166   3.554  0.55 18.81           O
+ATOM   1716  CB BLYS A  91       8.107   0.718   0.354  0.55 25.00           C
+ATOM   1717  CG BLYS A  91       9.312   0.519  -0.553  0.55 30.36           C
+ATOM   1718  CD BLYS A  91       9.622   1.747  -1.386  0.55 37.52           C
+ATOM   1719  CE BLYS A  91      10.858   1.518  -2.252  0.55 53.61           C
+ATOM   1720  NZ BLYS A  91      11.034   2.569  -3.290  0.55 72.69           N
+ATOM   1721  H  BLYS A  91       9.592   0.693   2.531  0.55 23.87           H
+ATOM   1722  HA BLYS A  91       8.361   2.630   1.082  0.55 22.15           H
+ATOM   1723  HB2BLYS A  91       7.898  -0.140   0.757  0.55 30.02           H
+ATOM   1724  HB3BLYS A  91       7.367   1.013  -0.200  0.55 30.02           H
+ATOM   1725  HG2BLYS A  91      10.090   0.320  -0.009  0.55 36.46           H
+ATOM   1726  HG3BLYS A  91       9.134  -0.218  -1.160  0.55 36.46           H
+ATOM   1727  HD2BLYS A  91       8.870   1.943  -1.967  0.55 45.05           H
+ATOM   1728  HD3BLYS A  91       9.792   2.501  -0.799  0.55 45.05           H
+ATOM   1729  HE2BLYS A  91      11.646   1.521  -1.686  0.55 64.35           H
+ATOM   1730  HE3BLYS A  91      10.776   0.663  -2.701  0.55 64.35           H
+ATOM   1731  HZ1BLYS A  91      11.753   2.392  -3.784  0.55 87.25           H
+ATOM   1732  HZ2BLYS A  91      10.319   2.596  -3.820  0.55 87.25           H
+ATOM   1733  HZ3BLYS A  91      11.137   3.364  -2.904  0.55 87.25           H
+ATOM   1734  N   HIS A  92       6.023   2.230   1.968  1.00 17.40           N
+ATOM   1735  CA  HIS A  92       4.778   2.231   2.722  1.00 16.30           C
+ATOM   1736  C   HIS A  92       4.056   0.927   2.418  1.00 19.78           C
+ATOM   1737  O   HIS A  92       3.203   0.857   1.535  1.00 22.05           O
+ATOM   1738  CB  HIS A  92       3.923   3.434   2.337  1.00 17.31           C
+ATOM   1739  CG  HIS A  92       4.564   4.757   2.623  1.00 16.63           C
+ATOM   1740  ND1 HIS A  92       5.477   5.337   1.766  1.00 15.41           N
+ATOM   1741  CD2 HIS A  92       4.396   5.629   3.649  1.00 15.86           C
+ATOM   1742  CE1 HIS A  92       5.873   6.495   2.278  1.00 15.61           C
+ATOM   1743  NE2 HIS A  92       5.213   6.704   3.405  1.00 15.47           N
+ATOM   1744  HA  HIS A  92       4.973   2.275   3.671  1.00 19.58           H
+ATOM   1745  HB2 HIS A  92       3.742   3.394   1.385  1.00 20.79           H
+ATOM   1746  HB3 HIS A  92       3.091   3.395   2.835  1.00 20.79           H
+ATOM   1747  HD2 HIS A  92       3.832   5.519   4.380  1.00 19.06           H
+ATOM   1748  HE1 HIS A  92       6.508   7.065   1.907  1.00 18.75           H
+ATOM   1749  H  AHIS A  92       5.956   2.608   1.199  0.45 20.90           H
+ATOM   1750  H  BHIS A  92       5.961   2.615   1.202  0.55 20.90           H
+ATOM   1751  N   THR A  93       4.371  -0.108   3.191  1.00 19.02           N
+ATOM   1752  CA  THR A  93       3.949  -1.462   2.825  1.00 22.06           C
+ATOM   1753  C   THR A  93       2.634  -1.900   3.452  1.00 25.16           C
+ATOM   1754  O   THR A  93       2.071  -2.919   3.027  1.00 28.50           O
+ATOM   1755  CB  THR A  93       5.049  -2.446   3.236  1.00 22.99           C
+ATOM   1756  OG1 THR A  93       5.375  -2.241   4.612  1.00 27.33           O
+ATOM   1757  CG2 THR A  93       6.293  -2.243   2.371  1.00 28.76           C
+ATOM   1758  H   THR A  93       4.820  -0.056   3.922  1.00 22.85           H
+ATOM   1759  HA  THR A  93       3.823  -1.497   1.864  1.00 26.50           H
+ATOM   1760  HB  THR A  93       4.741  -3.357   3.113  1.00 27.61           H
+ATOM   1761  HG1 THR A  93       6.121  -2.588   4.785  1.00 32.82           H
+ATOM   1762 HG21 THR A  93       6.996  -2.849   2.653  1.00 34.53           H
+ATOM   1763 HG22 THR A  93       6.082  -2.418   1.440  1.00 34.53           H
+ATOM   1764 HG23 THR A  93       6.612  -1.331   2.455  1.00 34.53           H
+ATOM   1765  N   GLY A  94       2.107  -1.177   4.431  1.00 22.97           N
+ATOM   1766  CA  GLY A  94       0.851  -1.550   5.027  1.00 23.51           C
+ATOM   1767  C   GLY A  94       0.607  -0.826   6.334  1.00 21.94           C
+ATOM   1768  O   GLY A  94       1.335   0.108   6.705  1.00 20.69           O
+ATOM   1769  H   GLY A  94       2.464  -0.468   4.762  1.00 27.59           H
+ATOM   1770  HA2 GLY A  94       0.128  -1.336   4.417  1.00 28.24           H
+ATOM   1771  HA3 GLY A  94       0.847  -2.505   5.199  1.00 28.24           H
+ATOM   1772  N   PRO A  95      -0.403  -1.268   7.083  1.00 19.78           N
+ATOM   1773  CA  PRO A  95      -0.717  -0.620   8.357  1.00 20.23           C
+ATOM   1774  C   PRO A  95       0.462  -0.695   9.305  1.00 21.94           C
+ATOM   1775  O   PRO A  95       1.230  -1.661   9.317  1.00 23.16           O
+ATOM   1776  CB  PRO A  95      -1.905  -1.429   8.891  1.00 22.81           C
+ATOM   1777  CG  PRO A  95      -2.495  -2.100   7.672  1.00 28.81           C
+ATOM   1778  CD  PRO A  95      -1.345  -2.359   6.758  1.00 25.54           C
+ATOM   1779  HA  PRO A  95      -0.983   0.303   8.222  1.00 24.30           H
+ATOM   1780  HB2 PRO A  95      -1.597  -2.086   9.534  1.00 27.39           H
+ATOM   1781  HB3 PRO A  95      -2.550  -0.835   9.306  1.00 27.39           H
+ATOM   1782  HG2 PRO A  95      -2.923  -2.931   7.930  1.00 34.60           H
+ATOM   1783  HG3 PRO A  95      -3.140  -1.509   7.253  1.00 34.60           H
+ATOM   1784  HD2 PRO A  95      -0.947  -3.225   6.941  1.00 30.67           H
+ATOM   1785  HD3 PRO A  95      -1.623  -2.311   5.830  1.00 30.67           H
+ATOM   1786  N   GLY A  96       0.618   0.360  10.097  1.00 19.02           N
+ATOM   1787  CA  GLY A  96       1.620   0.413  11.134  1.00 18.31           C
+ATOM   1788  C   GLY A  96       2.898   1.137  10.752  1.00 16.23           C
+ATOM   1789  O   GLY A  96       3.727   1.380  11.614  1.00 17.69           O
+ATOM   1790  H   GLY A  96       0.139   1.072  10.046  1.00 22.84           H
+ATOM   1791  HA2 GLY A  96       1.245   0.864  11.906  1.00 21.99           H
+ATOM   1792  HA3 GLY A  96       1.857  -0.494  11.384  1.00 21.99           H
+ATOM   1793  N  AILE A  97       3.060   1.483   9.476  0.65 15.78           N
+ATOM   1794  CA AILE A  97       4.227   2.221   9.018  0.65 15.15           C
+ATOM   1795  C  AILE A  97       4.222   3.631   9.590  0.65 14.61           C
+ATOM   1796  O  AILE A  97       3.180   4.291   9.656  0.65 15.31           O
+ATOM   1797  CB AILE A  97       4.207   2.241   7.482  0.65 14.95           C
+ATOM   1798  CG1AILE A  97       4.633   0.865   6.946  0.65 20.26           C
+ATOM   1799  CG2AILE A  97       5.064   3.370   6.914  0.65 15.52           C
+ATOM   1800  CD1AILE A  97       6.074   0.523   7.171  0.65 20.81           C
+ATOM   1801  H  AILE A  97       2.500   1.299   8.850  0.65 18.97           H
+ATOM   1802  HA AILE A  97       5.038   1.790   9.332  0.65 18.20           H
+ATOM   1803  HB AILE A  97       3.300   2.421   7.188  0.65 17.97           H
+ATOM   1804 HG12AILE A  97       4.100   0.184   7.385  0.65 24.33           H
+ATOM   1805 HG13AILE A  97       4.474   0.844   5.989  0.65 24.33           H
+ATOM   1806 HG21AILE A  97       5.182   3.228   5.962  0.65 18.65           H
+ATOM   1807 HG22AILE A  97       4.616   4.216   7.070  0.65 18.65           H
+ATOM   1808 HG23AILE A  97       5.926   3.366   7.359  0.65 18.65           H
+ATOM   1809 HD11AILE A  97       6.257  -0.346   6.780  0.65 25.00           H
+ATOM   1810 HD12AILE A  97       6.628   1.199   6.750  0.65 25.00           H
+ATOM   1811 HD13AILE A  97       6.247   0.500   8.125  0.65 25.00           H
+ATOM   1812  N  BILE A  97       3.048   1.547   9.502  0.35 15.90           N
+ATOM   1813  CA BILE A  97       4.263   2.229   9.067  0.35 15.05           C
+ATOM   1814  C  BILE A  97       4.230   3.689   9.510  0.35 14.47           C
+ATOM   1815  O  BILE A  97       3.231   4.391   9.306  0.35 14.89           O
+ATOM   1816  CB BILE A  97       4.410   2.123   7.543  0.35 15.90           C
+ATOM   1817  CG1BILE A  97       4.500   0.652   7.120  0.35 19.27           C
+ATOM   1818  CG2BILE A  97       5.612   2.893   7.051  0.35 19.78           C
+ATOM   1819  CD1BILE A  97       5.701  -0.081   7.648  0.35 20.56           C
+ATOM   1820  H  BILE A  97       2.461   1.444   8.882  0.35 19.10           H
+ATOM   1821  HA BILE A  97       5.027   1.810   9.493  0.35 18.09           H
+ATOM   1822  HB BILE A  97       3.620   2.517   7.141  0.35 19.10           H
+ATOM   1823 HG12BILE A  97       3.711   0.189   7.441  0.35 23.15           H
+ATOM   1824 HG13BILE A  97       4.537   0.611   6.151  0.35 23.15           H
+ATOM   1825 HG21BILE A  97       5.746   2.702   6.109  0.35 23.76           H
+ATOM   1826 HG22BILE A  97       5.453   3.841   7.177  0.35 23.76           H
+ATOM   1827 HG23BILE A  97       6.392   2.619   7.558  0.35 23.76           H
+ATOM   1828 HD11BILE A  97       5.689  -0.991   7.314  0.35 24.69           H
+ATOM   1829 HD12BILE A  97       6.505   0.371   7.347  0.35 24.69           H
+ATOM   1830 HD13BILE A  97       5.668  -0.085   8.618  0.35 24.69           H
+ATOM   1831  N  ALEU A  98       5.404   4.102   9.980  0.65 13.85           N
+ATOM   1832  CA ALEU A  98       5.620   5.435  10.529  0.65 13.81           C
+ATOM   1833  C  ALEU A  98       6.428   6.233   9.508  0.65 13.78           C
+ATOM   1834  O  ALEU A  98       7.553   5.858   9.142  0.65 13.41           O
+ATOM   1835  CB ALEU A  98       6.342   5.316  11.869  0.65 18.81           C
+ATOM   1836  CG ALEU A  98       6.633   6.576  12.661  0.65 18.63           C
+ATOM   1837  CD1ALEU A  98       5.379   7.309  13.058  0.65 21.75           C
+ATOM   1838  CD2ALEU A  98       7.420   6.195  13.905  0.65 17.30           C
+ATOM   1839  H  ALEU A  98       6.130   3.644   9.933  0.65 16.64           H
+ATOM   1840  HA ALEU A  98       4.785   5.906  10.676  0.65 16.60           H
+ATOM   1841  HB2ALEU A  98       5.800   4.751  12.442  0.65 22.60           H
+ATOM   1842  HB3ALEU A  98       7.199   4.893  11.701  0.65 22.60           H
+ATOM   1843  HG ALEU A  98       7.145   7.183  12.103  0.65 22.37           H
+ATOM   1844 HD11ALEU A  98       5.622   8.100  13.564  0.65 26.12           H
+ATOM   1845 HD12ALEU A  98       4.896   7.566  12.257  0.65 26.12           H
+ATOM   1846 HD13ALEU A  98       4.829   6.724  13.602  0.65 26.12           H
+ATOM   1847 HD21ALEU A  98       7.659   7.002  14.388  0.65 20.78           H
+ATOM   1848 HD22ALEU A  98       6.870   5.625  14.465  0.65 20.78           H
+ATOM   1849 HD23ALEU A  98       8.223   5.720  13.638  0.65 20.78           H
+ATOM   1850  N  BLEU A  98       5.335   4.149  10.103  0.35 12.90           N
+ATOM   1851  CA BLEU A  98       5.566   5.563  10.368  0.35 14.45           C
+ATOM   1852  C  BLEU A  98       6.281   6.214   9.191  0.35 16.15           C
+ATOM   1853  O  BLEU A  98       7.231   5.650   8.634  0.35 15.03           O
+ATOM   1854  CB BLEU A  98       6.457   5.725  11.599  0.35 13.72           C
+ATOM   1855  CG BLEU A  98       5.875   5.419  12.975  0.35 20.35           C
+ATOM   1856  CD1BLEU A  98       6.993   5.337  13.998  0.35 26.51           C
+ATOM   1857  CD2BLEU A  98       4.872   6.465  13.396  0.35 20.61           C
+ATOM   1858  H  BLEU A  98       5.981   3.645  10.366  0.35 15.51           H
+ATOM   1859  HA BLEU A  98       4.712   6.000  10.512  0.35 17.36           H
+ATOM   1860  HB2BLEU A  98       7.219   5.136  11.486  0.35 16.49           H
+ATOM   1861  HB3BLEU A  98       6.752   6.649  11.625  0.35 16.49           H
+ATOM   1862  HG BLEU A  98       5.413   4.567  12.932  0.35 24.45           H
+ATOM   1863 HD11BLEU A  98       6.605   5.232  14.881  0.35 31.84           H
+ATOM   1864 HD12BLEU A  98       7.556   4.575  13.791  0.35 31.84           H
+ATOM   1865 HD13BLEU A  98       7.515   6.154  13.961  0.35 31.84           H
+ATOM   1866 HD21BLEU A  98       4.466   6.193  14.234  0.35 24.76           H
+ATOM   1867 HD22BLEU A  98       5.328   7.313  13.509  0.35 24.76           H
+ATOM   1868 HD23BLEU A  98       4.191   6.544  12.709  0.35 24.76           H
+ATOM   1869  N  ASER A  99       5.856   7.335   9.042  0.65 13.76           N
+ATOM   1870  CA ASER A  99       6.410   8.089   7.928  0.65 15.28           C
+ATOM   1871  C  ASER A  99       6.361   9.579   8.245  0.65 13.01           C
+ATOM   1872  O  ASER A  99       5.590  10.028   9.089  0.65 13.63           O
+ATOM   1873  CB ASER A  99       5.630   7.758   6.656  0.65 14.40           C
+ATOM   1874  OG ASER A  99       6.262   8.346   5.533  0.65 14.16           O
+ATOM   1875  H  ASER A  99       5.131   7.672   9.361  0.65 16.53           H
+ATOM   1876  HA ASER A  99       7.345   7.872   7.791  0.65 18.36           H
+ATOM   1877  HB2ASER A  99       5.603   6.796   6.539  0.65 17.31           H
+ATOM   1878  HB3ASER A  99       4.728   8.108   6.734  0.65 17.31           H
+ATOM   1879  HG ASER A  99       5.684   8.639   4.999  0.65 17.01           H
+ATOM   1880  N  BSER A  99       5.843   7.417   8.825  0.35 13.28           N
+ATOM   1881  CA BSER A  99       6.567   8.201   7.833  0.35 14.96           C
+ATOM   1882  C  BSER A  99       6.346   9.690   8.073  0.35 14.28           C
+ATOM   1883  O  BSER A  99       5.317  10.112   8.614  0.35 12.20           O
+ATOM   1884  CB BSER A  99       6.179   7.801   6.407  0.35 19.48           C
+ATOM   1885  OG BSER A  99       4.918   8.329   6.036  0.35 24.22           O
+ATOM   1886  H  BSER A  99       5.136   7.795   9.135  0.35 15.96           H
+ATOM   1887  HA BSER A  99       7.518   8.044   7.937  0.35 17.97           H
+ATOM   1888  HB2BSER A  99       6.851   8.139   5.794  0.35 23.40           H
+ATOM   1889  HB3BSER A  99       6.139   6.833   6.354  0.35 23.40           H
+ATOM   1890  HG BSER A  99       4.457   8.481   6.721  0.35 29.09           H
+ATOM   1891  N  AMET A 100       7.192  10.351   7.546  0.65 13.44           N
+ATOM   1892  CA AMET A 100       7.268  11.789   7.783  0.65 12.69           C
+ATOM   1893  C  AMET A 100       6.253  12.539   6.930  0.65 13.20           C
+ATOM   1894  O  AMET A 100       6.136  12.298   5.726  0.65 15.24           O
+ATOM   1895  CB AMET A 100       8.660  12.324   7.459  0.65 13.53           C
+ATOM   1896  CG AMET A 100       9.748  11.929   8.426  0.65 13.33           C
+ATOM   1897  SD AMET A 100       9.434  12.381  10.142  0.65 15.29           S
+ATOM   1898  CE AMET A 100       9.613  14.159  10.057  0.65 17.36           C
+ATOM   1899  H  AMET A 100       7.720  10.065   6.930  0.65 16.15           H
+ATOM   1900  HA AMET A 100       7.077  11.938   8.722  0.65 15.25           H
+ATOM   1901  HB2AMET A 100       8.917  11.993   6.584  0.65 16.26           H
+ATOM   1902  HB3AMET A 100       8.619  13.293   7.449  0.65 16.26           H
+ATOM   1903  HG2AMET A 100       9.854  10.966   8.394  0.65 16.01           H
+ATOM   1904  HG3AMET A 100      10.572  12.364   8.156  0.65 16.01           H
+ATOM   1905  HE1AMET A 100       9.491  14.531  10.945  0.65 20.86           H
+ATOM   1906  HE2AMET A 100      10.501  14.372   9.729  0.65 20.86           H
+ATOM   1907  HE3AMET A 100       8.943  14.516   9.454  0.65 20.86           H
+ATOM   1908  N  BMET A 100       7.335  10.482   7.659  0.35 12.75           N
+ATOM   1909  CA BMET A 100       7.334  11.910   7.932  0.35 12.87           C
+ATOM   1910  C  BMET A 100       6.432  12.676   6.972  0.35 13.29           C
+ATOM   1911  O  BMET A 100       6.554  12.565   5.745  0.35 11.75           O
+ATOM   1912  CB BMET A 100       8.748  12.466   7.827  0.35 13.14           C
+ATOM   1913  CG BMET A 100       9.679  12.019   8.931  0.35 16.48           C
+ATOM   1914  SD BMET A 100       9.150  12.456  10.592  0.35 15.09           S
+ATOM   1915  CE BMET A 100      10.712  12.243  11.474  0.35 39.31           C
+ATOM   1916  H  BMET A 100       8.021  10.210   7.216  0.35 15.32           H
+ATOM   1917  HA BMET A 100       6.998  12.032   8.834  0.35 15.46           H
+ATOM   1918  HB2BMET A 100       9.132  12.178   6.985  0.35 15.80           H
+ATOM   1919  HB3BMET A 100       8.703  13.435   7.857  0.35 15.80           H
+ATOM   1920  HG2BMET A 100       9.757  11.053   8.895  0.35 19.80           H
+ATOM   1921  HG3BMET A 100      10.547  12.427   8.785  0.35 19.80           H
+ATOM   1922  HE1BMET A 100      10.597  12.528  12.394  0.35 47.19           H
+ATOM   1923  HE2BMET A 100      10.966  11.307  11.446  0.35 47.19           H
+ATOM   1924  HE3BMET A 100      11.394  12.783  11.043  0.35 47.19           H
+ATOM   1925  N   ALA A 101       5.546  13.485   7.548  1.00 13.59           N
+ATOM   1926  CA  ALA A 101       4.775  14.442   6.783  1.00 13.28           C
+ATOM   1927  C   ALA A 101       5.710  15.517   6.265  1.00 14.01           C
+ATOM   1928  O   ALA A 101       6.782  15.744   6.815  1.00 16.53           O
+ATOM   1929  CB  ALA A 101       3.704  15.077   7.686  1.00 16.29           C
+ATOM   1930  HA  ALA A 101       4.329  14.015   6.035  1.00 15.97           H
+ATOM   1931  HB1 ALA A 101       3.184  15.707   7.163  1.00 19.58           H
+ATOM   1932  HB2 ALA A 101       3.127  14.378   8.031  1.00 19.58           H
+ATOM   1933  HB3 ALA A 101       4.142  15.537   8.419  1.00 19.58           H
+ATOM   1934  H  AALA A 101       5.501  13.586   8.400  0.65 16.33           H
+ATOM   1935  H  BALA A 101       5.374  13.494   8.390  0.35 16.33           H
+ATOM   1936  N   ASN A 102       5.321  16.158   5.176  1.00 15.39           N
+ATOM   1937  CA  ASN A 102       6.150  17.223   4.636  1.00 15.86           C
+ATOM   1938  C   ASN A 102       5.290  18.114   3.763  1.00 18.92           C
+ATOM   1939  O   ASN A 102       4.116  17.827   3.513  1.00 20.96           O
+ATOM   1940  CB  ASN A 102       7.387  16.645   3.917  1.00 17.27           C
+ATOM   1941  CG  ASN A 102       7.033  15.873   2.674  1.00 16.41           C
+ATOM   1942  OD1 ASN A 102       6.276  16.340   1.831  1.00 18.67           O
+ATOM   1943  ND2 ASN A 102       7.581  14.681   2.542  1.00 17.70           N
+ATOM   1944  H   ASN A 102       4.597  15.999   4.740  1.00 18.49           H
+ATOM   1945  HA  ASN A 102       6.477  17.785   5.356  1.00 19.06           H
+ATOM   1946  HB2 ASN A 102       7.972  17.374   3.661  1.00 20.75           H
+ATOM   1947  HB3 ASN A 102       7.850  16.043   4.521  1.00 20.75           H
+ATOM   1948 HD21 ASN A 102       7.409  14.203   1.848  1.00 21.26           H
+ATOM   1949 HD22 ASN A 102       8.111  14.382   3.150  1.00 21.26           H
+ATOM   1950  N   ALA A 103       5.921  19.175   3.253  1.00 17.83           N
+ATOM   1951  CA  ALA A 103       5.258  20.180   2.433  1.00 22.30           C
+ATOM   1952  C   ALA A 103       6.038  20.415   1.161  1.00 23.98           C
+ATOM   1953  O   ALA A 103       6.046  21.530   0.634  1.00 26.32           O
+ATOM   1954  CB  ALA A 103       5.130  21.502   3.182  1.00 26.72           C
+ATOM   1955  H   ALA A 103       6.757  19.335   3.374  1.00 21.42           H
+ATOM   1956  HA  ALA A 103       4.369  19.859   2.215  1.00 26.78           H
+ATOM   1957  HB1 ALA A 103       4.721  22.158   2.596  1.00 32.09           H
+ATOM   1958  HB2 ALA A 103       4.575  21.368   3.966  1.00 32.09           H
+ATOM   1959  HB3 ALA A 103       6.013  21.801   3.448  1.00 32.09           H
+ATOM   1960  N   GLY A 104       6.681  19.379   0.650  1.00 19.59           N
+ATOM   1961  CA  GLY A 104       7.561  19.521  -0.488  1.00 19.42           C
+ATOM   1962  C   GLY A 104       8.873  18.807  -0.227  1.00 17.95           C
+ATOM   1963  O   GLY A 104       9.125  18.326   0.882  1.00 18.24           O
+ATOM   1964  H   GLY A 104       6.623  18.575   0.950  1.00 23.53           H
+ATOM   1965  HA2 GLY A 104       7.145  19.138  -1.276  1.00 23.33           H
+ATOM   1966  HA3 GLY A 104       7.741  20.460  -0.650  1.00 23.33           H
+ATOM   1967  N   PRO A 105       9.734  18.733  -1.236  1.00 15.88           N
+ATOM   1968  CA  PRO A 105      11.044  18.113  -1.028  1.00 16.44           C
+ATOM   1969  C   PRO A 105      11.824  18.785   0.090  1.00 17.20           C
+ATOM   1970  O   PRO A 105      11.866  20.011   0.199  1.00 18.80           O
+ATOM   1971  CB  PRO A 105      11.766  18.301  -2.375  1.00 18.80           C
+ATOM   1972  CG  PRO A 105      10.782  18.866  -3.306  1.00 28.24           C
+ATOM   1973  CD  PRO A 105       9.577  19.344  -2.571  1.00 20.38           C
+ATOM   1974  HA  PRO A 105      10.928  17.170  -0.836  1.00 19.75           H
+ATOM   1975  HB2 PRO A 105      12.513  18.908  -2.259  1.00 22.58           H
+ATOM   1976  HB3 PRO A 105      12.082  17.441  -2.694  1.00 22.58           H
+ATOM   1977  HG2 PRO A 105      11.194  19.609  -3.774  1.00 33.91           H
+ATOM   1978  HG3 PRO A 105      10.526  18.177  -3.938  1.00 33.91           H
+ATOM   1979  HD2 PRO A 105       9.571  20.312  -2.510  1.00 24.48           H
+ATOM   1980  HD3 PRO A 105       8.765  19.033  -3.001  1.00 24.48           H
+ATOM   1981  N   ASN A 106      12.466  17.973   0.926  1.00 15.31           N
+ATOM   1982  CA  ASN A 106      13.393  18.461   1.941  1.00 16.87           C
+ATOM   1983  C   ASN A 106      12.770  19.458   2.917  1.00 18.32           C
+ATOM   1984  O   ASN A 106      13.354  20.497   3.244  1.00 18.77           O
+ATOM   1985  CB  ASN A 106      14.643  19.029   1.258  1.00 16.27           C
+ATOM   1986  CG  ASN A 106      15.284  18.001   0.349  1.00 15.80           C
+ATOM   1987  OD1 ASN A 106      15.609  16.899   0.775  1.00 17.42           O
+ATOM   1988  ND2 ASN A 106      15.423  18.344  -0.934  1.00 18.26           N
+ATOM   1989  H   ASN A 106      12.378  17.118   0.924  1.00 18.40           H
+ATOM   1990  HA  ASN A 106      13.646  17.709   2.499  1.00 20.27           H
+ATOM   1991  HB2 ASN A 106      14.395  19.800   0.723  1.00 19.55           H
+ATOM   1992  HB3 ASN A 106      15.289  19.287   1.933  1.00 19.55           H
+ATOM   1993 HD21 ASN A 106      15.781  17.794  -1.489  1.00 21.94           H
+ATOM   1994 HD22 ASN A 106      15.154  19.115  -1.204  1.00 21.94           H
+ATOM   1995  N   THR A 107      11.581  19.112   3.433  1.00 16.27           N
+ATOM   1996  CA  THR A 107      10.852  19.969   4.364  1.00 17.29           C
+ATOM   1997  C   THR A 107      10.356  19.191   5.565  1.00 17.33           C
+ATOM   1998  O   THR A 107       9.302  19.490   6.146  1.00 20.04           O
+ATOM   1999  CB  THR A 107       9.674  20.684   3.701  1.00 16.50           C
+ATOM   2000  OG1 THR A 107       8.737  19.739   3.198  1.00 18.47           O
+ATOM   2001  CG2 THR A 107      10.141  21.597   2.583  1.00 20.76           C
+ATOM   2002  H   THR A 107      11.176  18.375   3.253  1.00 19.55           H
+ATOM   2003  HA  THR A 107      11.484  20.640   4.668  1.00 20.78           H
+ATOM   2004  HB  THR A 107       9.232  21.235   4.366  1.00 19.83           H
+ATOM   2005  HG1 THR A 107       9.030  19.393   2.491  1.00 22.19           H
+ATOM   2006 HG21 THR A 107       9.389  22.093   2.223  1.00 24.94           H
+ATOM   2007 HG22 THR A 107      10.800  22.225   2.921  1.00 24.94           H
+ATOM   2008 HG23 THR A 107      10.542  21.073   1.872  1.00 24.94           H
+ATOM   2009  N   ASN A 108      11.116  18.218   6.015  1.00 16.64           N
+ATOM   2010  CA  ASN A 108      10.728  17.464   7.196  1.00 16.41           C
+ATOM   2011  C   ASN A 108      10.885  18.312   8.447  1.00 17.08           C
+ATOM   2012  O   ASN A 108      11.873  19.022   8.614  1.00 18.70           O
+ATOM   2013  CB  ASN A 108      11.623  16.236   7.343  1.00 16.53           C
+ATOM   2014  CG  ASN A 108      11.461  15.289   6.214  1.00 18.62           C
+ATOM   2015  OD1 ASN A 108      10.421  14.664   6.055  1.00 17.85           O
+ATOM   2016  ND2 ASN A 108      12.456  15.235   5.347  1.00 16.66           N
+ATOM   2017  H   ASN A 108      11.860  17.971   5.660  1.00 19.99           H
+ATOM   2018  HA  ASN A 108       9.802  17.190   7.104  1.00 19.71           H
+ATOM   2019  HB2 ASN A 108      12.550  16.519   7.370  1.00 19.86           H
+ATOM   2020  HB3 ASN A 108      11.394  15.772   8.163  1.00 19.86           H
+ATOM   2021 HD21 ASN A 108      12.411  14.702   4.674  1.00 20.01           H
+ATOM   2022 HD22 ASN A 108      13.148  15.733   5.455  1.00 20.01           H
+ATOM   2023  N   GLY A 109       9.930  18.179   9.371  1.00 15.71           N
+ATOM   2024  CA  GLY A 109       9.967  18.880  10.648  1.00 16.29           C
+ATOM   2025  C   GLY A 109       9.777  17.912  11.784  1.00 15.76           C
+ATOM   2026  O   GLY A 109      10.650  17.099  12.091  1.00 17.47           O
+ATOM   2027  H   GLY A 109       9.237  17.678   9.277  1.00 18.88           H
+ATOM   2028  HA2 GLY A 109      10.823  19.324  10.754  1.00 19.57           H
+ATOM   2029  HA3 GLY A 109       9.260  19.544  10.680  1.00 19.57           H
+ATOM   2030  N   SER A 110       8.604  17.978  12.407  1.00 14.38           N
+ATOM   2031  CA  SER A 110       8.230  17.065  13.474  1.00 14.34           C
+ATOM   2032  C   SER A 110       6.969  16.266  13.184  1.00 13.69           C
+ATOM   2033  O   SER A 110       6.667  15.314  13.915  1.00 14.95           O
+ATOM   2034  CB  SER A 110       8.037  17.833  14.787  1.00 15.92           C
+ATOM   2035  OG  SER A 110       7.058  18.823  14.628  1.00 15.29           O
+ATOM   2036  H   SER A 110       7.995  18.558  12.223  1.00 17.27           H
+ATOM   2037  HA  SER A 110       8.953  16.431  13.603  1.00 17.23           H
+ATOM   2038  HB2 SER A 110       7.755  17.215  15.479  1.00 19.13           H
+ATOM   2039  HB3 SER A 110       8.875  18.252  15.037  1.00 19.13           H
+ATOM   2040  HG  SER A 110       6.850  19.144  15.376  1.00 18.38           H
+ATOM   2041  N   GLN A 111       6.196  16.639  12.190  1.00 13.11           N
+ATOM   2042  CA  GLN A 111       4.938  15.976  11.897  1.00 12.88           C
+ATOM   2043  C   GLN A 111       5.179  14.636  11.230  1.00 13.39           C
+ATOM   2044  O   GLN A 111       6.096  14.477  10.417  1.00 14.24           O
+ATOM   2045  CB  GLN A 111       4.046  16.837  11.037  1.00 13.89           C
+ATOM   2046  CG  GLN A 111       3.506  18.072  11.768  1.00 14.57           C
+ATOM   2047  CD  GLN A 111       2.537  18.808  10.944  1.00 17.22           C
+ATOM   2048  OE1 GLN A 111       1.559  18.253  10.461  1.00 18.73           O
+ATOM   2049  NE2 GLN A 111       2.806  20.086  10.729  1.00 18.29           N
+ATOM   2050  H   GLN A 111       6.377  17.288  11.656  1.00 15.75           H
+ATOM   2051  HA  GLN A 111       4.467  15.818  12.731  1.00 15.48           H
+ATOM   2052  HB2 GLN A 111       4.553  17.143  10.269  1.00 16.70           H
+ATOM   2053  HB3 GLN A 111       3.287  16.308  10.745  1.00 16.70           H
+ATOM   2054  HG2 GLN A 111       3.062  17.793  12.584  1.00 17.51           H
+ATOM   2055  HG3 GLN A 111       4.242  18.668  11.978  1.00 17.51           H
+ATOM   2056 HE21 GLN A 111       2.273  20.564  10.253  1.00 21.98           H
+ATOM   2057 HE22 GLN A 111       3.515  20.439  11.065  1.00 21.98           H
+ATOM   2058  N  APHE A 112       4.377  13.656  11.623  0.61 13.32           N
+ATOM   2059  CA APHE A 112       4.525  12.276  11.188  0.61 13.81           C
+ATOM   2060  C  APHE A 112       3.134  11.708  11.043  0.61 13.85           C
+ATOM   2061  O  APHE A 112       2.166  12.244  11.595  0.61 13.66           O
+ATOM   2062  CB APHE A 112       5.227  11.450  12.271  0.61 14.41           C
+ATOM   2063  CG APHE A 112       4.463  11.434  13.572  0.61 13.42           C
+ATOM   2064  CD1APHE A 112       3.431  10.531  13.791  0.61 13.02           C
+ATOM   2065  CD2APHE A 112       4.719  12.375  14.541  0.61 14.57           C
+ATOM   2066  CE1APHE A 112       2.711  10.555  14.965  0.61 14.70           C
+ATOM   2067  CE2APHE A 112       4.007  12.390  15.709  0.61 14.71           C
+ATOM   2068  CZ APHE A 112       3.000  11.497  15.906  0.61 14.04           C
+ATOM   2069  H  APHE A 112       3.716  13.769  12.161  0.61 16.00           H
+ATOM   2070  HA APHE A 112       5.017  12.241  10.353  0.61 16.60           H
+ATOM   2071  HB2APHE A 112       5.317  10.535  11.963  0.61 17.32           H
+ATOM   2072  HB3APHE A 112       6.103  11.831  12.441  0.61 17.32           H
+ATOM   2073  HD1APHE A 112       3.223   9.903  13.137  0.61 15.65           H
+ATOM   2074  HD2APHE A 112       5.384  13.010  14.401  0.61 17.51           H
+ATOM   2075  HE1APHE A 112       2.034   9.935  15.113  0.61 17.66           H
+ATOM   2076  HE2APHE A 112       4.211  13.012  16.370  0.61 17.67           H
+ATOM   2077  HZ APHE A 112       2.504  11.529  16.692  0.61 16.87           H
+ATOM   2078  N  BPHE A 112       4.276  13.699  11.503  0.39 12.75           N
+ATOM   2079  CA BPHE A 112       4.404  12.346  10.986  0.39 11.30           C
+ATOM   2080  C  BPHE A 112       3.033  11.743  10.743  0.39 12.00           C
+ATOM   2081  O  BPHE A 112       2.001  12.247  11.200  0.39 11.20           O
+ATOM   2082  CB BPHE A 112       5.238  11.465  11.936  0.39 12.31           C
+ATOM   2083  CG BPHE A 112       4.689  11.386  13.342  0.39 12.70           C
+ATOM   2084  CD1BPHE A 112       5.037  12.328  14.289  0.39 15.82           C
+ATOM   2085  CD2BPHE A 112       3.818  10.377  13.708  0.39 14.24           C
+ATOM   2086  CE1BPHE A 112       4.527  12.264  15.569  0.39 16.05           C
+ATOM   2087  CE2BPHE A 112       3.312  10.306  14.985  0.39 13.61           C
+ATOM   2088  CZ BPHE A 112       3.658  11.258  15.912  0.39 17.29           C
+ATOM   2089  H  BPHE A 112       3.578  13.825  11.988  0.39 15.32           H
+ATOM   2090  HA BPHE A 112       4.850  12.389  10.126  0.39 13.58           H
+ATOM   2091  HB2BPHE A 112       5.265  10.563  11.579  0.39 14.80           H
+ATOM   2092  HB3BPHE A 112       6.135  11.828  11.990  0.39 14.80           H
+ATOM   2093  HD1BPHE A 112       5.623  13.014  14.061  0.39 19.01           H
+ATOM   2094  HD2BPHE A 112       3.571   9.736  13.081  0.39 17.11           H
+ATOM   2095  HE1BPHE A 112       4.771  12.903  16.200  0.39 19.28           H
+ATOM   2096  HE2BPHE A 112       2.737   9.615  15.220  0.39 16.36           H
+ATOM   2097  HZ BPHE A 112       3.304  11.222  16.771  0.39 20.77           H
+ATOM   2098  N  APHE A 113       3.042  10.557  10.392  0.61 12.62           N
+ATOM   2099  CA APHE A 113       1.783   9.842  10.336  0.61 12.06           C
+ATOM   2100  C  APHE A 113       2.006   8.352  10.485  0.61 12.91           C
+ATOM   2101  O  APHE A 113       3.012   7.795  10.028  0.61 12.73           O
+ATOM   2102  CB APHE A 113       0.945  10.150   9.083  0.61 13.67           C
+ATOM   2103  CG APHE A 113       1.648   9.897   7.771  0.61 14.25           C
+ATOM   2104  CD1APHE A 113       2.437  10.870   7.205  0.61 15.55           C
+ATOM   2105  CD2APHE A 113       1.495   8.703   7.085  0.61 16.95           C
+ATOM   2106  CE1APHE A 113       3.069  10.671   6.003  0.61 16.20           C
+ATOM   2107  CE2APHE A 113       2.125   8.498   5.869  0.61 19.33           C
+ATOM   2108  CZ APHE A 113       2.918   9.481   5.334  0.61 15.91           C
+ATOM   2109  H  APHE A 113       3.692  10.175   9.979  0.61 15.17           H
+ATOM   2110  HA APHE A 113       1.254  10.131  11.095  0.61 14.50           H
+ATOM   2111  HB2APHE A 113       0.150   9.593   9.100  0.61 16.43           H
+ATOM   2112  HB3APHE A 113       0.694  11.086   9.103  0.61 16.43           H
+ATOM   2113  HD1APHE A 113       2.545  11.682   7.646  0.61 18.68           H
+ATOM   2114  HD2APHE A 113       0.964   8.030   7.447  0.61 20.37           H
+ATOM   2115  HE1APHE A 113       3.601  11.343   5.641  0.61 19.47           H
+ATOM   2116  HE2APHE A 113       2.011   7.694   5.415  0.61 23.22           H
+ATOM   2117  HZ APHE A 113       3.350   9.343   4.523  0.61 19.11           H
+ATOM   2118  N  BPHE A 113       3.049  10.648   9.999  0.39 13.24           N
+ATOM   2119  CA BPHE A 113       1.903   9.800   9.761  0.39 12.54           C
+ATOM   2120  C  BPHE A 113       2.123   8.463  10.460  0.39 12.21           C
+ATOM   2121  O  BPHE A 113       3.252   7.962  10.536  0.39 12.97           O
+ATOM   2122  CB BPHE A 113       1.769   9.494   8.263  0.39 17.37           C
+ATOM   2123  CG BPHE A 113       1.702  10.714   7.353  0.39 16.36           C
+ATOM   2124  CD1BPHE A 113       1.100  11.905   7.742  0.39 21.55           C
+ATOM   2125  CD2BPHE A 113       2.218  10.643   6.071  0.39 17.72           C
+ATOM   2126  CE1BPHE A 113       1.017  12.980   6.875  0.39 21.74           C
+ATOM   2127  CE2BPHE A 113       2.148  11.724   5.218  0.39 19.05           C
+ATOM   2128  CZ BPHE A 113       1.538  12.889   5.624  0.39 23.41           C
+ATOM   2129  H  BPHE A 113       3.755  10.363   9.599  0.39 15.91           H
+ATOM   2130  HA BPHE A 113       1.101  10.235  10.091  0.39 15.07           H
+ATOM   2131  HB2BPHE A 113       2.537   8.969   7.988  0.39 20.87           H
+ATOM   2132  HB3BPHE A 113       0.954   8.986   8.126  0.39 20.87           H
+ATOM   2133  HD1BPHE A 113       0.748  11.980   8.600  0.39 25.88           H
+ATOM   2134  HD2BPHE A 113       2.618   9.855   5.781  0.39 21.29           H
+ATOM   2135  HE1BPHE A 113       0.604  13.767   7.150  0.39 26.12           H
+ATOM   2136  HE2BPHE A 113       2.515  11.666   4.365  0.39 22.88           H
+ATOM   2137  HZ BPHE A 113       1.482  13.613   5.043  0.39 28.12           H
+ATOM   2138  N  AILE A 114       1.034   7.730  11.146  0.61 13.42           N
+ATOM   2139  CA AILE A 114       0.946   6.285  11.301  0.61 13.44           C
+ATOM   2140  C  AILE A 114      -0.056   5.801  10.260  0.61 13.89           C
+ATOM   2141  O  AILE A 114      -1.243   6.131  10.337  0.61 14.51           O
+ATOM   2142  CB AILE A 114       0.472   5.916  12.712  0.61 14.84           C
+ATOM   2143  CG1AILE A 114       1.166   6.765  13.782  0.61 15.18           C
+ATOM   2144  CG2AILE A 114       0.694   4.421  12.935  0.61 18.59           C
+ATOM   2145  CD1AILE A 114       0.501   6.637  15.147  0.61 17.81           C
+ATOM   2146  H  AILE A 114       0.386   8.144  11.531  0.61 16.12           H
+ATOM   2147  HA AILE A 114       1.810   5.875  11.138  0.61 16.15           H
+ATOM   2148  HB AILE A 114      -0.475   6.109  12.789  0.61 17.83           H
+ATOM   2149 HG12AILE A 114       2.088   6.477  13.867  0.61 18.24           H
+ATOM   2150 HG13AILE A 114       1.133   7.697  13.516  0.61 18.24           H
+ATOM   2151 HG21AILE A 114       0.416   4.191  13.835  0.61 22.34           H
+ATOM   2152 HG22AILE A 114       0.169   3.924  12.288  0.61 22.34           H
+ATOM   2153 HG23AILE A 114       1.636   4.221  12.819  0.61 22.34           H
+ATOM   2154 HD11AILE A 114       1.011   7.146  15.796  0.61 21.39           H
+ATOM   2155 HD12AILE A 114      -0.404   6.983  15.092  0.61 21.39           H
+ATOM   2156 HD13AILE A 114       0.482   5.701  15.403  0.61 21.39           H
+ATOM   2157  N  BILE A 114       1.029   7.879  10.953  0.39 12.50           N
+ATOM   2158  CA BILE A 114       0.935   6.438  11.175  0.39 14.56           C
+ATOM   2159  C  BILE A 114      -0.050   5.925  10.143  0.39 14.49           C
+ATOM   2160  O  BILE A 114      -1.217   6.338  10.134  0.39 14.54           O
+ATOM   2161  CB BILE A 114       0.453   6.078  12.587  0.39 14.54           C
+ATOM   2162  CG1BILE A 114       1.494   6.472  13.627  0.39 17.80           C
+ATOM   2163  CG2BILE A 114       0.161   4.561  12.672  0.39 15.56           C
+ATOM   2164  CD1BILE A 114       1.011   6.362  15.061  0.39 21.09           C
+ATOM   2165  H  BILE A 114       0.316   8.307  11.170  0.39 15.03           H
+ATOM   2166  HA BILE A 114       1.808   6.034  11.054  0.39 17.50           H
+ATOM   2167  HB BILE A 114      -0.363   6.571  12.769  0.39 17.47           H
+ATOM   2168 HG12BILE A 114       2.265   5.892  13.531  0.39 21.38           H
+ATOM   2169 HG13BILE A 114       1.752   7.395  13.474  0.39 21.38           H
+ATOM   2170 HG21BILE A 114      -0.067   4.334  13.587  0.39 18.70           H
+ATOM   2171 HG22BILE A 114      -0.580   4.348  12.084  0.39 18.70           H
+ATOM   2172 HG23BILE A 114       0.952   4.071  12.398  0.39 18.70           H
+ATOM   2173 HD11BILE A 114       1.711   6.677  15.655  0.39 25.33           H
+ATOM   2174 HD12BILE A 114       0.216   6.906  15.170  0.39 25.33           H
+ATOM   2175 HD13BILE A 114       0.806   5.434  15.255  0.39 25.33           H
+ATOM   2176  N   CYS A 115       0.406   5.051   9.261  1.00 15.09           N
+ATOM   2177  CA  CYS A 115      -0.489   4.513   8.253  1.00 15.66           C
+ATOM   2178  C   CYS A 115      -1.366   3.423   8.831  1.00 16.53           C
+ATOM   2179  O   CYS A 115      -0.912   2.598   9.631  1.00 18.55           O
+ATOM   2180  CB  CYS A 115       0.339   3.899   7.134  1.00 17.06           C
+ATOM   2181  SG  CYS A 115       1.369   5.078   6.297  1.00 22.00           S
+ATOM   2182  HA  CYS A 115      -1.054   5.224   7.914  1.00 18.82           H
+ATOM   2183  HB2 CYS A 115       0.914   3.213   7.509  1.00 20.49           H
+ATOM   2184  HB3 CYS A 115      -0.260   3.507   6.479  1.00 20.49           H
+ATOM   2185  HG  CYS A 115       0.720   6.055   6.046  1.00 26.42           H
+ATOM   2186  H  ACYS A 115       1.233   4.841   9.148  0.61 18.14           H
+ATOM   2187  H  BCYS A 115       1.215   4.759   9.225  0.39 18.14           H
+ATOM   2188  N   THR A 116      -2.629   3.420   8.417  1.00 16.25           N
+ATOM   2189  CA  THR A 116      -3.566   2.372   8.806  1.00 17.94           C
+ATOM   2190  C   THR A 116      -4.002   1.593   7.587  1.00 21.49           C
+ATOM   2191  O   THR A 116      -4.935   0.791   7.670  1.00 26.55           O
+ATOM   2192  CB  THR A 116      -4.760   2.954   9.558  1.00 17.81           C
+ATOM   2193  OG1 THR A 116      -5.405   3.958   8.775  1.00 21.93           O
+ATOM   2194  CG2 THR A 116      -4.276   3.575  10.888  1.00 21.34           C
+ATOM   2195  H   THR A 116      -2.970   4.020   7.904  1.00 19.52           H
+ATOM   2196  HA  THR A 116      -3.147   1.761   9.431  1.00 21.55           H
+ATOM   2197  HB  THR A 116      -5.401   2.250   9.743  1.00 21.40           H
+ATOM   2198  HG1 THR A 116      -6.057   4.277   9.197  1.00 26.34           H
+ATOM   2199 HG21 THR A 116      -5.034   3.902  11.396  1.00 25.63           H
+ATOM   2200 HG22 THR A 116      -3.807   2.909  11.414  1.00 25.63           H
+ATOM   2201 HG23 THR A 116      -3.675   4.315  10.708  1.00 25.63           H
+ATOM   2202  N   ALA A 117      -3.325   1.802   6.468  1.00 19.82           N
+ATOM   2203  CA  ALA A 117      -3.571   1.099   5.218  1.00 20.42           C
+ATOM   2204  C   ALA A 117      -2.259   1.134   4.461  1.00 21.97           C
+ATOM   2205  O   ALA A 117      -1.345   1.884   4.815  1.00 19.94           O
+ATOM   2206  CB  ALA A 117      -4.675   1.779   4.413  1.00 25.52           C
+ATOM   2207  H   ALA A 117      -2.687   2.375   6.403  1.00 23.80           H
+ATOM   2208  HA  ALA A 117      -3.846   0.183   5.378  1.00 24.52           H
+ATOM   2209  HB1 ALA A 117      -4.818   1.282   3.592  1.00 30.65           H
+ATOM   2210  HB2 ALA A 117      -5.489   1.789   4.939  1.00 30.65           H
+ATOM   2211  HB3 ALA A 117      -4.402   2.687   4.208  1.00 30.65           H
+ATOM   2212  N   LYS A 118      -2.162   0.329   3.406  1.00 22.52           N
+ATOM   2213  CA  LYS A 118      -1.044   0.438   2.478  1.00 21.09           C
+ATOM   2214  C   LYS A 118      -1.210   1.713   1.665  1.00 21.78           C
+ATOM   2215  O   LYS A 118      -2.297   1.998   1.151  1.00 23.96           O
+ATOM   2216  CB  LYS A 118      -1.022  -0.784   1.548  1.00 24.28           C
+ATOM   2217  CG  LYS A 118       0.107  -0.778   0.551  1.00 24.16           C
+ATOM   2218  CD  LYS A 118       0.090  -2.076  -0.294  1.00 31.06           C
+ATOM   2219  CE  LYS A 118       1.230  -2.154  -1.306  1.00 63.19           C
+ATOM   2220  NZ  LYS A 118       0.737  -2.069  -2.713  1.00 96.86           N
+ATOM   2221  H   LYS A 118      -2.729  -0.285   3.206  1.00 27.05           H
+ATOM   2222  HA  LYS A 118      -0.201   0.468   2.958  1.00 25.33           H
+ATOM   2223  HB2 LYS A 118      -0.932  -1.584   2.089  1.00 29.15           H
+ATOM   2224  HB3 LYS A 118      -1.854  -0.811   1.051  1.00 29.15           H
+ATOM   2225  HG2 LYS A 118       0.010  -0.019  -0.046  1.00 29.01           H
+ATOM   2226  HG3 LYS A 118       0.955  -0.725   1.019  1.00 29.01           H
+ATOM   2227  HD2 LYS A 118       0.168  -2.839   0.300  1.00 37.30           H
+ATOM   2228  HD3 LYS A 118      -0.746  -2.121  -0.784  1.00 37.30           H
+ATOM   2229  HE2 LYS A 118       1.841  -1.416  -1.155  1.00 75.85           H
+ATOM   2230  HE3 LYS A 118       1.695  -2.998  -1.199  1.00 75.85           H
+ATOM   2231  HZ1 LYS A 118       1.423  -2.105  -3.278  1.00116.25           H
+ATOM   2232  HZ2 LYS A 118       0.187  -2.748  -2.884  1.00116.25           H
+ATOM   2233  HZ3 LYS A 118       0.299  -1.304  -2.837  1.00116.25           H
+ATOM   2234  N   THR A 119      -0.152   2.526   1.587  1.00 19.53           N
+ATOM   2235  CA  THR A 119      -0.227   3.840   0.949  1.00 18.13           C
+ATOM   2236  C   THR A 119       0.931   3.994  -0.038  1.00 19.03           C
+ATOM   2237  O   THR A 119       1.785   4.869   0.087  1.00 18.28           O
+ATOM   2238  CB  THR A 119      -0.219   4.987   1.954  1.00 16.71           C
+ATOM   2239  OG1 THR A 119       0.976   4.943   2.736  1.00 18.84           O
+ATOM   2240  CG2 THR A 119      -1.379   4.877   2.920  1.00 20.14           C
+ATOM   2241  H   THR A 119       0.626   2.335   1.900  1.00 23.45           H
+ATOM   2242  HA  THR A 119      -1.065   3.876   0.463  1.00 21.78           H
+ATOM   2243  HB  THR A 119      -0.283   5.819   1.460  1.00 20.08           H
+ATOM   2244  HG1 THR A 119       1.007   5.605   3.253  1.00 22.63           H
+ATOM   2245 HG21 THR A 119      -1.341   5.597   3.568  1.00 24.19           H
+ATOM   2246 HG22 THR A 119      -2.219   4.932   2.437  1.00 24.19           H
+ATOM   2247 HG23 THR A 119      -1.341   4.029   3.389  1.00 24.19           H
+ATOM   2248  N   GLU A 120       0.922   3.153  -1.069  1.00 19.43           N
+ATOM   2249  CA  GLU A 120       2.084   3.034  -1.944  1.00 18.12           C
+ATOM   2250  C   GLU A 120       2.354   4.287  -2.752  1.00 17.46           C
+ATOM   2251  O   GLU A 120       3.495   4.499  -3.183  1.00 19.17           O
+ATOM   2252  CB  GLU A 120       1.890   1.842  -2.898  1.00 24.62           C
+ATOM   2253  CG  GLU A 120       0.739   1.992  -3.899  1.00 32.02           C
+ATOM   2254  CD  GLU A 120      -0.643   1.520  -3.396  1.00 52.34           C
+ATOM   2255  OE1 GLU A 120      -0.887   1.385  -2.168  1.00 32.11           O
+ATOM   2256  OE2 GLU A 120      -1.512   1.289  -4.265  1.00 63.97           O
+ATOM   2257  H   GLU A 120       0.262   2.645  -1.282  1.00 23.34           H
+ATOM   2258  HA  GLU A 120       2.865   2.872  -1.392  1.00 21.76           H
+ATOM   2259  HB2 GLU A 120       2.706   1.722  -3.409  1.00 29.57           H
+ATOM   2260  HB3 GLU A 120       1.712   1.050  -2.366  1.00 29.57           H
+ATOM   2261  HG2 GLU A 120       0.656   2.930  -4.131  1.00 38.45           H
+ATOM   2262  HG3 GLU A 120       0.951   1.472  -4.689  1.00 38.45           H
+ATOM   2263  N   TRP A 121       1.341   5.132  -2.973  1.00 17.84           N
+ATOM   2264  CA  TRP A 121       1.525   6.363  -3.724  1.00 17.49           C
+ATOM   2265  C   TRP A 121       2.405   7.369  -2.987  1.00 19.70           C
+ATOM   2266  O   TRP A 121       2.818   8.376  -3.582  1.00 19.86           O
+ATOM   2267  CB  TRP A 121       0.150   6.984  -4.077  1.00 19.51           C
+ATOM   2268  CG  TRP A 121      -0.645   7.384  -2.895  1.00 19.51           C
+ATOM   2269  CD1 TRP A 121      -0.626   8.589  -2.279  1.00 22.04           C
+ATOM   2270  CD2 TRP A 121      -1.572   6.574  -2.173  1.00 17.29           C
+ATOM   2271  NE1 TRP A 121      -1.476   8.581  -1.205  1.00 20.64           N
+ATOM   2272  CE2 TRP A 121      -2.075   7.356  -1.121  1.00 20.38           C
+ATOM   2273  CE3 TRP A 121      -2.048   5.267  -2.325  1.00 20.20           C
+ATOM   2274  CZ2 TRP A 121      -3.018   6.858  -0.213  1.00 20.89           C
+ATOM   2275  CZ3 TRP A 121      -2.984   4.784  -1.416  1.00 26.19           C
+ATOM   2276  CH2 TRP A 121      -3.456   5.586  -0.384  1.00 22.76           C
+ATOM   2277  H   TRP A 121       0.536   5.009  -2.695  1.00 21.43           H
+ATOM   2278  HA  TRP A 121       1.964   6.159  -4.565  1.00 21.01           H
+ATOM   2279  HB2 TRP A 121       0.295   7.776  -4.618  1.00 23.44           H
+ATOM   2280  HB3 TRP A 121      -0.368   6.333  -4.575  1.00 23.44           H
+ATOM   2281  HD1 TRP A 121      -0.111   9.316  -2.545  1.00 26.47           H
+ATOM   2282  HE1 TRP A 121      -1.611   9.241  -0.670  1.00 24.80           H
+ATOM   2283  HE3 TRP A 121      -1.745   4.731  -3.022  1.00 24.27           H
+ATOM   2284  HZ2 TRP A 121      -3.334   7.384   0.486  1.00 25.10           H
+ATOM   2285  HZ3 TRP A 121      -3.298   3.912  -1.500  1.00 31.45           H
+ATOM   2286  HH2 TRP A 121      -4.088   5.242   0.205  1.00 27.34           H
+ATOM   2287  N   LEU A 122       2.679   7.139  -1.703  1.00 16.70           N
+ATOM   2288  CA  LEU A 122       3.586   7.984  -0.936  1.00 16.68           C
+ATOM   2289  C   LEU A 122       5.039   7.563  -1.079  1.00 15.08           C
+ATOM   2290  O   LEU A 122       5.921   8.302  -0.641  1.00 16.23           O
+ATOM   2291  CB  LEU A 122       3.164   8.017   0.536  1.00 15.92           C
+ATOM   2292  CG  LEU A 122       1.731   8.539   0.755  1.00 17.89           C
+ATOM   2293  CD1 LEU A 122       1.394   8.488   2.242  1.00 21.28           C
+ATOM   2294  CD2 LEU A 122       1.577   9.934   0.215  1.00 21.69           C
+ATOM   2295  H   LEU A 122       2.345   6.489  -1.249  1.00 20.06           H
+ATOM   2296  HA  LEU A 122       3.524   8.897  -1.257  1.00 20.04           H
+ATOM   2297  HB2 LEU A 122       3.211   7.116   0.893  1.00 19.13           H
+ATOM   2298  HB3 LEU A 122       3.771   8.598   1.021  1.00 19.13           H
+ATOM   2299  HG  LEU A 122       1.104   7.977   0.274  1.00 21.49           H
+ATOM   2300 HD11 LEU A 122       0.481   8.790   2.370  1.00 25.56           H
+ATOM   2301 HD12 LEU A 122       1.487   7.574   2.556  1.00 25.56           H
+ATOM   2302 HD13 LEU A 122       2.005   9.067   2.725  1.00 25.56           H
+ATOM   2303 HD21 LEU A 122       0.703  10.273   0.462  1.00 26.06           H
+ATOM   2304 HD22 LEU A 122       2.270  10.497   0.594  1.00 26.06           H
+ATOM   2305 HD23 LEU A 122       1.662   9.909  -0.751  1.00 26.06           H
+ATOM   2306  N   ASP A 123       5.304   6.403  -1.667  1.00 16.26           N
+ATOM   2307  CA  ASP A 123       6.677   5.933  -1.802  1.00 17.55           C
+ATOM   2308  C   ASP A 123       7.508   6.923  -2.611  1.00 16.97           C
+ATOM   2309  O   ASP A 123       7.072   7.431  -3.655  1.00 19.09           O
+ATOM   2310  CB  ASP A 123       6.707   4.565  -2.486  1.00 17.23           C
+ATOM   2311  CG  ASP A 123       6.185   3.451  -1.618  1.00 19.59           C
+ATOM   2312  OD1 ASP A 123       6.001   3.639  -0.405  1.00 18.55           O
+ATOM   2313  OD2 ASP A 123       5.967   2.328  -2.154  1.00 21.46           O
+ATOM   2314  H   ASP A 123       4.712   5.872  -1.993  1.00 19.54           H
+ATOM   2315  HA  ASP A 123       7.065   5.847  -0.917  1.00 21.09           H
+ATOM   2316  HB2 ASP A 123       6.158   4.601  -3.285  1.00 20.70           H
+ATOM   2317  HB3 ASP A 123       7.623   4.352  -2.724  1.00 20.70           H
+ATOM   2318  N   GLY A 124       8.699   7.212  -2.119  1.00 16.77           N
+ATOM   2319  CA  GLY A 124       9.588   8.109  -2.806  1.00 15.83           C
+ATOM   2320  C   GLY A 124       9.306   9.567  -2.567  1.00 17.62           C
+ATOM   2321  O   GLY A 124      10.048  10.415  -3.078  1.00 20.39           O
+ATOM   2322  H   GLY A 124       9.012   6.895  -1.383  1.00 20.15           H
+ATOM   2323  HA2 GLY A 124      10.497   7.930  -2.517  1.00 19.02           H
+ATOM   2324  HA3 GLY A 124       9.522   7.945  -3.760  1.00 19.02           H
+ATOM   2325  N   LYS A 125       8.263   9.894  -1.790  1.00 15.61           N
+ATOM   2326  CA  LYS A 125       7.914  11.264  -1.448  1.00 17.61           C
+ATOM   2327  C   LYS A 125       7.964  11.538   0.049  1.00 16.61           C
+ATOM   2328  O   LYS A 125       8.189  12.680   0.447  1.00 16.34           O
+ATOM   2329  CB  LYS A 125       6.468  11.589  -1.922  1.00 23.77           C
+ATOM   2330  CG  LYS A 125       6.184  11.378  -3.382  1.00 41.57           C
+ATOM   2331  CD  LYS A 125       4.735  11.785  -3.779  1.00 50.11           C
+ATOM   2332  CE  LYS A 125       4.073  12.741  -2.781  1.00 53.84           C
+ATOM   2333  NZ  LYS A 125       2.784  13.309  -3.283  1.00 74.86           N
+ATOM   2334  H   LYS A 125       7.731   9.316  -1.442  1.00 18.76           H
+ATOM   2335  HA  LYS A 125       8.533  11.857  -1.901  1.00 21.15           H
+ATOM   2336  HB2 LYS A 125       5.853  11.025  -1.427  1.00 28.55           H
+ATOM   2337  HB3 LYS A 125       6.290  12.523  -1.728  1.00 28.55           H
+ATOM   2338  HG2 LYS A 125       6.800  11.916  -3.905  1.00 49.91           H
+ATOM   2339  HG3 LYS A 125       6.301  10.439  -3.594  1.00 49.91           H
+ATOM   2340  HD2 LYS A 125       4.759  12.227  -4.642  1.00 60.15           H
+ATOM   2341  HD3 LYS A 125       4.189  10.986  -3.831  1.00 60.15           H
+ATOM   2342  HE2 LYS A 125       3.888  12.261  -1.959  1.00 64.63           H
+ATOM   2343  HE3 LYS A 125       4.676  13.480  -2.605  1.00 64.63           H
+ATOM   2344  HZ1 LYS A 125       2.412  13.819  -2.656  1.00 89.86           H
+ATOM   2345  HZ2 LYS A 125       2.931  13.804  -4.008  1.00 89.86           H
+ATOM   2346  HZ3 LYS A 125       2.222  12.651  -3.491  1.00 89.86           H
+ATOM   2347  N   HIS A 126       7.695  10.537   0.880  1.00 14.13           N
+ATOM   2348  CA  HIS A 126       7.709  10.643   2.333  1.00 13.81           C
+ATOM   2349  C   HIS A 126       8.675   9.605   2.868  1.00 14.15           C
+ATOM   2350  O   HIS A 126       8.643   8.450   2.424  1.00 15.65           O
+ATOM   2351  CB  HIS A 126       6.307  10.410   2.926  1.00 14.27           C
+ATOM   2352  CG  HIS A 126       5.332  11.457   2.502  1.00 12.88           C
+ATOM   2353  ND1 HIS A 126       5.098  12.588   3.254  1.00 15.73           N
+ATOM   2354  CD2 HIS A 126       4.591  11.587   1.375  1.00 15.45           C
+ATOM   2355  CE1 HIS A 126       4.229  13.357   2.611  1.00 16.47           C
+ATOM   2356  NE2 HIS A 126       3.912  12.780   1.469  1.00 18.74           N
+ATOM   2357  H   HIS A 126       7.492   9.746   0.611  1.00 16.97           H
+ATOM   2358  HA  HIS A 126       8.003  11.528   2.600  1.00 16.59           H
+ATOM   2359  HB2 HIS A 126       5.975   9.549   2.628  1.00 17.15           H
+ATOM   2360  HB3 HIS A 126       6.365  10.426   3.894  1.00 17.15           H
+ATOM   2361  HD2 HIS A 126       4.550  10.982   0.670  1.00 18.56           H
+ATOM   2362  HE1 HIS A 126       3.898  14.171   2.916  1.00 19.78           H
+ATOM   2363  N  AVAL A 127       9.522  10.011   3.794  0.88 13.26           N
+ATOM   2364  CA AVAL A 127      10.548   9.140   4.368  0.88 13.91           C
+ATOM   2365  C  AVAL A 127       9.937   8.228   5.423  0.88 14.29           C
+ATOM   2366  O  AVAL A 127       9.408   8.698   6.429  0.88 14.64           O
+ATOM   2367  CB AVAL A 127      11.692   9.965   4.942  0.88 14.12           C
+ATOM   2368  CG1AVAL A 127      12.730   9.036   5.587  0.88 15.20           C
+ATOM   2369  CG2AVAL A 127      12.344  10.820   3.863  0.88 17.26           C
+ATOM   2370  H  AVAL A 127       9.530  10.807   4.120  0.88 15.94           H
+ATOM   2371  HA AVAL A 127      10.892   8.565   3.666  0.88 16.72           H
+ATOM   2372  HB AVAL A 127      11.338  10.563   5.619  0.88 16.97           H
+ATOM   2373 HG11AVAL A 127      13.454   9.573   5.947  0.88 18.26           H
+ATOM   2374 HG12AVAL A 127      12.305   8.533   6.299  0.88 18.26           H
+ATOM   2375 HG13AVAL A 127      13.073   8.429   4.912  0.88 18.26           H
+ATOM   2376 HG21AVAL A 127      13.081  11.315   4.254  0.88 20.74           H
+ATOM   2377 HG22AVAL A 127      12.673  10.242   3.157  0.88 20.74           H
+ATOM   2378 HG23AVAL A 127      11.685  11.436   3.506  0.88 20.74           H
+ATOM   2379  N  BVAL A 127       9.560  10.030   3.767  0.12 12.79           N
+ATOM   2380  CA BVAL A 127      10.628   9.176   4.284  0.12 14.19           C
+ATOM   2381  C  BVAL A 127      10.075   8.342   5.433  0.12 14.04           C
+ATOM   2382  O  BVAL A 127       9.805   8.859   6.519  0.12 11.08           O
+ATOM   2383  CB BVAL A 127      11.852   9.989   4.724  0.12 16.11           C
+ATOM   2384  CG1BVAL A 127      12.367  10.840   3.579  0.12 17.23           C
+ATOM   2385  CG2BVAL A 127      11.548  10.862   5.941  0.12 30.46           C
+ATOM   2386  H  BVAL A 127       9.564  10.823   4.100  0.12 15.37           H
+ATOM   2387  HA BVAL A 127      10.905   8.570   3.578  0.12 17.05           H
+ATOM   2388  HB BVAL A 127      12.546   9.363   4.983  0.12 19.36           H
+ATOM   2389 HG11BVAL A 127      13.156  11.322   3.873  0.12 20.70           H
+ATOM   2390 HG12BVAL A 127      12.592  10.263   2.832  0.12 20.70           H
+ATOM   2391 HG13BVAL A 127      11.676  11.468   3.315  0.12 20.70           H
+ATOM   2392 HG21BVAL A 127      12.278  11.488   6.071  0.12 36.58           H
+ATOM   2393 HG22BVAL A 127      10.722  11.346   5.784  0.12 36.58           H
+ATOM   2394 HG23BVAL A 127      11.456  10.294   6.722  0.12 36.58           H
+ATOM   2395  N  AVAL A 128       9.991   6.930   5.188  0.88 13.69           N
+ATOM   2396  CA AVAL A 128       9.578   5.914   6.147  0.88 13.32           C
+ATOM   2397  C  AVAL A 128      10.709   5.668   7.130  0.88 14.03           C
+ATOM   2398  O  AVAL A 128      11.859   5.464   6.720  0.88 16.38           O
+ATOM   2399  CB AVAL A 128       9.216   4.611   5.424  0.88 14.15           C
+ATOM   2400  CG1AVAL A 128       8.976   3.502   6.425  0.88 14.87           C
+ATOM   2401  CG2AVAL A 128       8.022   4.810   4.518  0.88 16.77           C
+ATOM   2402  H  AVAL A 128      10.274   6.594   4.449  0.88 16.45           H
+ATOM   2403  HA AVAL A 128       8.804   6.237   6.633  0.88 16.01           H
+ATOM   2404  HB AVAL A 128       9.960   4.345   4.861  0.88 17.00           H
+ATOM   2405 HG11AVAL A 128       8.582   2.743   5.967  0.88 17.87           H
+ATOM   2406 HG12AVAL A 128       9.824   3.245   6.820  0.88 17.87           H
+ATOM   2407 HG13AVAL A 128       8.373   3.823   7.113  0.88 17.87           H
+ATOM   2408 HG21AVAL A 128       7.829   3.976   4.063  0.88 20.15           H
+ATOM   2409 HG22AVAL A 128       7.260   5.079   5.054  0.88 20.15           H
+ATOM   2410 HG23AVAL A 128       8.230   5.501   3.869  0.88 20.15           H
+ATOM   2411  N  BVAL A 128       9.903   7.055   5.196  0.12 13.19           N
+ATOM   2412  CA BVAL A 128       9.472   6.156   6.255  0.12 15.74           C
+ATOM   2413  C  BVAL A 128      10.670   5.839   7.142  0.12 14.31           C
+ATOM   2414  O  BVAL A 128      11.820   5.766   6.685  0.12 16.68           O
+ATOM   2415  CB BVAL A 128       8.800   4.891   5.686  0.12 15.81           C
+ATOM   2416  CG1BVAL A 128       7.829   5.238   4.558  0.12 18.06           C
+ATOM   2417  CG2BVAL A 128       9.812   3.951   5.184  0.12 33.74           C
+ATOM   2418  H  BVAL A 128      10.027   6.677   4.434  0.12 15.86           H
+ATOM   2419  HA BVAL A 128       8.801   6.598   6.798  0.12 18.91           H
+ATOM   2420  HB BVAL A 128       8.301   4.472   6.403  0.12 18.99           H
+ATOM   2421 HG11BVAL A 128       7.444   4.419   4.210  0.12 21.69           H
+ATOM   2422 HG12BVAL A 128       7.128   5.809   4.909  0.12 21.69           H
+ATOM   2423 HG13BVAL A 128       8.312   5.701   3.856  0.12 21.69           H
+ATOM   2424 HG21BVAL A 128       9.369   3.246   4.687  0.12 40.51           H
+ATOM   2425 HG22BVAL A 128      10.426   4.428   4.604  0.12 40.51           H
+ATOM   2426 HG23BVAL A 128      10.294   3.574   5.937  0.12 40.51           H
+ATOM   2427  N   PHE A 129      10.399   5.665   8.425  1.00 14.47           N
+ATOM   2428  CA  PHE A 129      11.453   5.580   9.421  1.00 16.05           C
+ATOM   2429  C   PHE A 129      11.124   4.683  10.603  1.00 14.20           C
+ATOM   2430  O   PHE A 129      11.961   4.566  11.507  1.00 16.35           O
+ATOM   2431  CB  PHE A 129      11.856   6.989   9.887  1.00 15.90           C
+ATOM   2432  CG  PHE A 129      10.801   7.698  10.666  1.00 15.40           C
+ATOM   2433  CD1 PHE A 129       9.804   8.413  10.030  1.00 16.65           C
+ATOM   2434  CD2 PHE A 129      10.799   7.635  12.047  1.00 17.27           C
+ATOM   2435  CE1 PHE A 129       8.838   9.041  10.714  1.00 14.64           C
+ATOM   2436  CE2 PHE A 129       9.818   8.275  12.763  1.00 18.67           C
+ATOM   2437  CZ  PHE A 129       8.838   9.008  12.090  1.00 16.97           C
+ATOM   2438  HA  PHE A 129      12.237   5.188   9.005  1.00 19.28           H
+ATOM   2439  HB2 PHE A 129      12.641   6.916  10.451  1.00 19.10           H
+ATOM   2440  HB3 PHE A 129      12.058   7.528   9.106  1.00 19.10           H
+ATOM   2441  HD1 PHE A 129       9.804   8.460   9.101  1.00 20.00           H
+ATOM   2442  HD2 PHE A 129      11.463   7.159  12.492  1.00 20.75           H
+ATOM   2443  HE1 PHE A 129       8.169   9.500  10.259  1.00 17.59           H
+ATOM   2444  HE2 PHE A 129       9.807   8.222  13.691  1.00 22.43           H
+ATOM   2445  HZ  PHE A 129       8.188   9.470  12.569  1.00 20.39           H
+ATOM   2446  H  APHE A 129       9.600   5.710   8.742  0.88 17.39           H
+ATOM   2447  H  BPHE A 129       9.605   5.592   8.749  0.12 17.39           H
+ATOM   2448  N   GLY A 130       9.969   4.044  10.652  1.00 14.42           N
+ATOM   2449  CA  GLY A 130       9.650   3.206  11.796  1.00 15.77           C
+ATOM   2450  C   GLY A 130       8.397   2.412  11.543  1.00 14.09           C
+ATOM   2451  O   GLY A 130       7.763   2.521  10.498  1.00 16.25           O
+ATOM   2452  H   GLY A 130       9.361   4.076  10.045  1.00 17.33           H
+ATOM   2453  HA2 GLY A 130      10.381   2.591  11.965  1.00 18.95           H
+ATOM   2454  HA3 GLY A 130       9.515   3.761  12.580  1.00 18.95           H
+ATOM   2455  N   LYS A 131       8.015   1.617  12.541  1.00 16.36           N
+ATOM   2456  CA  LYS A 131       6.799   0.834  12.466  1.00 17.05           C
+ATOM   2457  C   LYS A 131       6.274   0.598  13.874  1.00 15.82           C
+ATOM   2458  O   LYS A 131       7.046   0.523  14.827  1.00 18.89           O
+ATOM   2459  CB  LYS A 131       7.019  -0.502  11.737  1.00 21.70           C
+ATOM   2460  CG  LYS A 131       7.738  -1.560  12.554  1.00 34.64           C
+ATOM   2461  CD  LYS A 131       7.732  -2.902  11.817  1.00 62.63           C
+ATOM   2462  CE  LYS A 131       8.503  -3.970  12.581  1.00 79.98           C
+ATOM   2463  NZ  LYS A 131       8.700  -5.204  11.767  1.00 93.60           N
+ATOM   2464  H   LYS A 131       8.450   1.518  13.276  1.00 19.66           H
+ATOM   2465  HA  LYS A 131       6.127   1.329  11.974  1.00 20.48           H
+ATOM   2466  HB2 LYS A 131       6.153  -0.863  11.489  1.00 26.06           H
+ATOM   2467  HB3 LYS A 131       7.549  -0.336  10.943  1.00 26.06           H
+ATOM   2468  HG2 LYS A 131       8.659  -1.290  12.698  1.00 41.59           H
+ATOM   2469  HG3 LYS A 131       7.289  -1.674  13.407  1.00 41.59           H
+ATOM   2470  HD2 LYS A 131       6.817  -3.206  11.712  1.00 75.18           H
+ATOM   2471  HD3 LYS A 131       8.147  -2.792  10.948  1.00 75.18           H
+ATOM   2472  HE2 LYS A 131       9.377  -3.623  12.822  1.00 95.99           H
+ATOM   2473  HE3 LYS A 131       8.010  -4.210  13.381  1.00 95.99           H
+ATOM   2474  HZ1 LYS A 131       9.158  -5.807  12.235  1.00112.34           H
+ATOM   2475  HZ2 LYS A 131       7.912  -5.550  11.543  1.00112.34           H
+ATOM   2476  HZ3 LYS A 131       9.152  -5.010  11.025  1.00112.34           H
+ATOM   2477  N   VAL A 132       4.958   0.457  13.972  1.00 16.23           N
+ATOM   2478  CA  VAL A 132       4.337   0.048  15.226  1.00 16.52           C
+ATOM   2479  C   VAL A 132       4.831  -1.344  15.579  1.00 20.27           C
+ATOM   2480  O   VAL A 132       4.807  -2.261  14.751  1.00 21.18           O
+ATOM   2481  CB  VAL A 132       2.811   0.066  15.085  1.00 17.64           C
+ATOM   2482  CG1 VAL A 132       2.140  -0.526  16.360  1.00 18.75           C
+ATOM   2483  CG2 VAL A 132       2.317   1.483  14.832  1.00 18.52           C
+ATOM   2484  H   VAL A 132       4.403   0.590  13.330  1.00 19.50           H
+ATOM   2485  HA  VAL A 132       4.589   0.665  15.931  1.00 19.84           H
+ATOM   2486  HB  VAL A 132       2.561  -0.483  14.326  1.00 21.19           H
+ATOM   2487 HG11 VAL A 132       1.178  -0.415  16.290  1.00 22.52           H
+ATOM   2488 HG12 VAL A 132       2.360  -1.468  16.424  1.00 22.52           H
+ATOM   2489 HG13 VAL A 132       2.471  -0.054  17.140  1.00 22.52           H
+ATOM   2490 HG21 VAL A 132       1.347   1.481  14.816  1.00 22.25           H
+ATOM   2491 HG22 VAL A 132       2.635   2.061  15.543  1.00 22.25           H
+ATOM   2492 HG23 VAL A 132       2.660   1.790  13.978  1.00 22.25           H
+ATOM   2493  N   LYS A 133       5.289  -1.497  16.809  1.00 17.78           N
+ATOM   2494  CA  LYS A 133       5.771  -2.759  17.372  1.00 22.08           C
+ATOM   2495  C   LYS A 133       4.725  -3.394  18.274  1.00 25.19           C
+ATOM   2496  O   LYS A 133       4.439  -4.586  18.151  1.00 29.52           O
+ATOM   2497  CB  LYS A 133       7.062  -2.468  18.138  1.00 27.40           C
+ATOM   2498  CG  LYS A 133       7.806  -3.669  18.658  1.00 47.48           C
+ATOM   2499  CD  LYS A 133       9.090  -3.197  19.342  1.00 51.01           C
+ATOM   2500  CE  LYS A 133      10.002  -4.345  19.739  1.00 75.66           C
+ATOM   2501  NZ  LYS A 133      11.242  -3.821  20.378  1.00 74.41           N
+ATOM   2502  H   LYS A 133       5.336  -0.851  17.375  1.00 21.36           H
+ATOM   2503  HA  LYS A 133       5.974  -3.403  16.675  1.00 26.52           H
+ATOM   2504  HB2 LYS A 133       7.664  -1.992  17.546  1.00 32.91           H
+ATOM   2505  HB3 LYS A 133       6.841  -1.914  18.903  1.00 32.91           H
+ATOM   2506  HG2 LYS A 133       7.260  -4.143  19.304  1.00 57.00           H
+ATOM   2507  HG3 LYS A 133       8.038  -4.258  17.923  1.00 57.00           H
+ATOM   2508  HD2 LYS A 133       9.580  -2.623  18.733  1.00 61.23           H
+ATOM   2509  HD3 LYS A 133       8.859  -2.707  20.146  1.00 61.23           H
+ATOM   2510  HE2 LYS A 133       9.546  -4.920  20.372  1.00 90.81           H
+ATOM   2511  HE3 LYS A 133      10.251  -4.852  18.950  1.00 90.81           H
+ATOM   2512  HZ1 LYS A 133      11.767  -4.496  20.623  1.00 89.31           H
+ATOM   2513  HZ2 LYS A 133      11.685  -3.304  19.804  1.00 89.31           H
+ATOM   2514  HZ3 LYS A 133      11.034  -3.341  21.098  1.00 89.31           H
+ATOM   2515  N   GLU A 134       4.177  -2.635  19.212  1.00 20.68           N
+ATOM   2516  CA  GLU A 134       3.113  -3.098  20.080  1.00 19.54           C
+ATOM   2517  C   GLU A 134       2.010  -2.068  20.085  1.00 19.48           C
+ATOM   2518  O   GLU A 134       2.270  -0.866  19.951  1.00 19.13           O
+ATOM   2519  CB  GLU A 134       3.542  -3.210  21.539  1.00 25.06           C
+ATOM   2520  CG  GLU A 134       4.697  -4.120  21.785  1.00 35.55           C
+ATOM   2521  CD  GLU A 134       5.051  -4.179  23.258  1.00 35.77           C
+ATOM   2522  OE1 GLU A 134       5.600  -3.187  23.776  1.00 44.11           O
+ATOM   2523  OE2 GLU A 134       4.761  -5.217  23.881  1.00 45.73           O
+ATOM   2524  H   GLU A 134       4.414  -1.823  19.367  1.00 24.84           H
+ATOM   2525  HA  GLU A 134       2.820  -3.961  19.747  1.00 23.48           H
+ATOM   2526  HB2 GLU A 134       3.794  -2.328  21.854  1.00 30.09           H
+ATOM   2527  HB3 GLU A 134       2.792  -3.546  22.055  1.00 30.09           H
+ATOM   2528  HG2 GLU A 134       4.469  -5.015  21.489  1.00 42.69           H
+ATOM   2529  HG3 GLU A 134       5.470  -3.796  21.297  1.00 42.69           H
+ATOM   2530  N   GLY A 135       0.782  -2.531  20.235  1.00 17.76           N
+ATOM   2531  CA  GLY A 135      -0.331  -1.636  20.352  1.00 16.57           C
+ATOM   2532  C   GLY A 135      -0.964  -1.195  19.056  1.00 17.79           C
+ATOM   2533  O   GLY A 135      -1.604  -0.144  19.018  1.00 18.58           O
+ATOM   2534  H   GLY A 135       0.575  -3.365  20.271  1.00 21.34           H
+ATOM   2535  HA2 GLY A 135      -1.020  -2.071  20.878  1.00 19.91           H
+ATOM   2536  HA3 GLY A 135      -0.034  -0.838  20.817  1.00 19.91           H
+ATOM   2537  N   MET A 136      -0.845  -1.972  17.988  1.00 17.43           N
+ATOM   2538  CA  MET A 136      -1.604  -1.630  16.791  1.00 16.67           C
+ATOM   2539  C   MET A 136      -3.084  -1.542  17.090  1.00 18.83           C
+ATOM   2540  O   MET A 136      -3.814  -0.767  16.457  1.00 19.61           O
+ATOM   2541  CB  MET A 136      -1.332  -2.669  15.703  1.00 21.72           C
+ATOM   2542  CG  MET A 136      -1.770  -2.206  14.335  1.00 24.21           C
+ATOM   2543  SD  MET A 136      -0.961  -0.691  13.715  1.00 24.14           S
+ATOM   2544  CE  MET A 136      -2.182  -0.144  12.519  1.00 31.35           C
+ATOM   2545  H   MET A 136      -0.353  -2.675  17.931  1.00 20.94           H
+ATOM   2546  HA  MET A 136      -1.308  -0.768  16.458  1.00 20.03           H
+ATOM   2547  HB2 MET A 136      -0.379  -2.848  15.669  1.00 26.09           H
+ATOM   2548  HB3 MET A 136      -1.816  -3.482  15.915  1.00 26.09           H
+ATOM   2549  HG2 MET A 136      -1.580  -2.914  13.699  1.00 29.08           H
+ATOM   2550  HG3 MET A 136      -2.723  -2.032  14.362  1.00 29.08           H
+ATOM   2551  HE1 MET A 136      -1.903   0.709  12.150  1.00 37.65           H
+ATOM   2552  HE2 MET A 136      -2.249  -0.804  11.812  1.00 37.65           H
+ATOM   2553  HE3 MET A 136      -3.039  -0.048  12.964  1.00 37.65           H
+ATOM   2554  N   ASN A 137      -3.566  -2.332  18.063  1.00 19.61           N
+ATOM   2555  CA  ASN A 137      -4.970  -2.269  18.437  1.00 17.36           C
+ATOM   2556  C   ASN A 137      -5.353  -0.912  18.998  1.00 16.44           C
+ATOM   2557  O   ASN A 137      -6.498  -0.479  18.839  1.00 19.47           O
+ATOM   2558  CB  ASN A 137      -5.306  -3.349  19.484  1.00 19.34           C
+ATOM   2559  CG  ASN A 137      -4.411  -3.283  20.721  1.00 19.19           C
+ATOM   2560  OD1 ASN A 137      -3.174  -3.285  20.628  1.00 20.34           O
+ATOM   2561  ND2 ASN A 137      -5.040  -3.243  21.886  1.00 23.29           N
+ATOM   2562  H   ASN A 137      -3.101  -2.901  18.510  1.00 23.55           H
+ATOM   2563  HA  ASN A 137      -5.489  -2.437  17.636  1.00 20.86           H
+ATOM   2564  HB2 ASN A 137      -6.225  -3.233  19.773  1.00 23.23           H
+ATOM   2565  HB3 ASN A 137      -5.193  -4.225  19.081  1.00 23.23           H
+ATOM   2566 HD21 ASN A 137      -4.588  -3.205  22.617  1.00 27.97           H
+ATOM   2567 HD22 ASN A 137      -5.899  -3.256  21.912  1.00 27.97           H
+ATOM   2568  N   ILE A 138      -4.400  -0.221  19.631  1.00 16.13           N
+ATOM   2569  CA  ILE A 138      -4.652   1.124  20.142  1.00 16.53           C
+ATOM   2570  C   ILE A 138      -4.740   2.128  18.995  1.00 16.25           C
+ATOM   2571  O   ILE A 138      -5.574   3.040  19.014  1.00 17.45           O
+ATOM   2572  CB  ILE A 138      -3.568   1.503  21.160  1.00 17.79           C
+ATOM   2573  CG1 ILE A 138      -3.570   0.521  22.353  1.00 19.07           C
+ATOM   2574  CG2 ILE A 138      -3.749   2.930  21.686  1.00 19.56           C
+ATOM   2575  CD1 ILE A 138      -4.900   0.396  23.057  1.00 21.08           C
+ATOM   2576  H   ILE A 138      -3.603  -0.509  19.777  1.00 19.37           H
+ATOM   2577  HA  ILE A 138      -5.509   1.133  20.597  1.00 19.86           H
+ATOM   2578  HB  ILE A 138      -2.720   1.451  20.693  1.00 21.37           H
+ATOM   2579 HG12 ILE A 138      -3.327  -0.360  22.028  1.00 22.91           H
+ATOM   2580 HG13 ILE A 138      -2.920   0.825  23.006  1.00 22.91           H
+ATOM   2581 HG21 ILE A 138      -3.047   3.122  22.327  1.00 23.49           H
+ATOM   2582 HG22 ILE A 138      -3.696   3.550  20.942  1.00 23.49           H
+ATOM   2583 HG23 ILE A 138      -4.617   3.001  22.114  1.00 23.49           H
+ATOM   2584 HD11 ILE A 138      -4.804  -0.209  23.809  1.00 25.32           H
+ATOM   2585 HD12 ILE A 138      -5.175   1.272  23.370  1.00 25.32           H
+ATOM   2586 HD13 ILE A 138      -5.556   0.047  22.434  1.00 25.32           H
+ATOM   2587  N   VAL A 139      -3.900   1.960  17.979  1.00 16.04           N
+ATOM   2588  CA  VAL A 139      -4.042   2.778  16.765  1.00 17.01           C
+ATOM   2589  C   VAL A 139      -5.394   2.549  16.112  1.00 17.58           C
+ATOM   2590  O   VAL A 139      -6.050   3.491  15.660  1.00 19.46           O
+ATOM   2591  CB  VAL A 139      -2.893   2.473  15.808  1.00 16.24           C
+ATOM   2592  CG1 VAL A 139      -3.082   3.290  14.514  1.00 19.83           C
+ATOM   2593  CG2 VAL A 139      -1.571   2.795  16.443  1.00 18.94           C
+ATOM   2594  H   VAL A 139      -3.253   1.394  17.961  1.00 19.27           H
+ATOM   2595  HA  VAL A 139      -3.998   3.715  17.013  1.00 20.44           H
+ATOM   2596  HB  VAL A 139      -2.892   1.528  15.592  1.00 19.51           H
+ATOM   2597 HG11 VAL A 139      -2.315   3.149  13.937  1.00 23.82           H
+ATOM   2598 HG12 VAL A 139      -3.890   2.991  14.068  1.00 23.82           H
+ATOM   2599 HG13 VAL A 139      -3.157   4.229  14.741  1.00 23.82           H
+ATOM   2600 HG21 VAL A 139      -0.868   2.675  15.786  1.00 22.75           H
+ATOM   2601 HG22 VAL A 139      -1.584   3.715  16.751  1.00 22.75           H
+ATOM   2602 HG23 VAL A 139      -1.428   2.197  17.194  1.00 22.75           H
+ATOM   2603  N   GLU A 140      -5.846   1.291  16.044  1.00 16.60           N
+ATOM   2604  CA  GLU A 140      -7.154   1.024  15.460  1.00 19.33           C
+ATOM   2605  C   GLU A 140      -8.262   1.687  16.267  1.00 18.14           C
+ATOM   2606  O   GLU A 140      -9.228   2.218  15.703  1.00 21.53           O
+ATOM   2607  CB  GLU A 140      -7.369  -0.485  15.344  1.00 23.29           C
+ATOM   2608  CG  GLU A 140      -6.401  -1.153  14.366  1.00 25.28           C
+ATOM   2609  CD  GLU A 140      -6.380  -2.676  14.473  1.00 44.92           C
+ATOM   2610  OE1 GLU A 140      -7.026  -3.243  15.392  1.00 37.93           O
+ATOM   2611  OE2 GLU A 140      -5.692  -3.299  13.638  1.00 38.72           O
+ATOM   2612  H   GLU A 140      -5.423   0.596  16.324  1.00 19.94           H
+ATOM   2613  HA  GLU A 140      -7.190   1.394  14.564  1.00 23.22           H
+ATOM   2614  HB2 GLU A 140      -7.239  -0.889  16.216  1.00 27.97           H
+ATOM   2615  HB3 GLU A 140      -8.272  -0.651  15.032  1.00 27.97           H
+ATOM   2616  HG2 GLU A 140      -6.662  -0.923  13.461  1.00 30.36           H
+ATOM   2617  HG3 GLU A 140      -5.503  -0.831  14.545  1.00 30.36           H
+ATOM   2618  N   ALA A 141      -8.126   1.706  17.600  1.00 18.41           N
+ATOM   2619  CA  ALA A 141      -9.121   2.384  18.422  1.00 19.43           C
+ATOM   2620  C   ALA A 141      -9.115   3.888  18.188  1.00 21.05           C
+ATOM   2621  O   ALA A 141     -10.177   4.513  18.158  1.00 23.20           O
+ATOM   2622  CB  ALA A 141      -8.873   2.056  19.895  1.00 22.85           C
+ATOM   2623  H   ALA A 141      -7.482   1.342  18.038  1.00 22.11           H
+ATOM   2624  HA  ALA A 141     -10.003   2.060  18.183  1.00 23.34           H
+ATOM   2625  HB1 ALA A 141      -9.542   2.504  20.435  1.00 27.44           H
+ATOM   2626  HB2 ALA A 141      -8.935   1.096  20.020  1.00 27.44           H
+ATOM   2627  HB3 ALA A 141      -7.987   2.365  20.142  1.00 27.44           H
+ATOM   2628  N   MET A 142      -7.925   4.485  18.030  1.00 20.00           N
+ATOM   2629  CA  MET A 142      -7.841   5.917  17.742  1.00 20.26           C
+ATOM   2630  C   MET A 142      -8.542   6.247  16.443  1.00 20.34           C
+ATOM   2631  O   MET A 142      -9.171   7.302  16.316  1.00 20.43           O
+ATOM   2632  CB  MET A 142      -6.374   6.340  17.565  1.00 24.60           C
+ATOM   2633  CG  MET A 142      -5.583   6.346  18.802  1.00 24.67           C
+ATOM   2634  SD  MET A 142      -3.820   6.446  18.432  1.00 26.88           S
+ATOM   2635  CE  MET A 142      -3.784   7.975  17.551  1.00 24.99           C
+ATOM   2636  H   MET A 142      -7.165   4.087  18.085  1.00 24.03           H
+ATOM   2637  HA  MET A 142      -8.238   6.386  18.492  1.00 24.33           H
+ATOM   2638  HB2 MET A 142      -5.948   5.724  16.949  1.00 29.54           H
+ATOM   2639  HB3 MET A 142      -6.355   7.239  17.202  1.00 29.54           H
+ATOM   2640  HG2 MET A 142      -5.829   7.114  19.341  1.00 29.62           H
+ATOM   2641  HG3 MET A 142      -5.748   5.527  19.296  1.00 29.62           H
+ATOM   2642  HE1 MET A 142      -2.866   8.186  17.322  1.00 30.01           H
+ATOM   2643  HE2 MET A 142      -4.314   7.887  16.743  1.00 30.01           H
+ATOM   2644  HE3 MET A 142      -4.154   8.673  18.114  1.00 30.01           H
+ATOM   2645  N   GLU A 143      -8.385   5.376  15.453  1.00 22.42           N
+ATOM   2646  CA  GLU A 143      -8.964   5.596  14.140  1.00 24.71           C
+ATOM   2647  C   GLU A 143     -10.446   5.880  14.221  1.00 26.48           C
+ATOM   2648  O   GLU A 143     -10.976   6.650  13.412  1.00 30.45           O
+ATOM   2649  CB  GLU A 143      -8.715   4.353  13.291  1.00 32.54           C
+ATOM   2650  CG  GLU A 143      -8.261   4.669  11.940  1.00 37.44           C
+ATOM   2651  CD  GLU A 143      -8.124   3.454  11.069  1.00 30.96           C
+ATOM   2652  OE1 GLU A 143      -8.259   2.311  11.547  1.00 34.22           O
+ATOM   2653  OE2 GLU A 143      -7.883   3.659   9.885  1.00 29.19           O
+ATOM   2654  H   GLU A 143      -7.942   4.642  15.518  1.00 26.93           H
+ATOM   2655  HA  GLU A 143      -8.544   6.363  13.720  1.00 29.67           H
+ATOM   2656  HB2 GLU A 143      -8.032   3.812  13.718  1.00 39.07           H
+ATOM   2657  HB3 GLU A 143      -9.540   3.849  13.220  1.00 39.07           H
+ATOM   2658  HG2 GLU A 143      -8.902   5.266  11.524  1.00 44.95           H
+ATOM   2659  HG3 GLU A 143      -7.393   5.099  11.992  1.00 44.95           H
+ATOM   2660  N   ARG A 144     -11.142   5.279  15.185  1.00 24.39           N
+ATOM   2661  CA  ARG A 144     -12.591   5.417  15.265  1.00 28.14           C
+ATOM   2662  C   ARG A 144     -13.034   6.808  15.684  1.00 28.78           C
+ATOM   2663  O   ARG A 144     -14.218   7.133  15.538  1.00 33.99           O
+ATOM   2664  CB  ARG A 144     -13.154   4.327  16.183  1.00 36.47           C
+ATOM   2665  CG  ARG A 144     -12.990   2.916  15.600  1.00 49.09           C
+ATOM   2666  CD  ARG A 144     -13.793   1.866  16.353  1.00 81.08           C
+ATOM   2667  NE  ARG A 144     -13.172   1.462  17.610  1.00 88.79           N
+ATOM   2668  CZ  ARG A 144     -12.343   0.434  17.748  1.00 76.07           C
+ATOM   2669  NH1 ARG A 144     -11.978  -0.308  16.713  1.00 73.68           N
+ATOM   2670  NH2 ARG A 144     -11.868   0.142  18.956  1.00 70.22           N
+ATOM   2671  H   ARG A 144     -10.798   4.788  15.801  1.00 29.30           H
+ATOM   2672  HA  ARG A 144     -12.983   5.274  14.390  1.00 33.79           H
+ATOM   2673  HB2 ARG A 144     -12.687   4.358  17.033  1.00 43.79           H
+ATOM   2674  HB3 ARG A 144     -14.101   4.488  16.319  1.00 43.79           H
+ATOM   2675  HG2 ARG A 144     -13.290   2.918  14.678  1.00 58.94           H
+ATOM   2676  HG3 ARG A 144     -12.054   2.663  15.643  1.00 58.94           H
+ATOM   2677  HD2 ARG A 144     -14.670   2.227  16.556  1.00 97.32           H
+ATOM   2678  HD3 ARG A 144     -13.880   1.077  15.795  1.00 97.32           H
+ATOM   2679  HE  ARG A 144     -13.357   1.922  18.312  1.00106.57           H
+ATOM   2680 HH11 ARG A 144     -12.280  -0.129  15.928  1.00 88.44           H
+ATOM   2681 HH12 ARG A 144     -11.440  -0.969  16.826  1.00 88.44           H
+ATOM   2682 HH21 ARG A 144     -12.099   0.617  19.635  1.00 84.29           H
+ATOM   2683 HH22 ARG A 144     -11.330  -0.521  19.058  1.00 84.29           H
+ATOM   2684  N   PHE A 145     -12.125   7.653  16.162  1.00 21.07           N
+ATOM   2685  CA  PHE A 145     -12.438   9.036  16.480  1.00 19.83           C
+ATOM   2686  C   PHE A 145     -12.145   9.995  15.334  1.00 20.29           C
+ATOM   2687  O   PHE A 145     -12.248  11.209  15.522  1.00 23.94           O
+ATOM   2688  CB  PHE A 145     -11.670   9.456  17.734  1.00 21.01           C
+ATOM   2689  CG  PHE A 145     -12.035   8.638  18.953  1.00 22.62           C
+ATOM   2690  CD1 PHE A 145     -13.236   8.857  19.605  1.00 28.79           C
+ATOM   2691  CD2 PHE A 145     -11.208   7.637  19.407  1.00 25.00           C
+ATOM   2692  CE1 PHE A 145     -13.585   8.093  20.708  1.00 29.85           C
+ATOM   2693  CE2 PHE A 145     -11.564   6.868  20.527  1.00 26.21           C
+ATOM   2694  CZ  PHE A 145     -12.748   7.105  21.156  1.00 30.05           C
+ATOM   2695  H   PHE A 145     -11.305   7.442  16.313  1.00 25.30           H
+ATOM   2696  HA  PHE A 145     -13.386   9.112  16.673  1.00 23.82           H
+ATOM   2697  HB2 PHE A 145     -10.720   9.345  17.574  1.00 25.23           H
+ATOM   2698  HB3 PHE A 145     -11.868  10.385  17.928  1.00 25.23           H
+ATOM   2699  HD1 PHE A 145     -13.813   9.520  19.301  1.00 34.57           H
+ATOM   2700  HD2 PHE A 145     -10.406   7.468  18.968  1.00 30.03           H
+ATOM   2701  HE1 PHE A 145     -14.390   8.252  21.145  1.00 35.84           H
+ATOM   2702  HE2 PHE A 145     -10.994   6.201  20.837  1.00 31.48           H
+ATOM   2703  HZ  PHE A 145     -12.990   6.593  21.895  1.00 36.08           H
+ATOM   2704  N   GLY A 146     -11.738   9.473  14.176  1.00 21.39           N
+ATOM   2705  CA  GLY A 146     -11.520  10.280  12.997  1.00 20.20           C
+ATOM   2706  C   GLY A 146     -12.774  10.404  12.164  1.00 23.85           C
+ATOM   2707  O   GLY A 146     -13.867   9.987  12.552  1.00 24.16           O
+ATOM   2708  H   GLY A 146     -11.579   8.636  14.056  1.00 25.69           H
+ATOM   2709  HA2 GLY A 146     -11.236  11.169  13.262  1.00 24.27           H
+ATOM   2710  HA3 GLY A 146     -10.827   9.876  12.452  1.00 24.27           H
+ATOM   2711  N   SER A 147     -12.599  10.985  10.986  1.00 19.29           N
+ATOM   2712  CA  SER A 147     -13.704  11.248  10.076  1.00 19.17           C
+ATOM   2713  C   SER A 147     -13.130  11.419   8.681  1.00 22.18           C
+ATOM   2714  O   SER A 147     -11.920  11.537   8.493  1.00 18.87           O
+ATOM   2715  CB  SER A 147     -14.454  12.515  10.482  1.00 21.21           C
+ATOM   2716  OG  SER A 147     -13.647  13.641  10.319  1.00 24.08           O
+ATOM   2717  H   SER A 147     -11.835  11.240  10.685  1.00 23.17           H
+ATOM   2718  HA  SER A 147     -14.316  10.496  10.084  1.00 23.03           H
+ATOM   2719  HB2 SER A 147     -15.242  12.608   9.924  1.00 25.48           H
+ATOM   2720  HB3 SER A 147     -14.713  12.444  11.414  1.00 25.48           H
+ATOM   2721  HG  SER A 147     -14.012  14.310  10.674  1.00 28.92           H
+ATOM   2722  N   ARG A 148     -14.026  11.474   7.695  1.00 20.05           N
+ATOM   2723  CA  ARG A 148     -13.586  11.553   6.310  1.00 19.08           C
+ATOM   2724  C   ARG A 148     -12.743  12.784   6.038  1.00 19.30           C
+ATOM   2725  O   ARG A 148     -11.797  12.713   5.246  1.00 21.89           O
+ATOM   2726  CB  ARG A 148     -14.784  11.572   5.369  1.00 19.98           C
+ATOM   2727  CG  ARG A 148     -15.497  10.275   5.210  1.00 24.52           C
+ATOM   2728  CD  ARG A 148     -14.704   9.251   4.428  1.00 29.30           C
+ATOM   2729  NE  ARG A 148     -14.252   9.756   3.133  1.00 23.65           N
+ATOM   2730  CZ  ARG A 148     -14.970   9.764   2.013  1.00 23.81           C
+ATOM   2731  NH1 ARG A 148     -16.210   9.295   1.971  1.00 27.68           N
+ATOM   2732  NH2 ARG A 148     -14.418  10.239   0.898  1.00 22.08           N
+ATOM   2733  H   ARG A 148     -14.879  11.466   7.802  1.00 24.08           H
+ATOM   2734  HA  ARG A 148     -13.049  10.763   6.139  1.00 22.92           H
+ATOM   2735  HB2 ARG A 148     -15.428  12.215   5.707  1.00 24.00           H
+ATOM   2736  HB3 ARG A 148     -14.477  11.842   4.489  1.00 24.00           H
+ATOM   2737  HG2 ARG A 148     -15.676   9.905   6.088  1.00 29.44           H
+ATOM   2738  HG3 ARG A 148     -16.330  10.430   4.738  1.00 29.44           H
+ATOM   2739  HD2 ARG A 148     -13.920   8.999   4.941  1.00 35.18           H
+ATOM   2740  HD3 ARG A 148     -15.261   8.473   4.269  1.00 35.18           H
+ATOM   2741  HE  ARG A 148     -13.455  10.074   3.091  1.00 28.40           H
+ATOM   2742 HH11 ARG A 148     -16.572   8.974   2.681  1.00 33.24           H
+ATOM   2743 HH12 ARG A 148     -16.651   9.313   1.233  1.00 33.24           H
+ATOM   2744 HH21 ARG A 148     -13.610  10.534   0.910  1.00 26.52           H
+ATOM   2745 HH22 ARG A 148     -14.869  10.251   0.166  1.00 26.52           H
+ATOM   2746  N   ASN A 149     -13.071  13.929   6.639  1.00 18.42           N
+ATOM   2747  CA  ASN A 149     -12.293  15.145   6.421  1.00 20.56           C
+ATOM   2748  C   ASN A 149     -11.131  15.287   7.399  1.00 18.86           C
+ATOM   2749  O   ASN A 149     -10.387  16.266   7.325  1.00 24.13           O
+ATOM   2750  CB  ASN A 149     -13.182  16.407   6.395  1.00 23.52           C
+ATOM   2751  CG  ASN A 149     -13.773  16.761   7.742  1.00 32.58           C
+ATOM   2752  OD1 ASN A 149     -13.391  16.225   8.771  1.00 26.40           O
+ATOM   2753  ND2 ASN A 149     -14.719  17.691   7.737  1.00 34.02           N
+ATOM   2754  H   ASN A 149     -13.737  14.023   7.175  1.00 22.13           H
+ATOM   2755  HA  ASN A 149     -11.908  15.102   5.531  1.00 24.70           H
+ATOM   2756  HB2 ASN A 149     -12.647  17.160   6.098  1.00 28.25           H
+ATOM   2757  HB3 ASN A 149     -13.917  16.258   5.779  1.00 28.25           H
+ATOM   2758 HD21 ASN A 149     -15.090  17.931   8.474  1.00 40.84           H
+ATOM   2759 HD22 ASN A 149     -14.961  18.053   6.995  1.00 40.84           H
+ATOM   2760  N   GLY A 150     -10.939  14.308   8.282  1.00 18.02           N
+ATOM   2761  CA  GLY A 150      -9.808  14.302   9.189  1.00 19.36           C
+ATOM   2762  C   GLY A 150     -10.049  14.888  10.555  1.00 18.65           C
+ATOM   2763  O   GLY A 150      -9.249  14.656  11.459  1.00 18.55           O
+ATOM   2764  H   GLY A 150     -11.460  13.629   8.372  1.00 21.64           H
+ATOM   2765  HA2 GLY A 150      -9.521  13.384   9.313  1.00 23.25           H
+ATOM   2766  HA3 GLY A 150      -9.087  14.806   8.780  1.00 23.25           H
+ATOM   2767  N   LYS A 151     -11.141  15.610  10.761  1.00 19.37           N
+ATOM   2768  CA  LYS A 151     -11.388  16.176  12.072  1.00 20.97           C
+ATOM   2769  C   LYS A 151     -11.745  15.071  13.050  1.00 19.00           C
+ATOM   2770  O   LYS A 151     -12.448  14.121  12.725  1.00 22.63           O
+ATOM   2771  CB  LYS A 151     -12.536  17.189  12.001  1.00 27.29           C
+ATOM   2772  CG  LYS A 151     -12.189  18.453  11.238  1.00 53.39           C
+ATOM   2773  CD  LYS A 151     -13.388  19.394  11.133  1.00 88.63           C
+ATOM   2774  CE  LYS A 151     -13.056  20.625  10.297  1.00 95.27           C
+ATOM   2775  NZ  LYS A 151     -14.218  21.548  10.138  1.00 92.94           N
+ATOM   2776  H   LYS A 151     -11.742  15.781  10.169  1.00 23.26           H
+ATOM   2777  HA  LYS A 151     -10.593  16.635  12.386  1.00 25.19           H
+ATOM   2778  HB2 LYS A 151     -13.292  16.773  11.559  1.00 32.77           H
+ATOM   2779  HB3 LYS A 151     -12.780  17.447  12.904  1.00 32.77           H
+ATOM   2780  HG2 LYS A 151     -11.475  18.920  11.698  1.00 64.09           H
+ATOM   2781  HG3 LYS A 151     -11.908  18.217  10.340  1.00 64.09           H
+ATOM   2782  HD2 LYS A 151     -14.127  18.929  10.711  1.00106.38           H
+ATOM   2783  HD3 LYS A 151     -13.645  19.688  12.021  1.00106.38           H
+ATOM   2784  HE2 LYS A 151     -12.341  21.117  10.730  1.00114.35           H
+ATOM   2785  HE3 LYS A 151     -12.776  20.340   9.413  1.00114.35           H
+ATOM   2786  HZ1 LYS A 151     -13.978  22.258   9.658  1.00111.55           H
+ATOM   2787  HZ2 LYS A 151     -14.884  21.129   9.721  1.00111.55           H
+ATOM   2788  HZ3 LYS A 151     -14.502  21.821  10.936  1.00111.55           H
+ATOM   2789  N   THR A 152     -11.249  15.209  14.273  1.00 22.49           N
+ATOM   2790  CA  THR A 152     -11.495  14.209  15.293  1.00 21.80           C
+ATOM   2791  C   THR A 152     -12.685  14.628  16.147  1.00 21.68           C
+ATOM   2792  O   THR A 152     -12.920  15.818  16.367  1.00 24.11           O
+ATOM   2793  CB  THR A 152     -10.247  13.973  16.144  1.00 20.95           C
+ATOM   2794  OG1 THR A 152      -9.851  15.160  16.821  1.00 23.02           O
+ATOM   2795  CG2 THR A 152      -9.073  13.533  15.263  1.00 21.49           C
+ATOM   2796  H   THR A 152     -10.769  15.874  14.532  1.00 27.02           H
+ATOM   2797  HA  THR A 152     -11.714  13.358  14.882  1.00 26.18           H
+ATOM   2798  HB  THR A 152     -10.458  13.284  16.794  1.00 25.16           H
+ATOM   2799  HG1 THR A 152     -10.426  15.368  17.398  1.00 27.65           H
+ATOM   2800 HG21 THR A 152      -8.282  13.397  15.808  1.00 25.81           H
+ATOM   2801 HG22 THR A 152      -9.290  12.704  14.810  1.00 25.81           H
+ATOM   2802 HG23 THR A 152      -8.883  14.214  14.599  1.00 25.81           H
+ATOM   2803  N   SER A 153     -13.444  13.637  16.597  1.00 23.87           N
+ATOM   2804  CA  SER A 153     -14.639  13.900  17.388  1.00 24.91           C
+ATOM   2805  C   SER A 153     -14.323  14.068  18.865  1.00 31.10           C
+ATOM   2806  O   SER A 153     -15.143  14.624  19.610  1.00 28.95           O
+ATOM   2807  CB  SER A 153     -15.639  12.772  17.167  1.00 27.55           C
+ATOM   2808  OG  SER A 153     -15.089  11.513  17.493  1.00 33.61           O
+ATOM   2809  H   SER A 153     -13.288  12.803  16.457  1.00 28.67           H
+ATOM   2810  HA  SER A 153     -15.066  14.722  17.099  1.00 29.92           H
+ATOM   2811  HB2 SER A 153     -16.415  12.929  17.727  1.00 33.09           H
+ATOM   2812  HB3 SER A 153     -15.900  12.765  16.233  1.00 33.09           H
+ATOM   2813  HG  SER A 153     -15.611  10.900  17.252  1.00 40.35           H
+ATOM   2814  N   LYS A 154     -13.152  13.612  19.292  1.00 24.22           N
+ATOM   2815  CA  LYS A 154     -12.632  13.835  20.625  1.00 23.87           C
+ATOM   2816  C   LYS A 154     -11.170  14.210  20.465  1.00 24.39           C
+ATOM   2817  O   LYS A 154     -10.565  13.970  19.416  1.00 23.15           O
+ATOM   2818  CB  LYS A 154     -12.779  12.589  21.498  1.00 27.36           C
+ATOM   2819  CG  LYS A 154     -14.243  12.273  21.817  1.00 34.24           C
+ATOM   2820  CD  LYS A 154     -14.373  11.273  22.945  1.00 49.27           C
+ATOM   2821  CE  LYS A 154     -15.759  11.320  23.568  1.00 73.65           C
+ATOM   2822  NZ  LYS A 154     -16.807  10.856  22.623  1.00 88.72           N
+ATOM   2823  H   LYS A 154     -12.618  13.150  18.801  1.00 29.09           H
+ATOM   2824  HA  LYS A 154     -13.104  14.555  21.071  1.00 28.67           H
+ATOM   2825  HB2 LYS A 154     -12.400  11.828  21.031  1.00 32.85           H
+ATOM   2826  HB3 LYS A 154     -12.311  12.732  22.335  1.00 32.85           H
+ATOM   2827  HG2 LYS A 154     -14.696  13.089  22.082  1.00 41.11           H
+ATOM   2828  HG3 LYS A 154     -14.668  11.899  21.030  1.00 41.11           H
+ATOM   2829  HD2 LYS A 154     -14.222  10.378  22.601  1.00 59.14           H
+ATOM   2830  HD3 LYS A 154     -13.721  11.477  23.633  1.00 59.14           H
+ATOM   2831  HE2 LYS A 154     -15.778  10.744  24.348  1.00 88.40           H
+ATOM   2832  HE3 LYS A 154     -15.964  12.233  23.824  1.00 88.40           H
+ATOM   2833  HZ1 LYS A 154     -17.605  10.887  23.014  1.00106.48           H
+ATOM   2834  HZ2 LYS A 154     -16.818  11.378  21.902  1.00106.48           H
+ATOM   2835  HZ3 LYS A 154     -16.641  10.019  22.371  1.00106.48           H
+ATOM   2836  N   LYS A 155     -10.612  14.827  21.492  1.00 21.41           N
+ATOM   2837  CA  LYS A 155      -9.228  15.271  21.458  1.00 20.97           C
+ATOM   2838  C   LYS A 155      -8.330  14.087  21.786  1.00 21.59           C
+ATOM   2839  O   LYS A 155      -8.441  13.490  22.856  1.00 21.74           O
+ATOM   2840  CB  LYS A 155      -9.019  16.382  22.482  1.00 25.08           C
+ATOM   2841  CG  LYS A 155      -7.777  17.195  22.248  1.00 35.15           C
+ATOM   2842  CD  LYS A 155      -7.967  18.096  21.025  1.00 56.77           C
+ATOM   2843  CE  LYS A 155      -6.842  19.100  20.862  1.00 52.25           C
+ATOM   2844  NZ  LYS A 155      -6.183  19.390  22.167  1.00 89.98           N
+ATOM   2845  H   LYS A 155     -11.017  15.003  22.230  1.00 25.72           H
+ATOM   2846  HA  LYS A 155      -9.006  15.609  20.576  1.00 25.19           H
+ATOM   2847  HB2 LYS A 155      -9.779  16.984  22.448  1.00 30.12           H
+ATOM   2848  HB3 LYS A 155      -8.951  15.984  23.364  1.00 30.12           H
+ATOM   2849  HG2 LYS A 155      -7.600  17.752  23.021  1.00 42.21           H
+ATOM   2850  HG3 LYS A 155      -7.025  16.604  22.085  1.00 42.21           H
+ATOM   2851  HD2 LYS A 155      -7.997  17.546  20.227  1.00 68.15           H
+ATOM   2852  HD3 LYS A 155      -8.798  18.588  21.120  1.00 68.15           H
+ATOM   2853  HE2 LYS A 155      -6.176  18.741  20.256  1.00 62.73           H
+ATOM   2854  HE3 LYS A 155      -7.200  19.930  20.509  1.00 62.73           H
+ATOM   2855  HZ1 LYS A 155      -5.514  19.966  22.048  1.00108.00           H
+ATOM   2856  HZ2 LYS A 155      -6.771  19.744  22.733  1.00108.00           H
+ATOM   2857  HZ3 LYS A 155      -5.859  18.639  22.518  1.00108.00           H
+ATOM   2858  N  AILE A 156      -7.477  13.728  20.840  0.71 17.82           N
+ATOM   2859  CA AILE A 156      -6.607  12.565  20.931  0.71 17.13           C
+ATOM   2860  C  AILE A 156      -5.208  13.091  21.216  0.71 17.96           C
+ATOM   2861  O  AILE A 156      -4.587  13.716  20.346  0.71 16.27           O
+ATOM   2862  CB AILE A 156      -6.634  11.778  19.615  0.71 17.75           C
+ATOM   2863  CG1AILE A 156      -8.073  11.503  19.162  0.71 21.05           C
+ATOM   2864  CG2AILE A 156      -5.852  10.482  19.763  0.71 21.21           C
+ATOM   2865  CD1AILE A 156      -8.919  10.768  20.168  0.71 24.00           C
+ATOM   2866  H  AILE A 156      -7.380  14.160  20.103  0.71 21.41           H
+ATOM   2867  HA AILE A 156      -6.883  11.986  21.658  0.71 20.58           H
+ATOM   2868  HB AILE A 156      -6.211  12.319  18.930  0.71 21.33           H
+ATOM   2869 HG12AILE A 156      -8.506  12.352  18.980  0.71 25.28           H
+ATOM   2870 HG13AILE A 156      -8.045  10.965  18.355  0.71 25.28           H
+ATOM   2871 HG21AILE A 156      -5.922   9.975  18.939  0.71 25.48           H
+ATOM   2872 HG22AILE A 156      -4.923  10.693  19.945  0.71 25.48           H
+ATOM   2873 HG23AILE A 156      -6.225   9.971  20.499  0.71 25.48           H
+ATOM   2874 HD11AILE A 156      -9.786  10.581  19.774  0.71 28.82           H
+ATOM   2875 HD12AILE A 156      -8.477   9.938  20.405  0.71 28.82           H
+ATOM   2876 HD13AILE A 156      -9.026  11.324  20.956  0.71 28.82           H
+ATOM   2877  N  BILE A 156      -7.387  13.778  20.906  0.29 17.66           N
+ATOM   2878  CA BILE A 156      -6.447  12.679  21.112  0.29 17.24           C
+ATOM   2879  C  BILE A 156      -5.072  13.279  21.380  0.29 16.48           C
+ATOM   2880  O  BILE A 156      -4.595  14.113  20.597  0.29 18.66           O
+ATOM   2881  CB BILE A 156      -6.444  11.736  19.897  0.29 19.73           C
+ATOM   2882  CG1BILE A 156      -7.845  11.141  19.705  0.29 21.10           C
+ATOM   2883  CG2BILE A 156      -5.420  10.622  20.069  0.29 17.20           C
+ATOM   2884  CD1BILE A 156      -8.017  10.341  18.453  0.29 27.83           C
+ATOM   2885  H  BILE A 156      -7.267  14.200  20.166  0.29 21.21           H
+ATOM   2886  HA BILE A 156      -6.694  12.160  21.893  0.29 20.71           H
+ATOM   2887  HB BILE A 156      -6.200  12.250  19.111  0.29 23.69           H
+ATOM   2888 HG12BILE A 156      -8.037  10.556  20.455  0.29 25.34           H
+ATOM   2889 HG13BILE A 156      -8.488  11.868  19.679  0.29 25.34           H
+ATOM   2890 HG21BILE A 156      -5.423  10.065  19.276  0.29 20.66           H
+ATOM   2891 HG22BILE A 156      -4.542  11.017  20.192  0.29 20.66           H
+ATOM   2892 HG23BILE A 156      -5.656  10.093  20.847  0.29 20.66           H
+ATOM   2893 HD11BILE A 156      -8.927  10.007  18.415  0.29 33.42           H
+ATOM   2894 HD12BILE A 156      -7.841  10.911  17.688  0.29 33.42           H
+ATOM   2895 HD13BILE A 156      -7.392   9.600  18.464  0.29 33.42           H
+ATOM   2896  N  ATHR A 157      -4.692  12.847  22.409  0.71 17.22           N
+ATOM   2897  CA ATHR A 157      -3.423  13.415  22.815  0.71 15.94           C
+ATOM   2898  C  ATHR A 157      -2.394  12.355  23.184  0.71 16.35           C
+ATOM   2899  O  ATHR A 157      -2.705  11.195  23.482  0.71 16.42           O
+ATOM   2900  CB ATHR A 157      -3.558  14.421  23.965  0.71 21.38           C
+ATOM   2901  OG1ATHR A 157      -4.051  13.760  25.131  0.71 19.30           O
+ATOM   2902  CG2ATHR A 157      -4.523  15.536  23.583  0.71 24.08           C
+ATOM   2903  H  ATHR A 157      -5.063  12.351  23.005  0.71 20.68           H
+ATOM   2904  HA ATHR A 157      -3.079  13.885  22.039  0.71 19.15           H
+ATOM   2905  HB ATHR A 157      -2.690  14.810  24.155  0.71 25.68           H
+ATOM   2906  HG1ATHR A 157      -4.786  13.389  24.962  0.71 23.19           H
+ATOM   2907 HG21ATHR A 157      -4.613  16.162  24.318  0.71 28.91           H
+ATOM   2908 HG22ATHR A 157      -4.191  16.010  22.804  0.71 28.91           H
+ATOM   2909 HG23ATHR A 157      -5.395  15.164  23.377  0.71 28.91           H
+ATOM   2910  N  BTHR A 157      -4.440  12.862  22.483  0.29 15.89           N
+ATOM   2911  CA BTHR A 157      -3.208  13.471  22.966  0.29 17.37           C
+ATOM   2912  C  BTHR A 157      -2.180  12.429  23.393  0.29 15.56           C
+ATOM   2913  O  BTHR A 157      -2.523  11.380  23.946  0.29 15.75           O
+ATOM   2914  CB BTHR A 157      -3.496  14.396  24.157  0.29 20.75           C
+ATOM   2915  OG1BTHR A 157      -4.256  15.528  23.716  0.29 25.21           O
+ATOM   2916  CG2BTHR A 157      -2.208  14.869  24.789  0.29 24.84           C
+ATOM   2917  H  BTHR A 157      -4.716  12.213  22.975  0.29 19.09           H
+ATOM   2918  HA BTHR A 157      -2.814  13.968  22.233  0.29 20.87           H
+ATOM   2919  HB BTHR A 157      -4.002  13.910  24.827  0.29 24.92           H
+ATOM   2920  HG1BTHR A 157      -4.376  16.060  24.355  0.29 30.28           H
+ATOM   2921 HG21BTHR A 157      -2.379  15.642  25.350  0.29 29.84           H
+ATOM   2922 HG22BTHR A 157      -1.827  14.163  25.334  0.29 29.84           H
+ATOM   2923 HG23BTHR A 157      -1.571  15.114  24.100  0.29 29.84           H
+ATOM   2924  N  AILE A 158      -1.144  12.791  23.135  0.71 15.52           N
+ATOM   2925  CA AILE A 158      -0.014  12.034  23.641  0.71 15.79           C
+ATOM   2926  C  AILE A 158       0.185  12.481  25.086  0.71 17.50           C
+ATOM   2927  O  AILE A 158       0.744  13.546  25.355  0.71 17.02           O
+ATOM   2928  CB AILE A 158       1.219  12.263  22.772  0.71 14.32           C
+ATOM   2929  CG1AILE A 158       0.921  11.868  21.324  0.71 16.95           C
+ATOM   2930  CG2AILE A 158       2.396  11.464  23.316  0.71 19.88           C
+ATOM   2931  CD1AILE A 158       1.976  12.336  20.321  0.71 19.66           C
+ATOM   2932  H  AILE A 158      -0.918  13.550  22.800  0.71 18.64           H
+ATOM   2933  HA AILE A 158      -0.205  11.083  23.646  0.71 18.97           H
+ATOM   2934  HB AILE A 158       1.448  13.206  22.792  0.71 17.21           H
+ATOM   2935 HG12AILE A 158       0.871  10.901  21.270  0.71 20.36           H
+ATOM   2936 HG13AILE A 158       0.072  12.259  21.063  0.71 20.36           H
+ATOM   2937 HG21AILE A 158       3.153  11.571  22.719  0.71 23.88           H
+ATOM   2938 HG22AILE A 158       2.621  11.796  24.199  0.71 23.88           H
+ATOM   2939 HG23AILE A 158       2.145  10.529  23.369  0.71 23.88           H
+ATOM   2940 HD11AILE A 158       1.745  12.001  19.441  0.71 23.61           H
+ATOM   2941 HD12AILE A 158       1.995  13.305  20.312  0.71 23.61           H
+ATOM   2942 HD13AILE A 158       2.841  11.990  20.590  0.71 23.61           H
+ATOM   2943  N  BILE A 158      -0.910  12.736  23.136  0.29 16.47           N
+ATOM   2944  CA BILE A 158       0.211  11.967  23.666  0.29 15.71           C
+ATOM   2945  C  BILE A 158       0.407  12.347  25.126  0.29 15.15           C
+ATOM   2946  O  BILE A 158       1.215  13.230  25.445  0.29 18.23           O
+ATOM   2947  CB BILE A 158       1.490  12.233  22.855  0.29 17.75           C
+ATOM   2948  CG1BILE A 158       1.278  11.844  21.395  0.29 17.25           C
+ATOM   2949  CG2BILE A 158       2.666  11.468  23.451  0.29 20.03           C
+ATOM   2950  CD1BILE A 158       2.482  12.087  20.503  0.29 12.89           C
+ATOM   2951  H  BILE A 158      -0.667  13.401  22.647  0.29 19.79           H
+ATOM   2952  HA BILE A 158       0.009  11.020  23.613  0.29 18.88           H
+ATOM   2953  HB BILE A 158       1.691  13.181  22.896  0.29 21.33           H
+ATOM   2954 HG12BILE A 158       1.069  10.897  21.354  0.29 20.73           H
+ATOM   2955 HG13BILE A 158       0.540  12.362  21.040  0.29 20.73           H
+ATOM   2956 HG21BILE A 158       3.459  11.647  22.922  0.29 24.06           H
+ATOM   2957 HG22BILE A 158       2.804  11.763  24.364  0.29 24.06           H
+ATOM   2958 HG23BILE A 158       2.465  10.519  23.436  0.29 24.06           H
+ATOM   2959 HD11BILE A 158       2.242  11.883  19.586  0.29 15.49           H
+ATOM   2960 HD12BILE A 158       2.747  13.018  20.577  0.29 15.49           H
+ATOM   2961 HD13BILE A 158       3.209  11.513  20.790  0.29 15.49           H
+ATOM   2962  N   ALA A 159      -0.337  11.693  26.023  1.00 16.57           N
+ATOM   2963  CA  ALA A 159      -0.270  12.068  27.433  1.00 17.88           C
+ATOM   2964  C   ALA A 159       1.124  11.872  28.003  1.00 18.84           C
+ATOM   2965  O   ALA A 159       1.556  12.630  28.880  1.00 22.99           O
+ATOM   2966  CB  ALA A 159      -1.278  11.244  28.224  1.00 20.73           C
+ATOM   2967  HA  ALA A 159      -0.498  13.007  27.521  1.00 21.48           H
+ATOM   2968  HB1 ALA A 159      -1.202  11.470  29.165  1.00 24.90           H
+ATOM   2969  HB2 ALA A 159      -2.171  11.448  27.906  1.00 24.90           H
+ATOM   2970  HB3 ALA A 159      -1.087  10.302  28.094  1.00 24.90           H
+ATOM   2971  H  AALA A 159      -0.731  10.944  25.872  0.71 19.91           H
+ATOM   2972  H  BALA A 159      -0.873  11.045  25.845  0.29 19.91           H
+ATOM   2973  N   ASP A 160       1.857  10.871  27.527  1.00 16.75           N
+ATOM   2974  CA  ASP A 160       3.239  10.663  27.923  1.00 18.19           C
+ATOM   2975  C   ASP A 160       3.941   9.962  26.775  1.00 16.89           C
+ATOM   2976  O   ASP A 160       3.310   9.351  25.909  1.00 16.83           O
+ATOM   2977  CB  ASP A 160       3.342   9.821  29.212  1.00 19.58           C
+ATOM   2978  CG  ASP A 160       4.688   9.947  29.910  1.00 22.09           C
+ATOM   2979  OD1 ASP A 160       5.508  10.806  29.567  1.00 23.96           O
+ATOM   2980  OD2 ASP A 160       4.912   9.131  30.837  1.00 32.92           O
+ATOM   2981  H   ASP A 160       1.570  10.289  26.962  1.00 20.12           H
+ATOM   2982  HA  ASP A 160       3.670  11.516  28.093  1.00 21.85           H
+ATOM   2983  HB2 ASP A 160       2.657  10.113  29.833  1.00 23.52           H
+ATOM   2984  HB3 ASP A 160       3.210   8.887  28.988  1.00 23.52           H
+ATOM   2985  N   CYS A 161       5.254  10.090  26.755  1.00 16.77           N
+ATOM   2986  CA  CYS A 161       6.058   9.439  25.736  1.00 17.75           C
+ATOM   2987  C   CYS A 161       7.499   9.367  26.203  1.00 16.94           C
+ATOM   2988  O   CYS A 161       7.931  10.111  27.088  1.00 21.87           O
+ATOM   2989  CB  CYS A 161       5.952  10.164  24.382  1.00 17.20           C
+ATOM   2990  SG  CYS A 161       6.198  11.962  24.393  1.00 19.46           S
+ATOM   2991  H   CYS A 161       5.708  10.551  27.322  1.00 20.14           H
+ATOM   2992  HA  CYS A 161       5.741   8.530  25.618  1.00 21.33           H
+ATOM   2993  HB2 CYS A 161       6.622   9.790  23.788  1.00 20.66           H
+ATOM   2994  HB3 CYS A 161       5.065  10.002  24.024  1.00 20.66           H
+ATOM   2995  HG  CYS A 161       7.314  12.202  24.763  1.00 23.37           H
+ATOM   2996  N   GLY A 162       8.241   8.468  25.582  1.00 20.66           N
+ATOM   2997  CA  GLY A 162       9.626   8.297  25.947  1.00 20.97           C
+ATOM   2998  C   GLY A 162      10.211   7.087  25.258  1.00 21.52           C
+ATOM   2999  O   GLY A 162       9.631   6.533  24.327  1.00 21.45           O
+ATOM   3000  H   GLY A 162       7.965   7.951  24.953  1.00 24.81           H
+ATOM   3001  HA2 GLY A 162      10.134   9.081  25.685  1.00 25.19           H
+ATOM   3002  HA3 GLY A 162       9.701   8.178  26.906  1.00 25.19           H
+ATOM   3003  N   GLN A 163      11.374   6.687  25.748  1.00 24.18           N
+ATOM   3004  CA  GLN A 163      12.123   5.588  25.164  1.00 23.27           C
+ATOM   3005  C   GLN A 163      12.037   4.372  26.079  1.00 26.21           C
+ATOM   3006  O   GLN A 163      12.163   4.501  27.305  1.00 31.85           O
+ATOM   3007  CB  GLN A 163      13.569   6.019  24.946  1.00 25.02           C
+ATOM   3008  CG  GLN A 163      14.400   5.014  24.220  1.00 27.80           C
+ATOM   3009  CD  GLN A 163      15.684   5.599  23.676  1.00 24.54           C
+ATOM   3010  OE1 GLN A 163      15.953   6.790  23.821  1.00 27.20           O
+ATOM   3011  NE2 GLN A 163      16.487   4.753  23.053  1.00 30.61           N
+ATOM   3012  H   GLN A 163      11.756   7.044  26.430  1.00 29.04           H
+ATOM   3013  HA  GLN A 163      11.744   5.326  24.310  1.00 27.95           H
+ATOM   3014  HB2 GLN A 163      13.574   6.837  24.425  1.00 30.05           H
+ATOM   3015  HB3 GLN A 163      13.982   6.173  25.810  1.00 30.05           H
+ATOM   3016  HG2 GLN A 163      14.633   4.296  24.829  1.00 33.38           H
+ATOM   3017  HG3 GLN A 163      13.891   4.663  23.473  1.00 33.38           H
+ATOM   3018 HE21 GLN A 163      17.232   5.030  22.724  1.00 36.76           H
+ATOM   3019 HE22 GLN A 163      16.265   3.925  22.978  1.00 36.76           H
+ATOM   3020  N   LEU A 164      11.790   3.208  25.484  1.00 26.11           N
+ATOM   3021  CA  LEU A 164      11.824   1.933  26.200  1.00 28.20           C
+ATOM   3022  C   LEU A 164      13.158   1.235  25.941  1.00 34.74           C
+ATOM   3023  O   LEU A 164      13.750   0.694  26.878  1.00 48.89           O
+ATOM   3024  CB  LEU A 164      10.686   1.028  25.747  1.00 31.34           C
+ATOM   3025  CG  LEU A 164       9.263   1.458  26.087  1.00 36.44           C
+ATOM   3026  CD1 LEU A 164       8.270   0.466  25.508  1.00 37.69           C
+ATOM   3027  CD2 LEU A 164       9.068   1.586  27.582  1.00 39.04           C
+ATOM   3028  H   LEU A 164      11.596   3.127  24.650  1.00 31.36           H
+ATOM   3029  HA  LEU A 164      11.718   2.093  27.150  1.00 33.87           H
+ATOM   3030  HB2 LEU A 164      10.733   0.953  24.781  1.00 37.63           H
+ATOM   3031  HB3 LEU A 164      10.820   0.157  26.154  1.00 37.63           H
+ATOM   3032  HG  LEU A 164       9.100   2.330  25.696  1.00 43.75           H
+ATOM   3033 HD11 LEU A 164       7.373   0.732  25.764  1.00 45.25           H
+ATOM   3034 HD12 LEU A 164       8.352   0.465  24.542  1.00 45.25           H
+ATOM   3035 HD13 LEU A 164       8.466  -0.417  25.858  1.00 45.25           H
+ATOM   3036 HD21 LEU A 164       8.149   1.841  27.759  1.00 46.87           H
+ATOM   3037 HD22 LEU A 164       9.262   0.733  28.000  1.00 46.87           H
+ATOM   3038 HD23 LEU A 164       9.671   2.266  27.921  1.00 46.87           H
+TER
+HETATM 3039  O   HOH A 166      10.332  16.592   2.777  1.00 16.45           O
+HETATM 3040  O   HOH A 167      14.332  12.529   6.191  1.00 17.12           O
+HETATM 3041  O   HOH A 168      -0.340  17.550  15.758  1.00 18.18           O
+HETATM 3042  O   HOH A 169       9.608  13.057   4.027  1.00 17.58           O
+HETATM 3043  O   HOH A 170       9.838  14.735  -0.417  1.00 18.55           O
+HETATM 3044  O   HOH A 171      13.623   5.059   4.330  1.00 20.25           O
+HETATM 3045  O   HOH A 172       9.104   6.216   0.654  1.00 19.08           O
+HETATM 3046  O   HOH A 173       7.342  16.871   9.241  1.00 18.66           O
+HETATM 3047  O   HOH A 174      -0.375  19.490  19.375  1.00 20.58           O
+HETATM 3048  O   HOH A 175      -7.366  15.231  18.320  1.00 21.17           O
+HETATM 3049  O   HOH A 176       1.194  14.783  18.136  1.00 20.01           O
+HETATM 3050  O   HOH A 177       8.373  14.948  24.600  1.00 21.57           O
+HETATM 3051  O   HOH A 178       6.621  19.871  11.294  1.00 23.66           O
+HETATM 3052  O   HOH A 179      13.430  14.639  -2.053  1.00 22.07           O
+HETATM 3053  O   HOH A 180       1.683   2.143   4.328  1.00 22.81           O
+HETATM 3054  O   HOH A 181      17.112  14.751  -0.045  1.00 21.37           O
+HETATM 3055  O   HOH A 182      -4.808  25.114  16.819  1.00 23.80           O
+HETATM 3056  O   HOH A 183      13.798  16.878  22.369  1.00 25.91           O
+HETATM 3057  O   HOH A 184      -6.857  13.848  25.303  1.00 23.98           O
+HETATM 3058  O   HOH A 185       4.671   0.293  -0.996  1.00 26.16           O
+HETATM 3059  O   HOH A 186       2.746  32.581  16.475  1.00 25.36           O
+HETATM 3060  O   HOH A 187      -1.801  11.214   0.100  1.00 25.30           O
+HETATM 3061  O   HOH A 188      -2.196  -5.739  22.216  1.00 27.40           O
+HETATM 3062  O   HOH A 189      -2.348  18.489   8.505  1.00 30.01           O
+HETATM 3063  O   HOH A 190      -9.827  13.614   3.456  1.00 28.02           O
+HETATM 3064  O   HOH A 191       0.326  -5.318  20.978  1.00 29.12           O
+HETATM 3065  O   HOH A 192       2.339  15.528   4.461  1.00 26.34           O
+HETATM 3066  O   HOH A 193      -9.030  17.318  14.558  1.00 30.27           O
+HETATM 3067  O   HOH A 194       7.466  20.774  23.516  1.00 28.90           O
+HETATM 3068  O   HOH A 195      18.484   7.210  17.193  1.00 32.62           O
+HETATM 3069  O   HOH A 196     -11.752  10.925   3.121  1.00 25.97           O
+HETATM 3070  O   HOH A 197       3.754  16.908   0.611  1.00 29.12           O
+HETATM 3071  O   HOH A 198       8.767  17.498  25.701  1.00 33.31           O
+HETATM 3072  O   HOH A 199      12.231   9.397  -4.676  1.00 29.48           O
+HETATM 3073  O   HOH A 200      19.857   7.333  14.816  1.00 31.89           O
+HETATM 3074  O   HOH A 201       8.683  -0.691   4.914  1.00 36.13           O
+HETATM 3075  O   HOH A 202       4.352  19.276  23.212  1.00 31.42           O
+HETATM 3076  O   HOH A 203      12.379   8.311  28.004  1.00 31.15           O
+HETATM 3077  O   HOH A 204      10.274  -1.426   2.418  1.00 34.09           O
+HETATM 3078  O   HOH A 205      -2.826  28.251  11.978  1.00 37.98           O
+HETATM 3079  O   HOH A 206     -16.940  10.875   8.283  1.00 33.32           O
+HETATM 3080  O   HOH A 207      16.949   6.627  -1.547  1.00 33.16           O
+HETATM 3081  O   HOH A 208       5.173   9.024  -4.983  1.00 39.13           O
+HETATM 3082  O   HOH A 209      20.910   7.556   3.805  1.00 35.46           O
+HETATM 3083  O   HOH A 210      -7.915  -2.843  22.146  1.00 37.99           O
+HETATM 3084  O   HOH A 211      -4.189  -1.668   2.838  1.00 41.05           O
+HETATM 3085  O   HOH A 212       8.619  13.186  26.960  1.00 31.23           O
+HETATM 3086  O   HOH A 213     -12.238   3.507  19.912  1.00 35.85           O
+HETATM 3087  O   HOH A 214      10.969  22.337  -0.900  1.00 35.99           O
+HETATM 3088  O   HOH A 215      20.726  12.977   5.376  1.00 37.57           O
+HETATM 3089  O   HOH A 216       5.827  26.838  14.795  1.00 44.62           O
+HETATM 3090  O   HOH A 217     -10.218   1.112  13.271  1.00 40.90           O
+HETATM 3091  O   HOH A 218      -5.291  -0.746  10.218  1.00 46.64           O
+HETATM 3092  O   HOH A 219      -7.549  18.068  17.835  1.00 40.25           O
+HETATM 3093  O   HOH A 220       0.151  19.248   7.664  1.00 41.66           O
+HETATM 3094  O   HOH A 221     -18.198   8.172   3.648  1.00 43.72           O
+HETATM 3095  O   HOH A 222       1.031  -4.380  17.472  1.00 38.20           O
+HETATM 3096  O   HOH A 223      21.715   8.566   6.370  1.00 36.60           O
+HETATM 3097  O   HOH A 224      -8.934  -1.967  19.460  1.00 40.68           O
+HETATM 3098  O   HOH A 225       2.027  14.036   0.000  1.00 39.31           O
+HETATM 3099  O   HOH A 226      -2.895  18.867  22.903  1.00 45.18           O
+HETATM 3100  O   HOH A 227       2.303  34.390  14.428  1.00 39.84           O
+HETATM 3101  O   HOH A 228      -6.820  25.753  13.917  1.00 43.04           O
+HETATM 3102  O   HOH A 229       0.776  15.310  29.119  1.00 41.72           O
+HETATM 3103  O   HOH A 230      20.192  19.321   9.034  1.00 45.72           O
+HETATM 3104  O   HOH A 231      15.963  21.046   4.245  1.00 38.21           O
+HETATM 3105  O   HOH A 232      -8.717   2.525   2.929  1.00 36.33           O
+HETATM 3106  O   HOH A 233      18.606  20.446   5.822  1.00 37.81           O
+HETATM 3107  O   HOH A 234       4.783  -7.176  19.453  1.00 44.15           O
+HETATM 3108  O   HOH A 235      20.822   3.730   5.080  1.00 41.19           O
+HETATM 3109  O   HOH A 236      19.699   5.489  18.957  1.00 43.04           O
+HETATM 3110  O   HOH A 237      18.235  21.408   8.905  1.00 37.34           O
+HETATM 3111  O   HOH A 238      -8.562   0.849  26.284  1.00 42.43           O
+HETATM 3112  O   HOH A 239       6.618   1.687  -4.599  1.00 41.44           O
+HETATM 3113  O   HOH A 240       6.990   2.029  31.242  1.00 47.42           O
+HETATM 3114  O   HOH A 241      15.992  26.551  11.234  1.00 47.87           O
+HETATM 3115  O   HOH A 242       0.515   7.746  30.929  1.00 45.00           O
+HETATM 3116  O   HOH A 243       3.549   6.774  31.087  1.00 43.87           O
+HETATM 3117  O   HOH A 244      -6.230  20.872  11.445  1.00 43.92           O
+HETATM 3118  O   HOH A 245      -7.264  16.377  26.061  1.00 40.49           O
+HETATM 3119  O   HOH A 246      -5.018   2.274   0.681  1.00 45.10           O
+HETATM 3120  O   HOH A 247      -3.048  14.566  27.412  1.00 41.08           O
+HETATM 3121  O   HOH A 248     -15.460  10.070  14.858  1.00 41.59           O
+HETATM 3122  O   HOH A 249      20.404  13.991  19.214  1.00 45.60           O
+HETATM 3123  O   HOH A 250     -13.028   9.841  26.577  1.00 43.64           O
+HETATM 3124  O   HOH A 251       6.421  18.828  25.596  1.00 44.23           O
+HETATM 3125  O   HOH A 252      -0.596  12.425   2.218  1.00 40.38           O
+HETATM 3126  O   HOH A 253      14.964  23.271  16.242  1.00 43.26           O
+HETATM 3127  O   HOH A 254       5.926  19.162   8.351  1.00 40.42           O
+HETATM 3128  O   HOH A 255      21.499  12.699  13.885  1.00 36.20           O
+HETATM 3129  O   HOH A 256      15.734  13.120  -2.263  1.00 28.36           O
+HETATM 3130  O   HOH A 257      -1.695  -5.300  18.455  1.00 44.59           O
+HETATM 3131  O   HOH A 258       4.881  -1.045  24.863  1.00 39.33           O
+HETATM 3132  O   HOH A 259      19.010   5.233  21.773  1.00 45.71           O
+HETATM 3133  O   HOH A 260     -12.182   2.430  11.757  1.00 49.29           O
+HETATM 3134  O   HOH A 261     -16.060  14.222   7.700  1.00 43.50           O
+HETATM 3135  O   HOH A 262     -11.932   2.878  22.407  1.00 52.83           O
+HETATM 3136  O   HOH A 263       9.335  -2.973   0.533  1.00 47.55           O
+HETATM 3137  O   HOH A 264      15.205   1.969  23.060  1.00 28.57           O
+HETATM 3138  O   HOH A 265       3.374  30.006  15.340  1.00 36.21           O
+HETATM 3139  O   HOH A 266       1.182  10.994  -4.263  1.00 46.22           O
+HETATM 3140  O   HOH A 267       3.828  -3.544   6.451  1.00 46.98           O
+HETATM 3141  O   HOH A 268       6.940  20.401   6.337  1.00 43.97           O
+HETATM 3142  O   HOH A 269      20.606   0.506  15.058  1.00 45.65           O
+HETATM 3143  O   HOH A 270       1.983  -3.757   7.792  1.00 50.24           O
+HETATM 3144  O   HOH A 271      -7.798   1.004   8.739  1.00 49.20           O
+HETATM 3145  O   HOH A 272      11.402   5.957   2.849  1.00 17.35           O
+HETATM 3146  O   HOH A 273     -14.150   4.846  12.172  1.00 50.24           O
+HETATM 3147  O   HOH A 274      -7.775  18.023  10.865  1.00 38.22           O
+HETATM 3148  O   HOH A 275      14.990  21.068  -1.944  1.00 24.26           O
+HETATM 3149  O   HOH A 276     -15.961  15.650  10.378  1.00 37.93           O
+HETATM 3150  O   HOH A 277      22.244  11.426   7.177  1.00 44.34           O
+HETATM 3151  O   HOH A 278      12.576   6.923  -4.645  1.00 46.38           O
+HETATM 3152  O   HOH A 279     -15.243  14.386  13.611  1.00 39.47           O
+HETATM 3153  O   HOH A 280      -8.952  -0.929  23.930  1.00 54.73           O
+HETATM 3154  O   HOH A 281     -13.437  16.977  22.849  1.00 47.77           O
+HETATM 3155  O   HOH A 282      -6.341  23.074  18.083  1.00 44.12           O
+HETATM 3156  O   HOH A 283       4.100  36.830  13.986  1.00 46.96           O
+HETATM 3157  O   HOH A 284       7.809  -2.818  22.967  1.00 57.51           O
+HETATM 3158  O   HOH A 285     -12.741   7.205   6.164  1.00 38.56           O
+HETATM 3159  O   HOH A 286     -14.757   7.616   7.959  1.00 41.55           O
+HETATM 3160  O   HOH A 287      14.901  -1.113  21.221  1.00 46.76           O
+HETATM 3161  O   HOH A 288      10.070  27.132   8.946  1.00 63.15           O
+HETATM 3162  O   HOH A 289       0.009  -4.689   3.486  1.00 50.19           O
+HETATM 3163  O   HOH A 290       7.148  24.196   1.292  1.00 46.85           O
+HETATM 3164  O   HOH A 291      19.367  10.503  -0.200  1.00 52.66           O
+HETATM 3165  O   HOH A 292       4.505  -2.516   9.952  1.00 50.88           O
+HETATM 3166  O   HOH A 293       3.467  -2.697  12.372  1.00 36.81           O
+HETATM 3167  O   HOH A 294      -2.055  18.433  26.366  1.00 45.57           O
+HETATM 3168  O   HOH A 295      24.479   6.009  12.456  1.00 51.32           O
+HETATM 3169  O   HOH A 296      15.830  24.716   8.774  1.00 41.91           O
+HETATM 3170  O   HOH A 297      13.079  -1.477   1.102  1.00 48.10           O
+END

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -33,7 +33,7 @@ class TestQFitProtein:
         # Prepare args
         args = [
             "./example/3K0N.mtz",  # mapfile, using relative directory from tests/
-            "./example/3K0N.pdb",  # structurefile, using relative directory from tests/
+            "./example/3K0N_refine.pdb",  # structurefile, using relative directory from tests/
             "-l", "2FOFCWT,PH2FOFCWT",
         ]
 

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -78,4 +78,4 @@ class TestQFitProtein:
         multiconformer = qfit._run_qfit_residue_parallel()
         mconformer_list = list(multiconformer.residues)
         print(mconformer_list)  # If we fail, this gets printed.
-        assert len(mconformer_list) == 5  # Expect: 3*Ser99, 2*Phe113
+        assert len(mconformer_list) == 4  # Expect: 3*Ser99, 2*Phe113


### PR DESCRIPTION
This PR is updating the PDB 3K0N that is run for the tests. Due to some slight mis-modeling of M61, it was causing F113 to crash into it. We will now be using a re-refined 3K0N PDB that models M61 along with a few other residues better into the density. 

### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

-