### PR TITLE
updating chi sampling dof per iteration to 1

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -72,7 +72,7 @@ class QFitOptions:
         # Sampling options
         self.clash_scaling_factor = 0.75
         self.external_clash = False
-        self.dofs_per_iteration = 1
+        self.dofs_per_iteration = 1 
         self.dihedral_stepsize = 10
         self.hydro = False
         self.rmsd_cutoff = 0.01

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -72,7 +72,7 @@ class QFitOptions:
         # Sampling options
         self.clash_scaling_factor = 0.75
         self.external_clash = False
-        self.dofs_per_iteration = 2
+        self.dofs_per_iteration = 1
         self.dihedral_stepsize = 10
         self.hydro = False
         self.rmsd_cutoff = 0.01


### PR DESCRIPTION
This option determines if we sample a single chi angle at a time or 2 chi angles at a time. 
Unknown why this was set to 2. It was done by Gydo. But based on the extensive sampling with other things, we can reduce it to 1. 

After running this through the qFit test set compared to chi_sampling_dof = 2, this gave equal results in the number of altconfs and Rfree values. Examining the <100 residues that had differences, they were minor (RMSD < 0.07). But this significantly reduces our sampling. 

### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
