### PR TITLE
301 reconfigure qfit segment

### DIFF
--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -147,7 +147,6 @@ echo "refinement.main.number_of_macro_cycles=5"                                 
 echo "refinement.main.nqh_flips=False"                                            >> ${pdb_name}_occ_refine.params
 echo "refinement.refine.${adp}"                                                  >> ${pdb_name}_occ_refine.params
 echo "refinement.output.write_maps=False"                                        >> ${pdb_name}_occ_refine.params
-echo "refinement.hydrogens.refine=riding"                                        >> ${pdb_name}_occ_refine.params
 
 if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
   echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_occ_refine.params

--- a/scripts/post/qfit_segment_refine.sh
+++ b/scripts/post/qfit_segment_refine.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# This script works with Phenix version 1.20.
+
+#This script should be used ONLY after using only-segment. If using qFit protein, please use qfit_final_refine_xray.sh.
+
+qfit_usage() {
+  echo >&2 "Usage:";
+  echo >&2 "  $0 mapfile.mtz [multiconformer_model2.pdb]";
+  echo >&2 "";
+  echo >&2 "mapfile.mtz and multiconformer_model2.pdb MUST exist in this directory.";
+  echo >&2 "Outputs will be written to mapfile_qFit.{pdb|mtz|log}.";
+  exit 1;
+}
+
+#___________________________SOURCE__________________________________
+# Check that Phenix is loaded
+if [ -z "${PHENIX}" ]; then
+  echo >&2 "I require PHENIX but it's not loaded.";
+  echo >&2 "Please \`source phenix_env.sh\` from where it is installed.";
+  exit 1;
+else
+  export PHENIX_OVERWRITE_ALL=true;
+fi
+
+# Check that qFit is loaded.
+command -v remove_duplicates >/dev/null 2>&1 || {
+  echo >&2 "I require qFit (remove_duplicates) but it's not loaded.";
+  echo >&2 "Please activate the environment where qFit is installed.";
+  echo >&2 "   e.g. conda activate qfit"
+  exit 1;
+}
+
+# Assert required files exist
+mapfile=$1
+multiconf=${2:-multiconformer_model2.pdb}
+echo "mapfile              : ${mapfile} $([[ -f ${mapfile} ]] || echo '[NOT FOUND]')";
+echo "qfit unrefined model : ${multiconf} $([[ -f ${multiconf} ]] || echo '[NOT FOUND]')";
+echo "";
+if [[ ! -f "${mapfile}" ]] || [[ ! -f "${multiconf}" ]]; then
+  qfit_usage;
+fi
+pdb_name="${mapfile%.mtz}"
+
+
+#__________________________________DETERMINE RESOLUTION AND (AN)ISOTROPIC REFINEMENT__________________________________
+mtzmetadata=`phenix.mtz.dump "${pdb_name}.mtz"`
+resrange=`grep "Resolution range:" <<< "${mtzmetadata}"`
+
+echo "${resrange}"
+
+res=`echo "${resrange}" | cut -d " " -f 4 | cut -c 1-5`
+res1000=`echo $res | awk '{tot = $1*1000}{print tot }'`
+
+if (( $res1000 < 1550 )); then
+  adp='adp.individual.anisotropic="not (water or element H)"'
+else
+  adp='adp.individual.isotropic=all'
+fi
+
+#__________________________________DETERMINE FOBS v IOBS v FP__________________________________
+# List of Fo types we will check for
+obstypes=("FP" "FOBS" "F-obs" "I" "IOBS" "I-obs" "F(+)" "I(+)")
+
+# Get amplitude fields
+ampfields=`grep -E "amplitude|intensity|F\(\+\)|I\(\+\)" <<< "${mtzmetadata}"`
+ampfields=`echo "${ampfields}" | awk '{$1=$1};1' | cut -d " " -f 1`
+
+# Clear xray_data_labels variable
+xray_data_labels=""
+
+# Is amplitude an Fo?
+for field in ${ampfields}; do
+  # Check field in obstypes
+  if [[ " ${obstypes[*]} " =~ " ${field} " ]]; then
+    # Check SIGFo is in the mtz too!
+    if grep -F -q -w "SIG$field" <<< "${mtzmetadata}"; then
+      xray_data_labels="${field},SIG${field}";
+      break
+    fi
+  fi
+done
+if [ -z "${xray_data_labels}" ]; then
+  echo >&2 "Could not determine Fo field name with corresponding SIGFo in .mtz.";
+  echo >&2 "Was not among "${obstypes[*]}". Please check .mtz file\!";
+  exit 1;
+else
+  echo "data labels: ${xray_data_labels}"
+  # Start writing refinement parameters into a parameter file
+  echo "refinement.input.xray_data.labels=$xray_data_labels" > ${pdb_name}_refine.params
+fi
+
+#_____________________________DETERMINE R FREE FLAGS______________________________
+gen_Rfree=True
+rfreetypes="FREE R-free-flags"
+for field in ${rfreetypes}; do
+  if grep -F -q -w $field <<< "${mtzmetadata}"; then
+    gen_Rfree=False;
+    echo "Rfree column: ${field}";
+    echo "refinement.input.xray_data.r_free_flags.label=${field}" >> ${pdb_name}_refine.params
+    break
+  fi
+done
+echo "refinement.input.xray_data.r_free_flags.generate=${gen_Rfree}" >> ${pdb_name}_refine.params
+
+#__________________________________REMOVE DUPLICATE HET ATOMS__________________________________
+remove_duplicates "${multiconf}"
+
+
+#________________________________REMOVE TRAILING HYDROGENS___________________________________
+phenix.pdbtools remove="element H" "${multiconf}.fixed"
+
+#__________________________________GET CIF FILE__________________________________
+
+phenix.ready_set hydrogens=false \
+                 trust_residue_code_is_chemical_components_code=true \
+                 pdb_file_name="${multiconf}.f_modified.pdb"
+# If there are no unknown ligands, ready_set doesn't output a file. We have to do it.
+if [ ! -f "${multiconf}.f_modified.updated.pdb" ]; then
+  cp -v "${multiconf}.f_modified.pdb" "${multiconf}.f_modified.updated.pdb";
+fi
+if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
+  echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_refine.params
+fi
+
+#__________________________________REFINE WITH OCCUPANCIES RESTRAINED__________________________________
+# Write refinement parameters into parameters file
+echo "refinement.refine.strategy=*individual_sites *individual_adp *occupancies"  > ${pdb_name}_occ_refine.params
+echo "refinement.output.prefix=${pdb_name}"                                      >> ${pdb_name}_occ_refine.params
+echo "refinement.output.serial=1"                                                >> ${pdb_name}_occ_refine.params
+echo "refinement.main.number_of_macro_cycles=5"                                  >> ${pdb_name}_occ_refine.params
+echo "refinement.main.nqh_flips=False"                                            >> ${pdb_name}_occ_refine.params
+echo "refinement.refine.${adp}"                                                  >> ${pdb_name}_occ_refine.params
+echo "refinement.output.write_maps=False"                                        >> ${pdb_name}_occ_refine.params
+
+if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
+  echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_occ_refine.params
+fi
+
+
+phenix.refine "${multiconf}.f_modified.updated.pdb" \
+                "${pdb_name}.mtz" \
+                "${pdb_name}_occ_refine.params" \
+                qFit_occupancy.params \
+                --overwrite
+
+#__________________________________ADD HYDROGENS__________________________________
+# The first round of refinement regularizes geometry from qFit.
+# Here we add H with phenix.ready_set. Addition of H to the backbone is important
+#   since it introduces planarity restraints to the peptide bond.
+# We will also create a cif file for any ligands in the structure at this point.
+phenix.ready_set hydrogens=true pdb_file_name="${pdb_name}_001.pdb"
+mv "${pdb_name}_001.updated.pdb" "${pdb_name}_001.pdb"
+
+#__________________________________FINAL REFINEMENT__________________________________
+
+# Write refinement parameters into parameters file
+echo "refinement.refine.strategy=*individual_sites *individual_adp *occupancies"  > ${pdb_name}_final_refine.params
+echo "refinement.output.prefix=${pdb_name}"      >> ${pdb_name}_final_refine.params
+echo "refinement.output.serial=5"                >> ${pdb_name}_final_refine.params
+echo "refinement.main.number_of_macro_cycles=5"  >> ${pdb_name}_final_refine.params
+echo "refinement.main.nqh_flips=True"            >> ${pdb_name}_final_refine.params
+echo "refinement.refine.${adp}"                  >> ${pdb_name}_final_refine.params
+echo "refinement.output.write_maps=False"        >> ${pdb_name}_final_refine.params
+echo "refinement.hydrogens.refine=riding"        >> ${pdb_name}_final_refine.params
+echo "refinement.main.ordered_solvent=True"      >> ${pdb_name}_final_refine.params
+
+
+if [ -f "${pdb_name}_001.ligands.cif" ]; then
+  echo "refinement.input.monomers.file_name='${pdb_name}_001.ligands.cif'"  >> ${pdb_name}_final_refine.params
+fi
+
+phenix.refine "${pdb_name}_001.pdb" "${pdb_name}_001.mtz" "${pdb_name}_final_refine.params" --overwrite 
+
+#________________________________CHECK FOR REDUCE ERRORS______________________________
+if [ -f "reduce_failure.pdb" ]; then
+  echo "refinement.refine.strategy=*individual_sites *individual_adp *occupancies"  > ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.output.prefix=${pdb_name}"      >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.output.serial=5"                >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.main.number_of_macro_cycles=5"  >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.main.nqh_flips=False"           >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.refine.${adp}"                  >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.output.write_maps=False"        >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.hydrogens.refine=riding"        >> ${pdb_name}_final_refine_noreduce.params
+  echo "refinement.main.ordered_solvent=True"      >> ${pdb_name}_final_refine_noreduce.params
+  
+
+  phenix.refine "${pdb_name}_001.pdb" "${pdb_name}_001.mtz" "${pdb_name}_final_refine_noreduce.params" --overwrite
+fi
+
+#__________________________________NAME FINAL FILES__________________________________
+cp -v "${pdb_name}_005.pdb" "${pdb_name}_qFit.pdb"
+cp -v "${pdb_name}_005.mtz" "${pdb_name}_qFit.mtz"
+cp -v "${pdb_name}_005.log" "${pdb_name}_qFit.log"
+
+#__________________________COMMENTARY FOR USER_______________________________________
+if [ -f "${pdb_name}_005.pdb" ]; then 
+   echo ""
+   echo "[qfit_final_refine_xray] Refinement is complete."
+   echo "                         Please be sure to INSPECT your refined structure, especially all new altconfs."
+   echo "                         The output can be found at ${pdb_name}_qFit.(pdb|mtz|log) ."
+else
+   echo "Refinement did not complete."
+   echo "Please check for failure reports by examining log files."
+fi
+
+if [ -f "reduce_failure.pdb" ]; then
+  echo "Refinement was run without checking for flips in NQH residues due to memory constraints. Please inspect your structure."
+fi
+

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1299,9 +1299,9 @@ class QFitSegment(_BaseQFit):
             f"{multiconformers.average_conformers():.2f}"
         )
         multiconformers = multiconformers.reorder()
