### PR TITLE
Add in B-factor sampling

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -308,7 +308,7 @@ class _BaseQFit:
         """
         new_coor = []
         new_bfactor =[]
-        multiplication_factors = [1.0, 1.2, 1.3, 1.5, 0.9, 0.7, 0.5] 
+        multiplication_factors = [1.0, 1.3, 1.5, 0.9, 0.5] 
         for coor, b, multi in zip(self._coor_set, self._bs, multiplication_factors):
             new_coor.append(coor)
             new_bfactor.append(b * multi)
@@ -1373,6 +1373,7 @@ class QFitSegment(_BaseQFit):
                         f"fragment {_resi_list[0].shortcode}--{_resi_list[-1].shortcode}"
                     )
                     fragments = fragments[mask]
+                    self.sample_b()
                     self._occupancies = self._occupancies[mask]
                     self._coor_set = [fragment.coor for fragment in fragments]
                     self._bs = [fragment.b for fragment in fragments]

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -301,7 +301,7 @@ class _BaseQFit:
         return solver.obj_value
 
     
-        def sample_b(self):
+    def sample_b(self):
         """
         This funciton will take in coor set and b-factors for all conformers selected after QP (to help save time) 
         and multiple each atom's b-factor by it multiplication factor.  
@@ -310,8 +310,8 @@ class _BaseQFit:
         new_bfactor =[]
         multiplication_factors = [1.0, 1.2, 1.3, 1.5, 0.9, 0.7, 0.5] 
         for coor, b, multi in zip(self._coor_set, self._bs, multiplication_factors):
-                new_coor.append(coor)
-                new_bfactor.append(b * multi)
+            new_coor.append(coor)
+            new_bfactor.append(b * multi)
         self._coor_set = new_coor
         self._bs = new_bfactor
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -256,14 +256,6 @@ class _BaseQFit:
             np.maximum(model, self.options.bulk_solvent_level, out=model)
             self._transformer.reset(full=True)
 
