### PR TITLE
Updating BIC hyperparameter

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -83,7 +83,6 @@ class QFitOptions:
         self.threshold = 0.20
         self.bic_threshold = True
         self.seg_bic_threshold = True
-        self.bic_number = 0.95
 
         ### From QFitRotamericResidueOptions, QFitCovalentLigandOptions
         # Backbone sampling
@@ -320,8 +319,8 @@ class _BaseQFit:
                 nconfs = np.sum(solver.weights >= 0.002)
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
                 k = (
-                    model_params_per_atom * natoms * nconfs * self.options.BIC_num
-                )  # 0.95 hyperparameter in put in here since we are almost always over penalizing
+                    model_params_per_atom * natoms * nconfs * 1.5
+                )  #hyperparameter 1.5 determined to be the best cut off between too many conformations and improving Rfree
                 if segment is not None:
                     k = nconfs  # for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much
                 BIC = n * np.log(rss / n) + k * np.log(n)

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -83,6 +83,7 @@ class QFitOptions:
         self.threshold = 0.20
         self.bic_threshold = True
         self.seg_bic_threshold = True
+        self.bic_number = 0.95
 
         ### From QFitRotamericResidueOptions, QFitCovalentLigandOptions
         # Backbone sampling
@@ -290,13 +291,13 @@ class _BaseQFit:
         self,
         cardinality,
         threshold,
-        loop_range=[0.5, 0.4, 0.33, 0.3, 0.25, 0.2],
+        loop_range=[1.0, 0.5, 0.33, 0.25, 0.2],
         do_BIC_selection=None,
         segment=None,
     ):
         # set loop range differently for EM
         if self.options.em:
-            loop_range = [0.5, 0.33, 0.25]
+            loop_range = [1.0, 0.5, 0.33, 0.25]
         # Set the default (from options) if it hasn't been passed as an argument
         if do_BIC_selection is None:
             do_BIC_selection = self.options.bic_threshold
@@ -319,7 +320,7 @@ class _BaseQFit:
                 nconfs = np.sum(solver.weights >= 0.002)
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
                 k = (
-                    model_params_per_atom * natoms * nconfs * 0.95
+                    model_params_per_atom * natoms * nconfs * self.options.BIC_num
                 )  # 0.95 hyperparameter in put in here since we are almost always over penalizing
                 if segment is not None:
                     k = nconfs  # for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -62,7 +62,6 @@ def build_argparser():
         help="Run qFit with EM options",
     )
     # Map options
-    )
     p.add_argument(
         "-l",
         "--label",

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -61,13 +61,7 @@ def build_argparser():
         dest="em",
         help="Run qFit with EM options",
     )
-    # Map input options
-    p.add_argument(
-        "-bn",
-        "--BIC_num",
-        action="store_true",
-        dest="BIC_num"
-    )
+    # Map options
     )
     p.add_argument(
         "-l",

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -61,8 +61,14 @@ def build_argparser():
         dest="em",
         help="Run qFit with EM options",
     )
-
     # Map input options
+    p.add_argument(
+        "-bn",
+        "--BIC_num",
+        action="store_true",
+        dest="BIC_num"
+    )
+    )
     p.add_argument(
         "-l",
         "--label",


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----

### Description of the Change

This PR will update the hyperparameter from 0.95 to 1.5 within the BIC equation in qFit. 0.95 was chosen originally. After testing 1.5 had the best result between choosing the least number of conformations and not reducing Rfree. 