-        multiconformers = multiconformers.remove_identical_conformers(
-            self.options.rmsd_cutoff
-        )
+#         multiconformers = multiconformers.remove_identical_conformers(
+#             self.options.rmsd_cutoff
+#         )
         multiconformers = multiconformers.normalize_occupancy()  # ensure that sum(occupancy) of residues is equal to one.
         logger.info(
             f"Average number of conformers after removal of identical conformers: "

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -616,7 +616,8 @@ class QFitProtein:
         For refinement, we need to create occupancy restraints for all residues in the same segment with the same altloc.
         This function will go through the qFit output and create a constraint file to be fed into refinement
         '''
-        f = open("qFit_occupancy.params", "w+")
+        fname = os.path.join(self.options.directory, "qFit_occupancy.params")
+        f = open(fname, "w+")
         f.write("refinement {\n")
         f.write("  refine {\n")
         f.write("    occupancies {\n")

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -386,9 +386,11 @@ class QFitProtein:
         
         if self.options.only_segment:
             multiconformer = self._run_qfit_segment(self.structure)
+            multiconformer = self._create_refine_restraints(multiconformer)
         else:
             multiconformer = self._run_qfit_residue_parallel()
             multiconformer = self._run_qfit_segment(multiconformer)
+            multiconformer = self._create_refine_restraints(multiconformer)
         return multiconformer
 
     def get_map_around_substructure(self, substructure):

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -395,12 +395,11 @@ class Structure(_BaseStructure):
                           new_occ = normalize_to_precision(
                              np.array(new_occ), 2
                            )  # deal with imprecision 
-                    altloc_id = ['A', 'B', 'C', 'D', 'E']
                     for i in range(0, len(new_occ)):
                          mask = (
                                (self.data["resi"] == residue.resi[0])
                                & (self.data["chain"] == residue.chain[0])
-                               & (self.data["altloc"] == altloc_id[i])
+                               & (self.data["altloc"] == altlocs[i])
                                )
                          for attr in data:
                              array = getattr(multiconformer,attr)


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
