### PR TITLE
Correct sample_b() implementation

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -313,7 +313,8 @@ class _BaseQFit:
         new_coor = []
         new_bfactor = []
         multiplication_factors = [1.0, 1.3, 1.5, 0.9, 0.5]
-        for coor, b, multi in zip(self._coor_set, self._bs, multiplication_factors):
+        coor_b_pairs = zip(self._coor_set, self._bs)
+        for (coor, b), multi in itertools.product(coor_b_pairs, multiplication_factors):
             new_coor.append(coor)
             new_bfactor.append(b * multi)
         self._coor_set = new_coor

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -80,9 +80,9 @@ class QFitOptions:
         self.sample_backbone_step = 0.1
         self.sample_backbone_sigma = 0.125
 
-        #Sample B-factors 
+        # Sample B-factors
         self.sample_bfactors = True
-        
+
         # N-CA-CB angle sampling
         self.sample_angle = True
         self.sample_angle_range = 7.5
@@ -303,13 +303,16 @@ class _BaseQFit:
 
     
     def sample_b(self):
-        """
-        This funciton will take in coor set and b-factors for all conformers selected after QP (to help save time) 
-        and multiple each atom's b-factor by it multiplication factor.  
+        """Create copies of conformers that vary in B-factor.
+
+        For all conformers selected, create a copy with the B-factor vector by a scaling factor.
+
+        It is intended that this will be run after a QP step (to help save time)
+        and before an MIQP step.
         """
         new_coor = []
-        new_bfactor =[]
-        multiplication_factors = [1.0, 1.3, 1.5, 0.9, 0.5] 
+        new_bfactor = []
+        multiplication_factors = [1.0, 1.3, 1.5, 0.9, 0.5]
         for coor, b, multi in zip(self._coor_set, self._bs, multiplication_factors):
             new_coor.append(coor)
             new_bfactor.append(b * multi)


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

In a discussion with coauthors in 2023-Apr, the sample_b() routine should _expand_ the number of conformers going into the MIQP round --- each conformer turns into 5 conformers with differing B-factors.

### Release Notes

- Fixed an issue where B-factor sampling reduced the number of conformers.

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
