### PR TITLE
Segment BIC criteria = nconfs

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -288,6 +288,7 @@ class _BaseQFit:
         threshold,
         loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2],
         do_BIC_selection=None,
+        segment=None,
     ):
         #set loop range differently for EM
         if self.options.em:
@@ -314,7 +315,8 @@ class _BaseQFit:
                 nconfs = np.sum(solver.weights >= 0.002)
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
                 k = model_params_per_atom * natoms * nconfs * 0.95 #0.95 hyperparameter in put in here since we are almost always over penalizing 
-
+                if segment is not None:
+                    k = nconfs. #for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 solution = MIQPSolutionStats(
                     threshold=threshold,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1436,8 +1436,7 @@ class QFitSegment(_BaseQFit):
                         self._convert()
                         self._solve_miqp(
                             threshold=self.options.threshold,
-                            cardinality=self.options.cardinality,
-                            loop_range=[0.34, 0.25, 0.2, 0.16, 0.14],
+                            cardinality=self.options.cardinality
                         )
                     except SolverError:
                         # MIQP failed and we need to remove conformers that are close to each other

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1436,7 +1436,8 @@ class QFitSegment(_BaseQFit):
                         self._convert()
                         self._solve_miqp(
                             threshold=self.options.threshold,
-                            cardinality=self.options.cardinality
+                            cardinality=self.options.cardinality,
+                            segement=True
                         )
                     except SolverError:
                         # MIQP failed and we need to remove conformers that are close to each other

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1437,7 +1437,7 @@ class QFitSegment(_BaseQFit):
                         self._solve_miqp(
                             threshold=self.options.threshold,
                             cardinality=self.options.cardinality,
-                            segement=True
+                            segment=True
                         )
                     except SolverError:
                         # MIQP failed and we need to remove conformers that are close to each other

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -316,7 +316,7 @@ class _BaseQFit:
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
                 k = model_params_per_atom * natoms * nconfs * 0.95 #0.95 hyperparameter in put in here since we are almost always over penalizing 
                 if segment is not None:
-                    k = nconfs. #for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much
+                    k = nconfs #for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much
                 BIC = n * np.log(rss / n) + k * np.log(n)
                 solution = MIQPSolutionStats(
                     threshold=threshold,


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----
This PR is changing the BIC penalty parameter from natoms * 4* nconfs to nconfs in only segments. Including all the atoms and the parameters sampled reduce our ability to identify alt confs in the segment portion of the algorithm. 