### PR TITLE
Unify map extraction: use --padding option (and default value) in QFitSegment

### DIFF
--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -603,10 +603,10 @@ class QFitProtein:
         else:
             self.options.threshold = 0.2
 
-        # Extract map of multiconformer in P1, with 5 A padding
+        # Extract map of multiconformer in P1
         logger.debug("Extracting map...")
         _then = time.process_time()
-        self.xmap = self.xmap.extract(self.structure.coor, padding=5)
+        self.xmap = self.get_map_around_substructure(self.structure)
         _now = time.process_time()
         logger.debug(f"Map extraction took {(_now - _then):.03f} s.")
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

QFitSegment was using a custom 'padding' during map extraction.
This commit changes the map extraction in QFitSegment to use the same routine as is being used in QFitRotamericResidue (and elsewhere).
We currently ask the user what padding they'd like for map calculations: we should respect that.

### Release Notes

- Respect --padding during QFitSegment

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
