### PR TITLE
adding flag to only run qFit segment

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -111,6 +111,7 @@ class QFitOptions:
 
         ### From QFitSegmentOptions
         self.fragment_length = None
+        self.only_segment = False
 
         ### From QFitProteinOptions
         self.nproc = 1

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -385,7 +385,7 @@ class QFitProtein:
             self.pdb = ""
         
         if self.options.only_segment:
-            multiconformer = self._run_qfit_segment()
+            multiconformer = self._run_qfit_segment(self.structure)
         else:
             multiconformer = self._run_qfit_residue_parallel()
             multiconformer = self._run_qfit_segment(multiconformer)

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -384,12 +384,6 @@ class QFitProtein:
         else:
             self.pdb = ""
         
-        # Extract non-protein atoms
-        hetatms = self.structure.extract("record", "HETATM", "==")
-        waters = self.structure.extract("record", "ATOM", "==")
-        waters = waters.extract("resn", "HOH", "==")
-        hetatms = hetatms.combine(waters)
-        
         if self.options.only_segment:
             multiconformer = self._run_qfit_segment()
         else:
@@ -419,6 +413,13 @@ class QFitProtein:
         except ValueError:
             ctx = mp.get_context(method="spawn")
 
+        # Extract non-protein atoms
+        hetatms = self.structure.extract("record", "HETATM", "==")
+        waters = self.structure.extract("record", "ATOM", "==")
+        waters = waters.extract("resn", "HOH", "==")
+        hetatms = hetatms.combine(waters)
+        
+        
         # Create a list of residues from single conformations of proteinaceous residues.
         # If we were to loop over all single_conformer_residues, then we end up adding HETATMs in two places
         #    First as we combine multiconformer_residues into multiconformer_model (because they won't be in ROTAMERS)

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -384,7 +384,13 @@ class QFitProtein:
             self.pdb = self.options.pdb + "_"
         else:
             self.pdb = ""
-            
+        
+        # Extract non-protein atoms
+        hetatms = self.structure.extract("record", "HETATM", "==")
+        waters = self.structure.extract("record", "ATOM", "==")
+        waters = waters.extract("resn", "HOH", "==")
+        hetatms = hetatms.combine(waters)
+        
         if self.options.only_segment:
             multiconformer = self._run_qfit_segment()
         else:
@@ -413,12 +419,6 @@ class QFitProtein:
             ctx = mp.get_context(method="forkserver")
         except ValueError:
             ctx = mp.get_context(method="spawn")
-
-        # Extract non-protein atoms
-        hetatms = self.structure.extract("record", "HETATM", "==")
-        waters = self.structure.extract("record", "ATOM", "==")
-        waters = waters.extract("resn", "HOH", "==")
-        hetatms = hetatms.combine(waters)
 
         # Create a list of residues from single conformations of proteinaceous residues.
         # If we were to loop over all single_conformer_residues, then we end up adding HETATMs in two places

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -377,8 +377,12 @@ class QFitProtein:
             self.pdb = self.options.pdb + "_"
         else:
             self.pdb = ""
-        multiconformer = self._run_qfit_residue_parallel()
-        multiconformer = self._run_qfit_segment(multiconformer)
+            
+        if self.options.only_segment:
+            multiconformer = self._run_qfit_segment()
+        else:
+            multiconformer = self._run_qfit_residue_parallel()
+            multiconformer = self._run_qfit_segment(multiconformer)
         return multiconformer
 
     def get_map_around_substructure(self, substructure):

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -327,6 +327,13 @@ def build_argparser():
 
     # qFit Segment options
     p.add_argument(
+        "--only-segment",
+        default=False,
+        dest="only_segment",
+        type=bool,
+        help="Only perform qfit segment",
+    )
+    p.add_argument(
         "-f",
         "--fragment-length",
         default=4,

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -328,9 +328,8 @@ def build_argparser():
     # qFit Segment options
     p.add_argument(
         "--only-segment",
-        default=False,
+        action="store_true",
         dest="only_segment",
-        type=bool,
         help="Only perform qfit segment",
     )
     p.add_argument(


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
