### PR TITLE
Update qFit CryoEM refinement

### DIFF
--- a/scripts/post/qfit_final_refine_cryoem.sh
+++ b/scripts/post/qfit_final_refine_cryoem.sh
@@ -40,13 +40,13 @@ echo "mapfile              : ${mapfile} $([[ -f ${mapfile} ]] || echo '[NOT FOUN
 echo "original model : ${org_model} $([[ -f ${org_model} ]] || echo '[NOT FOUND]')";
 echo "qfit unrefined model : ${multiconf} $([[ -f ${multiconf} ]] || echo '[NOT FOUND]')";
 echo "";
-if [[ ! -f "${mapfile}" ]] || [[ ! -f "${multiconf}" ]] || [[ -f ${org_model} ]]; then
+if [[ ! -f "${mapfile}" ]] || [[ ! -f "${multiconf}" ]] || [[ ! -f ${org_model} ]]; then
   qfit_usage;
 fi
 
 #CCP4 or MAP
 
-pdb_name="${mapfile%.ccp4}"
+pdb_name="${org_model%.pdb}"
 echo $pdb_name
 
 #__________________________________DETERMINE RESOLUTION AND (AN)ISOTROPIC REFINEMENT__________________________________
@@ -81,13 +81,12 @@ if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
   echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_occ_refine.params
 fi
 
-
 zeroes=50
 i=1
 while [ $zeroes -gt 1 ]; do
   cp "${pdb_name}2_real_space_refined.001.pdb" "${pdb_name}2_real_space_refined.001.$(printf '%03d' $i).pdb";
   ((i++));
-  phenix.real_space_refine "${pdb_name}2_real_space_refined.001.pdb" "${pdb_name}.ccp4" ${pdb_name}_occ_refine.params
+  phenix.real_space_refine "${pdb_name}2_real_space_refined.001.pdb" "${mapfile}" ${pdb_name}_occ_refine.params
 
   zeroes=`redistribute_cull_low_occupancies -occ 0.09 "${pdb_name}3_real_space_refined.pdb" | tail -n 1`
   echo "Post refinement zeroes: ${zeroes}"
@@ -123,10 +122,9 @@ if [ -f "${pdb_name}_002.ligands.cif" ]; then
   echo "refinement.input.monomers.file_name='${pdb_name}_002.ligands.cif'"  >> ${pdb_name}_final_refine.params
 fi
 
-phenix.real_space_refine "${pdb_name}4_real_space_refined.001.pdb" "${pdb_name}.ccp4" ${pdb_name}_final_refine.params
+phenix.real_space_refine "${pdb_name}4_real_space_refined.001.pdb" "${mapfile}" ${pdb_name}_final_refine.params
 
 #__________________________________NAME FINAL FILES__________________________________
 cp "${pdb_name}5_real_space_refined.pdb" "${pdb_name}_qFit.pdb"
-cp "${pdb_name}.ccp4" "${pdb_name}_qFit.ccp4"
 cp "${pdb_name}5_real_space_refined.log" "${pdb_name}_qFit.log"
 

--- a/scripts/post/qfit_final_refine_cryoem.sh
+++ b/scripts/post/qfit_final_refine_cryoem.sh
@@ -52,7 +52,7 @@ echo $pdb_name
 #__________________________________DETERMINE RESOLUTION AND (AN)ISOTROPIC REFINEMENT__________________________________
 resolution=$(grep 'REMARK   2 RESOLUTION.    ' $org_model)
 echo $resolution
-res=`echo "${resolution}" | cut -d " " -f 14 | cut -c 1-5`
+res=`echo "${resolution}" | cut -d " " -f 9 | cut -c 1-5`
 echo "Resolution: ${res}"
 
 #__________________________________REMOVE DUPLICATE HET ATOMS__________________________________


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [ ] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [ ] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [ ] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
