### PR TITLE
Improved Error Message when CPLEX is not installed

### DIFF
--- a/src/qfit/solvers.py
+++ b/src/qfit/solvers.py
@@ -13,6 +13,10 @@ try:
     import cplex
 except ImportError:
     CPLEX = False
+    msg = (
+        "CPLEX or CVXOPT is not install. Please re-install these packages and qFit to run"
+          )
+    raise RuntimeError(msg)
 else:
     CPLEX = True
     SolverError = cplex.exceptions.CplexSolverError


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----
When CPLEX is not installed, we used to get the error message:

`ImportError: cannot import name 'SolverError' from 'qfit.solvers' `

But we should be returning a runtime error stating that CPLEX and CVOPT are not installed. 

