### PR TITLE
qscore cutoff option for EM structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ An example test case (3K0N) can be found in the [example/qfit_protein_example](e
 
 ### Recommended settings
 
-To model alternate conformers for all residues in a protein of interest using qFit,
+To model alternate conformers for all residues in a *X-ray crystallography* model using qFit,
 the following command should be used:
 
 `qfit_protein [COMPOSITE_OMIT_MAP_FILE] -l [LABELS] [PDB_FILE]`
@@ -120,7 +120,6 @@ be used as input to the post-qFit refinement script provided in [scripts](script
 If you wish to specify a different directory for the output, this can be done
 using the flag *-d*.
  
-
 By default, qFit expects the labels FWT,PHWT to be present in the input map.
 Different labels can be set accordingly using the flag *-l*.
 
@@ -138,7 +137,16 @@ Bear in mind that this final step currently depends on an existing installation
 of the Phenix software suite. This script is currently written to work with version Phenix 1.20.
 
 
-More advanced features of qFit (modeling single residue, ligand or cryo-EM structure, parallelization) are explained in [TUTORIAL](example/TUTORIAL.md).
+To model alternate conformers for all residues in a *Cryo-EM* model using qFit,
+the following command should be used:
+
+`qfit_protein [MAP_FILE] -r [RES] [PDB_FILE] --qscore [QSCORE_TXT_FILE]`
+
+After *multiconformer_model2.pdb* has been generated, refine this model using:
+
+`qfit_final_refine_cryoEM.sh example/qfit_protein_example/em_map.ccp4 example/qfit_protein_example/multiconformer_model2.pdb example/qfit_protein_example/input_pdb_file.pdb`
+
+More advanced features of qFit (modeling single residue, more advanced options, and further explainations) are explained in [TUTORIAL](example/TUTORIAL.md).
 
 
 ## License

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -36,6 +36,7 @@ class QFitOptions:
         self.debug = False
         self.write_intermediate_conformers = False
         self.label = None
+        self.qscore = None
         self.map = None
         self.structure = None
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -730,7 +730,7 @@ class QFitProtein:
         # Determine if q-score is too low
         if options.qscore is not None:
            (chainid, resi, icode) = residue._identifier_tuple
-            if list(options.qscore[(options.qscore['Res_num'] == resi) & (options.qscore['Chain'] == chainid)]['Q_sideChain'])[0] < 0.7:
+           if list(options.qscore[(options.qscore['Res_num'] == resi) & (options.qscore['Chain'] == chainid)]['Q_sideChain'])[0] < 0.7:
                 logger.info(
                     f"Residue {residue.shortcode}: Q-score is too low for this residue. Using deposited structure."
                 )

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -348,6 +348,13 @@ def build_argparser():
         default=True,
         help="Use BIC to select the most parsimonious MIQP threshold (segment)",
     )
+    
+    # EM options
+    p.add_argument(
+        "-q",
+        "--qscore",
+        help="Q-score text output file",
+    )
 
     # Output options
     p.add_argument(

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -811,6 +811,17 @@ def prepare_qfit_protein(options):
             radius = 0.5 + reso / 3.0
         scaler.scale(structure, radius=options.scale_rmask * radius)
 
+    if options.qscore is not None:
+       with open(options.qscore, 'r') as f: #not all qscore header are the same 'length'
+          for line_n, line_content in enumerate(f):
+              if "Q_sideChain" in line_content:
+                 break
+          start_row = line_n + 1
+       options.qscore = pd.read_csv(options.qscore, sep='\t', skiprows=start_row,skip_blank_lines=True,on_bad_lines='skip', header=None)
+       options.qscore = options.qscore.iloc[:,:6] #we only care about the first 6 columns
+       options.qscore.columns =['Chain', 'Res', 'Res_num', 'Q_backBone', 'Q_sideChain', 'Q_residue'] #rename column names
+       options.qscore['Res_num'] = options.qscore['Res_num'].fillna(0).astype(int)    
+        
     return QFitProtein(structure, xmap, options)
 
 

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -726,7 +726,25 @@ class QFitProtein:
                 f"Residue {residue.shortcode}: {fname} already exists, using this checkpoint."
             )
             return
-
+        
+        # Determine if q-score is too low
+        if options.qscore is not None:
+           (chainid, resi, icode) = residue._identifier_tuple
+            if list(options.qscore[(options.qscore['Res_num'] == resi) & (options.qscore['Chain'] == chainid)]['Q_sideChain'])[0] < 0.7:
+                logger.info(
+                    f"Residue {residue.shortcode}: Q-score is too low for this residue. Using deposited structure."
+                )
+                resi_selstr = f"chain {chainid} and resi {resi}"
+                if icode:
+                    resi_selstr += f" and icode {icode}"
+                structure_new = structure
+                structure_resi = structure.extract(resi_selstr)
+                chain = structure_resi[chainid]
+                conformer = chain.conformers[0]
+                residue = conformer[residue.id]
+                residue.tofile(fname)
+                return
+        
         # Copy the structure
         (chainid, resi, icode) = residue._identifier_tuple
         resi_selstr = f"chain {chainid} and resi {resi}"

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -355,6 +355,12 @@ def build_argparser():
         "--qscore",
         help="Q-score text output file",
     )
+    p.add_argument(
+        "-q_cutoff",
+        "--qscore_cutoff",
+        help="Q-score value where we should not model in alternative conformers.",
+        default=0.7
+    )
 
     # Output options
     p.add_argument(
@@ -730,7 +736,7 @@ class QFitProtein:
         # Determine if q-score is too low
         if options.qscore is not None:
            (chainid, resi, icode) = residue._identifier_tuple
-           if list(options.qscore[(options.qscore['Res_num'] == resi) & (options.qscore['Chain'] == chainid)]['Q_sideChain'])[0] < 0.7:
+           if list(options.qscore[(options.qscore['Res_num'] == resi) & (options.qscore['Chain'] == chainid)]['Q_sideChain'])[0] < options.q_cutoff:
                 logger.info(
                     f"Residue {residue.shortcode}: Q-score is too low for this residue. Using deposited structure."
                 )


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

This is implementing qscore (https://github.com/gregdp/mapq, https://www.nature.com/articles/s41592-020-0731-1) for EM structures. This implements an option to provide a qscore txt file and qFit will not model residues with sidechain qscores <0.7 as these residues do not have enough supporting density.  