### PR TITLE
create all rotamers script

### DIFF
--- a/src/qfit/create_rot_lib.py
+++ b/src/qfit/create_rot_lib.py
@@ -1,0 +1,61 @@
+import itertools
+import logging
+import os
+from sys import argv
+import copy
+import subprocess
+import numpy as np
+import argparse
+
+from .samplers import ChiRotator, CBAngleRotator, BondRotator
+from .samplers import CovalentBondRotator, GlobalRotator
+from .samplers import RotationSets, Translator
+from .structure import Structure, _Segment, calc_rmsd
+from .structure.residue import residue_type
+from .structure.rotamers import ROTAMERS
+
+def build_argparser():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "structure",
+        help="PDB-file containing structure.",
+        type=str
+    )
+    p.add_argument(
+       "selection",
+       help="residue chain and id",
+       type=str
+    )
+    return p
+
+class rotamers():
+     def __init__(self, residue):
+        self.residue = residue
+      
+     def run(self):
+        #determine number of chi_index
+        #get_all rotamers
+        all_rotamers = self.residue.rotamers
+        #get number of chi angles
+        nchi = self.residue.nchi  
+        for r in all_rotamers:
+            for n in range(1, nchi):
+                self.residue.set_chi(n, r[n])
+            self.residue.tofile(f'{self.residue.resn[0]}_{r}.pdb') 
+def get_rotamers(structure, selection):
+    chainid, residue_id = selection.split(",")
+    structure_resi = structure.extract(f"resi {residue_id} and chain {chainid}")
+    chain = structure_resi[chainid]
+    conformer = chain.conformers[0]
+    residue = conformer[int(residue_id)]
+    rot = rotamers(residue)
+    rot.run() 
+
+def main():
+    p = build_argparser()
+    args = p.parse_args(args=None)
+    structure = Structure.fromfile(args.structure).reorder()
+    get_rotamers(structure, args.selection)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
