### PR TITLE
301 re create refinement script to group occupancy of segment alt locs

### DIFF
--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -150,7 +150,7 @@ echo "refinement.output.write_maps=False"                                       
 echo "refinement.hydrogens.refine=riding"                                        >> ${pdb_name}_occ_refine.params
 
 if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
-  echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_refine.params
+  echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_occ_refine.params
 fi
 
 zeroes=50
@@ -161,6 +161,7 @@ while [ $zeroes -gt 1 ]; do
   phenix.refine "${pdb_name}_002.pdb" \
                 "${pdb_name}_002.mtz" \
                 "${pdb_name}_occ_refine.params" \
+                qFit_occupancy.params \
                 --overwrite
 
   zeroes=`redistribute_cull_low_occupancies -occ 0.09 "${pdb_name}_003.pdb" | tail -n 1`
@@ -235,6 +236,7 @@ if [ -f "${pdb_name}_005.pdb" ]; then
    echo "                         The output can be found at ${pdb_name}_qFit.(pdb|mtz|log) ."
 else
    echo "Refinement did not complete."
+   echo "Please check for failure reports by examining log files."
 fi
 
 if [ "${too_many_loops_flag}" = true ]; then

--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -228,10 +228,14 @@ cp -v "${pdb_name}_005.mtz" "${pdb_name}_qFit.mtz"
 cp -v "${pdb_name}_005.log" "${pdb_name}_qFit.log"
 
 #__________________________COMMENTARY FOR USER_______________________________________
-echo ""
-echo "[qfit_final_refine_xray] Refinement is complete."
-echo "                         Please be sure to INSPECT your refined structure, especially all new altconfs."
-echo "                         The output can be found at ${pdb_name}_qFit.(pdb|mtz|log) ."
+if [ -f "${pdb_name}_005.pdb" ]; then 
+   echo ""
+   echo "[qfit_final_refine_xray] Refinement is complete."
+   echo "                         Please be sure to INSPECT your refined structure, especially all new altconfs."
+   echo "                         The output can be found at ${pdb_name}_qFit.(pdb|mtz|log) ."
+else
+   echo "Refinement did not complete."
+fi
 
 if [ "${too_many_loops_flag}" = true ]; then
   echo "[qfit_final_refine_xray] WARNING: Refinement and low-occupancy rotamer culling was taking too long (${i} rounds).";

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -614,31 +614,45 @@ class QFitProtein:
         For refinement, we need to create occupancy restraints for all residues in the same segment with the same altloc.
         This function will go through the qFit output and create a constraint file to be fed into refinement
         '''
-        #create header
         f = open("qFit_occupancy.params", "w+")
-        f.write("refinement {")
-        f.write("  refine {")
-        f.write("    occupancies {")
+        f.write("refinement {\n")
+        f.write("  refine {\n")
+        f.write("    occupancies {\n")
+        resi_ = []
+        altloc_ = []
+        chain_ = []
         for chain in multiconformer:
             for residue in chain:
-                if residue.extract('name', 'CA', '==').q == 1.0:
+              if residue.resn[0] in ROTAMERS:
+                if len(residue.extract('name', 'CA', '==').q) == 1:
                     #if something exists in the list, print it
-                    if len(resi) > 0:  #something exists and we should write it out
-                        for a in set(altloc):
+                    if len(resi_) > 0:  #something exists and we should write it out
+                        for a in set(altloc_):
                             #create a string from each value in the resi array
-                            f.write("      constrained_group {")
-                            f.write(f"        selection = altid {a} and ((chain {chain[0]} and resseq {}) or (chain A and resseq 24))")
-                        f.write("             }")
-                    resi = []
-                    altloc = []
-                    chain = []
-                    continue
+                            #resi_str = ','.join(map(str, resi_))
+                            f.write("      constrained_group {\n")
+                            for l in range(0, len(resi_)):
+                                #make string for each residue and concat the strings together
+                                if l == 0:
+                                    resi_selection = f"((chain {chain_[0]} and resseq {resi_[l]})"  #first residue
+                                else:
+                                    resi_selection = resi_selection + f" or (chain {chain_[0]} and resseq {resi_[l]})"
+                            f.write(f"        selection = altid {a} and {resi_selection})\n")
+                            f.write("             }\n")
+                    resi_ = []
+                    altloc_ = []
+                    chain_ = []
                 else:
-                    for alt in set(residue.altloc):
+                    for alt in list(set(residue.altloc)):
                         #only append if it does not already exist in array
-                        resi.append(residue.resi[0])
-                        chain.append(residue.chain[0])
-                        altloc.append(alt[0])
+                        if residue.resi[0] not in resi_:
+                           resi_.append(residue.resi[0])
+                        chain_.append(residue.chain[0])
+                        altloc_.append(alt[0])
+        f.write("   }\n")
+        f.write(" }\n")
+        f.write("}\n")
+        f.close()
     
     @staticmethod
     def _run_qfit_residue(residue, structure, xmap, options, logqueue):


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change
This change will create a grouped occupancy file based on residues that are grouped with qFit segment. 

It breaks grouped occupancy when the CA has one conformation. 

The occupancy parameter file is then used during the iterative refinement. It is not kept for final refinement. 

The normalize occupancy script needs to be updated to reflect this grouped refinement and remove grouped residues with occupancies that fall below 0.1 (or something like that based on resolution). 

 