### PR TITLE
Make BIC routine _actually_ select based on lowest BIC

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1128,7 +1128,7 @@ class QFitRotamericResidue(_BaseQFit):
             self._convert()
             self._solve_miqp(
                 threshold=self.options.threshold,
-                cardinality=self.options.cardinality,
+                cardinality=None,  # don't enforce strict cardinality constraint, just less-than 1/threshold
                 do_BIC_selection=False,  # override (cancel) BIC selection during chi sampling
             )
             self._update_conformers()

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -297,7 +297,8 @@ class _BaseQFit:
                 rss = solver.obj_value * self._voxel_volume
                 n = len(self._target)
                 natoms = self._coor_set[0].shape[0]
-                k = (4 * natoms) / threshold
+                nconfs = np.sum(solver.weights >= 0.002)
+                k = 4 * natoms * nconfs
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 solution = MIQPSolutionStats(
                     threshold=threshold,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -334,6 +334,9 @@ class _BaseQFit:
         This funciton will take in coor set and b-factors for all conformers selected after QP (to help save time) 
         and multiple each atom's b-factor by it multiplication factor.  
         """
+        if not self.options.sample_bfactors:
+            return
+
         new_coor = []
         new_bfactor =[]
         multiplication_factors = [1.0, 1.3, 1.5, 0.9, 0.5] 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -282,16 +282,9 @@ class _BaseQFit:
             for threshold in loop_range:
                 solver.solve(cardinality=None, threshold=threshold)
                 rss = solver.obj_value * self._voxel_volume
-                confs = np.sum(solver.weights >= 0.002)
                 n = len(self._target)
-                try:
-                    natoms = len(self.residue._rotamers["atoms"])
-                    k = 4 * confs * natoms
-                except AttributeError:
-                    k = 4 * confs
-                except:
-                    natoms = np.sum(self.ligand.active)
-                    k = 4 * confs * natoms
+                natoms = self._coor_set[0].shape[0]
+                k = (4 * natoms) / threshold
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 if BIC < self.BIC:
                     self.BIC = BIC

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -713,7 +713,7 @@ class QFitRotamericResidue(_BaseQFit):
         if self.residue.nchi >= 1 and self.options.sample_rotamers:
             self._sample_sidechain()
 
-        # Perform a final QP / MIQP step
+        # Check that there are no self-clashes within a conformer
         self.residue.active = True
         self.residue.update_clash_mask()
         new_coor_set = []

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -300,7 +300,7 @@ class _BaseQFit:
                 natoms = self._coor_set[0].shape[0]
                 nconfs = np.sum(solver.weights >= 0.002)
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
-                k = model_params_per_atom * natoms * nconfs
+                k = model_params_per_atom * natoms * nconfs * 0.95 #0.95 hyperparameter in put in here since we are almost always over penalizing 
 
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 solution = MIQPSolutionStats(

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -258,7 +258,7 @@ class _BaseQFit:
         # Create and run solver
         logger.info("Solving QP")
         solver = QPSolver(self._target, self._models, use_cplex=self.options.cplex)
-        solver()
+        solver.solve()
 
         # Update occupancies from solver weights
         self._occupancies = solver.weights
@@ -280,7 +280,7 @@ class _BaseQFit:
         if self.options.bic_threshold:
             self.BIC = np.inf
             for threshold in loop_range:
-                solver(cardinality=None, threshold=threshold)
+                solver.solve(cardinality=None, threshold=threshold)
                 rss = solver.obj_value * self._voxel_volume
                 confs = np.sum(solver.weights >= 0.002)
                 n = len(self._target)
@@ -296,7 +296,7 @@ class _BaseQFit:
                 if BIC < self.BIC:
                     self.BIC = BIC
         else:
-            solver(cardinality=cardinality, threshold=threshold)
+            solver.solve(cardinality=cardinality, threshold=threshold)
 
         # Update occupancies from solver weights
         self._occupancies = solver.weights

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -277,31 +277,36 @@ class _BaseQFit:
         cardinality,
         threshold,
         loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2],
+        chi=False,
     ):
         # Create solver
         logger.info("Solving MIQP")
         solver = MIQPSolver(self._target, self._models, use_cplex=self.options.cplex)
 
+        
+        #determine if this occuring during chi sampling
+        if chi == False:
+        
         # Threshold selection by BIC:
-        if self.options.bic_threshold:
-            # Iteratively test decreasing values of the threshold parameter tdmin (threshold)
-            # to determine if the better fit (RSS) justifies the use of a more complex model (k)
-            miqp_solutions = []
-            for threshold in loop_range:
-                solver.solve(cardinality=None, threshold=threshold)
-                rss = solver.obj_value * self._voxel_volume
-                n = len(self._target)
-                natoms = self._coor_set[0].shape[0]
-                k = (4 * natoms) / threshold
-                BIC = n * np.log(rss / n) + k * np.log(n)
-                solution = MIQPSolutionStats(
-                    threshold=threshold,
-                    BIC=BIC,
-                    rss=rss,
-                    objective=solver.obj_value.copy(),
-                    weights=solver.weights.copy(),
-                )
-                miqp_solutions.append(solution)
+            if self.options.bic_threshold:
+                # Iteratively test decreasing values of the threshold parameter tdmin (threshold)
+                # to determine if the better fit (RSS) justifies the use of a more complex model (k)
+                miqp_solutions = []
+                for threshold in loop_range:
+                    solver.solve(cardinality=None, threshold=threshold)
+                    rss = solver.obj_value * self._voxel_volume
+                    n = len(self._target)
+                    natoms = self._coor_set[0].shape[0]
+                    k = (4 * natoms) / threshold
+                    BIC = n * np.log(rss / n) + k * np.log(n)
+                    solution = MIQPSolutionStats(
+                        threshold=threshold,
+                        BIC=BIC,
+                        rss=rss,
+                        objective=solver.obj_value.copy(),
+                        weights=solver.weights.copy(),
+                    )
+                    miqp_solutions.append(solution)
 
             # Update occupancies from solver weights
             miqp_solution_lowest_bic = min(miqp_solutions, key=lambda sol: sol.BIC)
@@ -1122,7 +1127,7 @@ class QFitRotamericResidue(_BaseQFit):
             self.sample_b()
             self._convert()
             self._solve_miqp(
-                threshold=self.options.threshold, cardinality=self.options.cardinality
+                threshold=self.options.threshold, cardinality=self.options.cardinality, chi=True
             )
             self._update_conformers()
             if self.options.write_intermediate_conformers:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -296,9 +296,12 @@ class _BaseQFit:
                 solver.solve(cardinality=None, threshold=threshold)
                 rss = solver.obj_value * self._voxel_volume
                 n = len(self._target)
+
                 natoms = self._coor_set[0].shape[0]
                 nconfs = np.sum(solver.weights >= 0.002)
-                k = 4 * natoms * nconfs
+                model_params_per_atom = 3 + int(self.options.sample_bfactors)
+                k = model_params_per_atom * natoms * nconfs
+
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 solution = MIQPSolutionStats(
                     threshold=threshold,

--- a/src/qfit/qfit_ligand.py
+++ b/src/qfit/qfit_ligand.py
@@ -258,7 +258,7 @@ def build_argparser():
         "--threshold-selection",
         dest="bic_threshold",
         action=ToggleActionFlag,
-        default=True,
+        default=False,
         help="Use BIC to select the most parsimonious MIQP threshold",
     )
 

--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -31,7 +31,7 @@ class _Base_QPSolver(object):
     def initialize(self):
         raise NotImplementedError
 
-    def __call__(self):
+    def solve(self):
         raise NotImplementedError
 
 
@@ -78,7 +78,7 @@ if CPLEX:
             )
             self.initialized = True
 
-        def __call__(self):
+        def solve(self):
             if not self.initialized:
                 self.initialize()
 
@@ -106,7 +106,7 @@ if CPLEX:
 
             self.initialized = True
 
-        def __call__(self, cardinality=None, exact=False, threshold=None):
+        def solve(self, cardinality=None, exact=False, threshold=None):
             if not self.initialized:
                 self.initialize()
 

--- a/tests/test_qfit_protein.py
+++ b/tests/test_qfit_protein.py
@@ -78,4 +78,4 @@ class TestQFitProtein:
         multiconformer = qfit._run_qfit_residue_parallel()
         mconformer_list = list(multiconformer.residues)
         print(mconformer_list)  # If we fail, this gets printed.
-        assert len(mconformer_list) == 4  # Expect: 3*Ser99, 4*Phe113
+        assert len(mconformer_list) == 2  # Expect: 1*Ser99, 1*Phe113


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

We were previously selecting the number of conformers from the _last_ iteration of the BIC loop, because a "else break" had been commented and removed.
As such, every MIQP was performed 5 times (redundantly!), and the last MIQP iteration was the one that made it through (threshold/tdmin = 0.2).

This PR implements the desired behaviour. It calculates the MIQP solutions for all thresholds, and then chooses the solution with lowest BIC.

### Discussion points

The number of conformers selected is drastically decreased, and two tests fail: ones which check that the provided examples return an expected number of conformers. These two examples return only one rotamer each now. I do not know why.

### Release Notes

- Fixed a bug with BIC selection in MIQP

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