-    def _randomize_bs(self, bs, atoms):
-        bs_copy = copy.deepcopy(bs)
-        if self.options.randomize_b:
-            mask = np.in1d(self.conformer.name, atoms)
-            add = 0.2 * self.prng.random(bs_copy[mask].shape[0]) - 0.1
-            bs_copy[mask] += np.multiply(bs[mask], add)
-        return bs_copy
-
     def _solve(
         self,
         cardinality=None,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -81,6 +81,9 @@ class QFitOptions:
         self.sample_backbone_step = 0.1
         self.sample_backbone_sigma = 0.125
 
+        #Sample B-factors 
+        self.sample_bfactors = True
+        
         # N-CA-CB angle sampling
         self.sample_angle = True
         self.sample_angle_range = 7.5

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -300,6 +300,21 @@ class _BaseQFit:
         # residual = 0
         return solver.obj_value
 
+    
+        def sample_b(self):
+        """
+        This funciton will take in coor set and b-factors for all conformers selected after QP (to help save time) 
+        and multiple each atom's b-factor by it multiplication factor.  
+        """
+        new_coor = []
+        new_bfactor =[]
+        multiplication_factors = [1.0, 1.2, 1.3, 1.5, 0.9, 0.7, 0.5] 
+        for coor, b, multi in zip(self._coor_set, self._bs, multiplication_factors):
+                new_coor.append(coor)
+                new_bfactor.append(b * multi)
+        self._coor_set = new_coor
+        self._bs = new_bfactor
+
     def _zero_out_most_similar_conformer(self):
         """Zero-out the lowest occupancy, most similar conformer.
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -55,7 +55,6 @@ class QFitOptions:
         self.omit = False
         self.scale = True
         self.scale_rmask = 1.0
-        self.randomize_b = False
         self.bulk_solvent_level = 0.3
 
         # Sampling options
@@ -248,8 +247,6 @@ class _BaseQFit:
         for n, coor in enumerate(self._coor_set):
             self.conformer.coor = coor
             self.conformer.b = self._bs[n]
-            if self.options.randomize_b:
-                self._update_transformer(self.conformer)
             self._transformer.density()
             model = self._models[n]
             model[:] = self._transformer.xmap.array[mask]
@@ -940,7 +937,7 @@ class QFitRotamericResidue(_BaseQFit):
         iteration = 0
         new_bs = []
         for b in self._bs:
-            new_bs.append(self._randomize_bs(b, ["N", "CA", "C", "O", "CB", "H", "HA"]))
+            new_bs.append(b)
         self._bs = new_bs
         while True:
             chis_to_sample = opt.dofs_per_iteration
@@ -1040,12 +1037,12 @@ class QFitRotamericResidue(_BaseQFit):
                                         >= 0.01
                                     ):
                                         new_coor_set.append(self.residue.coor)
-                                        new_bs.append(self._randomize_bs(b, bs_atoms))
+                                        new_bs.append(b)
                                     else:
                                         ex += 1
                                 else:
                                     new_coor_set.append(self.residue.coor)
-                                    new_bs.append(self._randomize_bs(b, bs_atoms))
+                                    new_bs.append(b)
                             else:
                                 ex += 1
 
@@ -2020,7 +2017,7 @@ class QFitCovalentLigand(_BaseQFit):
         iteration = 0
         new_bs = []
         for b in self._bs:
-            new_bs.append(self._randomize_bs(b, ["N", "CA", "C", "O", "CB", "H", "HA"]))
+            new_bs.append(b)
         self._bs = new_bs
 
         while True:
@@ -2132,12 +2129,10 @@ class QFitCovalentLigand(_BaseQFit):
                                             >= 0.01
                                         ):
                                             new_coor_set.append(coor)
-                                            new_bs.append(
-                                                self._randomize_bs(b, bs_atoms)
-                                            )
+                                            new_bs.append(b)
                                     else:
                                         new_coor_set.append(coor)
-                                        new_bs.append(self._randomize_bs(b, bs_atoms))
+                                        new_bs.append(b)
                             elif self.covalent_residue.clashes() == 0:
                                 if new_coor_set:
                                     delta = np.array(new_coor_set) - np.array(coor)
@@ -2152,10 +2147,10 @@ class QFitCovalentLigand(_BaseQFit):
                                         >= 0.01
                                     ):
                                         new_coor_set.append(coor)
-                                        new_bs.append(self._randomize_bs(b, bs_atoms))
+                                        new_bs.append(b)
                                 else:
                                     new_coor_set.append(coor)
-                                    new_bs.append(self._randomize_bs(b, bs_atoms))
+                                    new_bs.append(b)
 
                 self._coor_set = new_coor_set
                 self._bs = new_bs
@@ -2255,10 +2250,10 @@ class QFitCovalentLigand(_BaseQFit):
                                 >= 0.01
                             ):
                                 new_coor_set.append(new_coor)
-                                new_bs.append(self._randomize_bs(b, bs_atoms))
+                                new_bs.append(b)
                         else:
                             new_coor_set.append(new_coor)
-                            new_bs.append(self._randomize_bs(b, bs_atoms))
+                            new_bs.append(b)
                 elif self.covalent_residue.clashes() == 0:
                     if new_coor_set:
                         delta = np.array(new_coor_set) - np.array(new_coor)
@@ -2267,10 +2262,10 @@ class QFitCovalentLigand(_BaseQFit):
                             >= 0.01
                         ):
                             new_coor_set.append(new_coor)
-                            new_bs.append(self._randomize_bs(b, bs_atoms))
+                            new_bs.append(b)
                     else:
                         new_coor_set.append(new_coor)
-                        new_bs.append(self._randomize_bs(b, bs_atoms))
+                        new_bs.append(b)
         self._coor_set = new_coor_set
         self._bs = new_bs
         self.conformer = self.covalent_residue

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -85,11 +85,11 @@ def build_argparser():
         help="Scattering type [THIS IS CURRENTLY NOT SUPPORTED]",
     )
     p.add_argument(
-        "-rb",
-        "--randomize-b",
-        action="store_true",
-        dest="randomize_b",
-        help="Randomize B-factors of generated conformers",
+        "-sb",
+        "--sample-b",
+        action="store_false",
+        dest="sample_bfactors",
+        help="Sample B-factors of generated conformers",
     )
     p.add_argument(
         "-o",


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
