### PR TITLE
adding order solvent picking in refinement

### DIFF
--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -201,6 +201,7 @@ echo "refinement.main.nqh_flips=True"            >> ${pdb_name}_final_refine.par
 echo "refinement.refine.${adp}"                  >> ${pdb_name}_final_refine.params
 echo "refinement.output.write_maps=False"        >> ${pdb_name}_final_refine.params
 echo "refinement.hydrogens.refine=riding"        >> ${pdb_name}_final_refine.params
+echo "refinement.main.ordered_solvent=True"      >> ${pdb_name}_final_refine.params
 
 if [ -f "${pdb_name}_002.ligands.cif" ]; then
   echo "refinement.input.monomers.file_name='${pdb_name}_002.ligands.cif'"  >> ${pdb_name}_final_refine.params
@@ -218,6 +219,8 @@ if [ -f "reduce_failure.pdb" ]; then
   echo "refinement.refine.${adp}"                  >> ${pdb_name}_final_refine_noreduce.params
   echo "refinement.output.write_maps=False"        >> ${pdb_name}_final_refine_noreduce.params
   echo "refinement.hydrogens.refine=riding"        >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.main.ordered_solvent=True"      >> ${pdb_name}_final_refine_noreduce.params
+  
 
   phenix.refine "${pdb_name}_002.pdb" "${pdb_name}_002.mtz" "${pdb_name}_final_refine_noreduce.params" --overwrite
 fi


### PR DESCRIPTION
This will be implemented in the last refinement round

### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change
This change will add ordered solvent in the last round of refinement. This will 'Add (or/and remove) and refine ordered solvent molecules (water)'. This will help with clashing water molecules and significantly improved Rfree for every model compared to our previous refinement script. 
![water_picking_v_orignial_rvalues_comparison](https://user-images.githubusercontent.com/15824327/212345378-0815869d-a755-4d3d-8ddc-6a716918a3c8.png)

