### PR TITLE
update BIC to reflect paper

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -282,12 +282,12 @@ class _BaseQFit:
                     n = len(self._target)
                     try:
                         natoms = len(self.residue._rotamers["atoms"])
-                        k = 4 * confs * natoms
+                        k = (4 * atoms)/threshold
                     except AttributeError:
-                        k = 4 * confs
+                        k = (4 * atoms)/threshold
                     except:
                         natoms = np.sum(self.ligand.active)
-                        k = 4 * confs * natoms
+                        k = (4 * atoms)/threshold
                     BIC = n * np.log(rss / n) + k * np.log(n)
                     if BIC < self.BIC:
                         self.BIC = BIC

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1386,7 +1386,7 @@ class QFitSegment(_BaseQFit):
                         self._solve(
                             threshold=self.options.threshold,
                             cardinality=self.options.cardinality,
-                            loop_range=[0.34, 0.25, 0.2, 0.16, 0.14],
+                            loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2],
                         )
                     except SolverError:
                         # MIQP failed and we need to remove conformers that are close to each other


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [ ] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [ ] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [ ] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
