### PR TITLE
354 re work angle sampling to rotate 360

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -922,7 +922,7 @@ class QFitRotamericResidue(_BaseQFit):
         Only operates on residues with large aromatic sidechains
             (Trp, Tyr, Phe, His) where CG is a member of the aromatic ring.
         Here, slight deflections of the ring are likely to lead to better-
-            scoring conformers when we scan χ(Cα-Cβ) and χ(Cβ-Cγ) later.
+            scoring conformers when we scan χ(Cα-Cβ) and χ(Cβ-Cγ).
 
         This angle does not exist in {Gly, Ala}, and it does not make sense to
             sample this angle in Pro.
@@ -962,14 +962,18 @@ class QFitRotamericResidue(_BaseQFit):
         new_bs = []
         for coor in self._coor_set:
             self.residue.coor = coor
-            rotator = CBAngleRotator(self.residue)
+            # Initialize rotator 
+            perp_rotator = CBAngleRotator(self.residue)
+            # Rotate about the axis perpendicular to CB-CA and CB-CG vectors
             for perp_angle in angles:
-                rotator(perp_angle)
+                perp_rotator(perp_angle)
                 coor_rotated = self.residue.coor
-                new_rotator = BisectingAngleRotator(self.residue)
+                # Initialize rotator
+                bisec_rotator = BisectingAngleRotator(self.residue)
+                # Rotate about the axis bisecting the CA-CA-CG angle for each angle you sample across the perpendicular axis
                 for bisec_angle in angles:
                     self.residue.coor = coor_rotated  # Ensure that the second rotation is applied to the updated coordinates from first rotation
-                    new_rotator(bisec_angle)
+                    bisec_rotator(bisec_angle)
                     coor = self.residue.coor
 
                     # Move on if these coordinates are unsupported by density

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -136,7 +136,7 @@ class CBAngleRotator:
 
 class BisectingAngleRotator:
     """"
-    Deflects a residue's sidechain by bending the CA-CB-CG angle. Rotate about axis perpendicular to this angle. 
+    Deflects a residue's sidechain by bending the CA-CB-CG angle. Rotate about axis bisecting this angle. 
     """
     
     def __init__(self, residue):

--- a/src/qfit/samplers.py
+++ b/src/qfit/samplers.py
@@ -80,7 +80,7 @@ class Translator:
 
 
 class CBAngleRotator:
-    """Deflects a residue's sidechain by bending the CA-CB-CG angle.
+    """Deflects a residue's sidechain by bending the CA-CB-CG angle. Rotate about the axis perpendicular to CB-CA and CB-CG vectors.
 
     Attributes:
         residue (qfit._BaseResidue): Residue being manipulated.
@@ -136,11 +136,21 @@ class CBAngleRotator:
 
 class BisectingAngleRotator:
     """"
-    Deflects a residue's sidechain by bending the CA-CB-CG angle. Rotate about axis bisecting this angle. 
+    Deflects a residue's sidechain by bending the CA-CB-CG angle. Rotate the aromatic side chain about an axis bisecting this angle. 
+
+    Attributes:
+        residue (qfit._BaseResidue): Residue being manipulated.
+        atoms_to_rotate (np.ndarray[int]): Atom indices that will be moved by
+            the flexion.
     """
     
     def __init__(self, residue):
-
+        """
+        Inits a BisectingAngleRotator to rotate the sidechain about an axis bisecting the CA-CB-CG angle of a residue
+        
+        Args:
+            residue (qfit._BaseResidue): Residue to manipulate.
+        """
         self.residue = residue
 
         # These atoms define the angle
@@ -153,29 +163,27 @@ class BisectingAngleRotator:
             "name", ("N", "CA", "C", "O", "CB", "H", "HA", "HB2", "HB3"), "!="
         )
 
-        # Define rotation unit vector
+        # Define the origin of rotation as the coordinates of the CB atom
         self._origin = self.residue.extract("name", "CB").coor[0]
+        # Get the coordinates of the atoms to rotate 
         self._coor_to_rotate = self.residue._coor[self.atoms_to_rotate]
         self._coor_to_rotate -= self._origin
+        # Extract the coordinates of the CA and CG atoms, and translate them relative to the origin
         axis_coor = self.residue.extract("name", ("CA", "CG")).coor
         axis_coor -= self._origin
-        axis = np.cross(axis_coor[0], axis_coor[1])
-        axis /= np.linalg.norm(axis)
-        self.axis = axis
 
-        
-        # Define a bisecting unit vector for further rotation
+        # Normalize the vectors pointing from CB to CA and from CB to CG
         vec_CA = axis_coor[0]
         vec_CG = axis_coor[1]
         vec_CA /= np.linalg.norm(vec_CA)
         vec_CG /= np.linalg.norm(vec_CG)
-            
+        # Define a new rotation axis as the normalized sum of vec_CA and vec_CG. This makes the axis bisect the angle between these two vectors 
         new_axis = vec_CA + vec_CG
         new_axis /= np.linalg.norm(new_axis)
         self.new_axis = new_axis
 
-
-        # Align rotation unit vector to Z-axis
+       
+        # Align the new rotation axis to the Z-axis to simplify the rotation transformation
         aligner = ZAxisAligner(new_axis)
         self._forward = aligner.forward_rotation
         self._coor_to_rotate = (aligner.backward_rotation @ self._coor_to_rotate.T).T


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

Link to issue:

https://github.com/ExcitedStates/qfit-3.0/issues/354

Currently we only sample up/down some input angle for aromatic side chains. I'm adding to this sampling method, letting the side chains rotate closer to 360 degrees rather than just about a single axis. This covers more of the conformational space.


### Release Notes

Modified α-β-γ angle sampling in qfit_protein to cover more of the conformational space. 

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
