### PR TITLE
Allow qFit to run with multiple backbone inputs

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -755,9 +755,13 @@ class QFitRotamericResidue(_BaseQFit):
         #     use current coords for this residue, and abort.
 
         # we want to sample the backbone for every coordinate in the backbone that exists. 
-        if self.options.backbone_coordinates is not None:
-            for name, coor in self.options.backbone_coordinates.items():
-                self.segment[index].extract("name", name).coor = coor
+        print(self.options.backbone_coordinates)
+        for residue_key, atom_dict in self.options.backbone_coordinates.items():
+            for atom_name, coor in atom_dict.items():
+                print(atom_name)
+                print(coor)
+                self.segment[index].coor[self.segment[index].name == atom_name] = coor
+
         
             # we only want to look for backbone in the segment we are using for inverse kinetmatics, not the entire protein
             for n, residue in enumerate(self.segment.residues[(index - 3) : (index + 3)]):

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -818,7 +818,7 @@ class QFitRotamericResidue(_BaseQFit):
                     prefix=f"sample_backbone_segment{index:03d}"
                 )
 
-     def _sample_angle(self):
+    def _sample_angle(self):
         """Sample residue conformations by flexing α-β-γ angle.
 
         Only operates on residues with large aromatic sidechains

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -644,21 +644,15 @@ class QFitRotamericResidue(_BaseQFit):
 
     def run(self):
         if self.options.sample_backbone:
-            residue_chain_key = (self.residue.resi[0], self.residue.chain[0].replace('"', ''))
             for altloc in self.options.backbone_coor_dict['coords']:
-                self.residue.coor = self.options.backbone_coor_dict['coords'][altloc]#[atom_name]
+                self.residue.coor = self.options.backbone_coor_dict['coords'][altloc]
                 if self.residue.resn[0] == 'GLY':
                     atom = self.residue.extract("name", "O")
                 else:
                     atom = self.residue.extract("name", "CB")
-                self.u_matrix = [
-                    [atom.u00[0], atom.u01[0], atom.u02[0]],
-                    [atom.u01[0], atom.u11[0], atom.u12[0]],
-                    [atom.u02[0], atom.u12[0], atom.u22[0]],
-                ]
+                if self.options.backbone_coor_dict['u_matrices'][altloc] is not None:
+                    self.u_matrix = self.options.backbone_coor_dict['u_matrices'][altloc]
                 self._sample_backbone()
-        else:
-            self._sample_backbone()
         if self.options.sample_angle:
             self._sample_angle()
 
@@ -736,6 +730,7 @@ class QFitRotamericResidue(_BaseQFit):
 
         # Determine directions for backbone sampling
         atom = self.residue.extract("name", atom_name)
+        
         try:
             if not self.u_matrix:
                 self.u_matrix = [
@@ -744,7 +739,7 @@ class QFitRotamericResidue(_BaseQFit):
                     [atom.u02[0], atom.u12[0], atom.u22[0]],
                 ]
             directions = adp_ellipsoid_axes(self.u_matrix)
-            logger.debug(f"[_sample_backbone] u_matrix = {u_matrix}")
+            logger.debug(f"[_sample_backbone] u_matrix = {self.u_matrix}")
         except AttributeError:
             logger.debug(
                 f"[{self.identifier}] Got AttributeError for directions at Cβ. Treating as isotropic B, using Cβ-Cα, C-N,(Cβ-Cα × C-N) vectors."

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -736,34 +736,34 @@ class QFitRotamericResidue(_BaseQFit):
 
         # Determine directions for backbone sampling
         atom = self.residue.extract("name", atom_name)
-        if not self.u_matrix:
-            try:
+        try:
+            if not self.u_matrix:
                 self.u_matrix = [
                     [atom.u00[0], atom.u01[0], atom.u02[0]],
                     [atom.u01[0], atom.u11[0], atom.u12[0]],
                     [atom.u02[0], atom.u12[0], atom.u22[0]],
                 ]
-                directions = adp_ellipsoid_axes(self.u_matrix)
-                logger.debug(f"[_sample_backbone] u_matrix = {u_matrix}")
-            except AttributeError:
-                logger.debug(
-                    f"[{self.identifier}] Got AttributeError for directions at Cβ. Treating as isotropic B, using Cβ-Cα, C-N,(Cβ-Cα × C-N) vectors."
-                )
-                # Choose direction vectors as Cβ-Cα, C-N, and then (Cβ-Cα × C-N)
-                # Find coordinates of Cα, Cβ, N atoms
-                pos_CA = self.residue.extract("name", "CA").coor[0]
-                pos_CB = self.residue.extract("name", atom_name).coor[0] # Position of CB for all residues except for GLY, which is position of O
-                pos_N = self.residue.extract("name", "N").coor[0]
-                # Set x, y, z = Cβ-Cα, Cα-N, (Cβ-Cα × Cα-N)
-                vec_x = pos_CB - pos_CA
-                vec_y = pos_CA - pos_N
-                vec_z = np.cross(vec_x, vec_y)
-                # Normalize
-                vec_x /= np.linalg.norm(vec_x)
-                vec_y /= np.linalg.norm(vec_y)
-                vec_z /= np.linalg.norm(vec_z)
+            directions = adp_ellipsoid_axes(self.u_matrix)
+            logger.debug(f"[_sample_backbone] u_matrix = {u_matrix}")
+        except AttributeError:
+            logger.debug(
+                f"[{self.identifier}] Got AttributeError for directions at Cβ. Treating as isotropic B, using Cβ-Cα, C-N,(Cβ-Cα × C-N) vectors."
+            )
+            # Choose direction vectors as Cβ-Cα, C-N, and then (Cβ-Cα × C-N)
+            # Find coordinates of Cα, Cβ, N atoms
+            pos_CA = self.residue.extract("name", "CA").coor[0]
+            pos_CB = self.residue.extract("name", atom_name).coor[0] # Position of CB for all residues except for GLY, which is position of O
+            pos_N = self.residue.extract("name", "N").coor[0]
+            # Set x, y, z = Cβ-Cα, Cα-N, (Cβ-Cα × Cα-N)
+            vec_x = pos_CB - pos_CA
+            vec_y = pos_CA - pos_N
+            vec_z = np.cross(vec_x, vec_y)
+            # Normalize
+            vec_x /= np.linalg.norm(vec_x)
+            vec_y /= np.linalg.norm(vec_y)
+            vec_z /= np.linalg.norm(vec_z)
 
-                directions = np.vstack([vec_x, vec_y, vec_z])
+            directions = np.vstack([vec_x, vec_y, vec_z])
 
         # If we are missing a backbone atom in our segment,
         #     use current coords for this residue, and abort.

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -509,11 +509,14 @@ class QFitProtein:
                 else:
                     atom_name = "CB"
                 atom = self.structure.extract("chain", residue.chain[0], "==").extract("resi", residue.resi[0], "==").extract("name", atom_name).extract("altloc", altloc)
-                u_matrix = [
-                            [atom.u00[0], atom.u01[0], atom.u02[0]],
-                            [atom.u01[0], atom.u11[0], atom.u12[0]],
-                            [atom.u02[0], atom.u12[0], atom.u22[0]],
-                ]
+                try:
+                    u_matrix = [
+                                [atom.u00[0], atom.u01[0], atom.u02[0]],
+                                [atom.u01[0], atom.u11[0], atom.u12[0]],
+                                [atom.u02[0], atom.u12[0], atom.u22[0]],
+                    ]
+                except:
+                    u_matrix = None
                 grouped_u_matrices[altloc] = u_matrix
             backbone_coor_dict[residue_chain_key]['coords'] = grouped_coords
             backbone_coor_dict[residue_chain_key]['u_matrices'] = grouped_u_matrices

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -883,8 +883,6 @@ class QFitProtein:
 
         chain_resi_id= f"{resi}, '{chainid}'"
         chain_resi_id = (resi, chainid)
-        print('chain_resi_id:')
-        print(chain_resi_id)
         options.backbone_coor_dict = backbone_coor_dict[chain_resi_id]
         # Exception handling in case qFit-residue fails:
         qfit = QFitRotamericResidue(residue, structure_new, xmap, options)

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -495,15 +495,14 @@ class QFitProtein:
             )
 
         backbone_coor_dict = {}
-        grouped_coords = {}
-        grouped_u_matrices = {}
         for residue in residues:
+            grouped_coords = {}
+            grouped_u_matrices = {}
             residue_chain_key = (residue.resi[0], residue.chain[0].replace('"', ''))
             if residue_chain_key not in backbone_coor_dict:
                 backbone_coor_dict[residue_chain_key] = {}
             for altloc in np.unique(self.structure.extract("chain", residue.chain[0], "==").extract("resi", residue.resi[0], "==").altloc):
-                residue_atoms = self.structure.extract("chain", residue.chain[0], "==").extract("resi", residue.resi[0], "==").extract("altloc", altloc)
-                grouped_coords[altloc] = residue_atoms.coor
+                grouped_coords[altloc] = self.structure.extract("chain", residue.chain[0], "==").extract("resi", residue.resi[0], "==").extract("altloc", altloc).coor
                 if residue.resn[0] == "GLY": 
                     atom_name = "O"
                 else:
@@ -520,7 +519,6 @@ class QFitProtein:
                 grouped_u_matrices[altloc] = u_matrix
             backbone_coor_dict[residue_chain_key]['coords'] = grouped_coords
             backbone_coor_dict[residue_chain_key]['u_matrices'] = grouped_u_matrices
-
         # Filter the residues: take only those not containing checkpoints.
         def does_multiconformer_checkpoint_exist(residue):
             fname = os.path.join(
@@ -885,6 +883,8 @@ class QFitProtein:
 
         chain_resi_id= f"{resi}, '{chainid}'"
         chain_resi_id = (resi, chainid)
+        print('chain_resi_id:')
+        print(chain_resi_id)
         options.backbone_coor_dict = backbone_coor_dict[chain_resi_id]
         # Exception handling in case qFit-residue fails:
         qfit = QFitRotamericResidue(residue, structure_new, xmap, options)

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -462,14 +462,21 @@ class QFitProtein:
 
         # Get information about all backbone atoms. If the input structure has multiple backbones, we will initiate backbone sampling (and all residue sampling) using all backbone coordinates 
         backbone_coor_dict = {}
-            for residue in self.structure.extract(f"resi {resi} and chain {chainid}"):
-                if residue.resn[0] != "HOH":
-                    ca_coor = residue.extract("name", "CA").coor
-                    c_coor = residue.extract("name", "C").coor
-                    n_coor = residue.extract("name", "N").coor
-                    o_coor = residue.extract("name", "O").coor
-                    grouped_coords = {"CA": ca_coor, "C": c_coor, "N": n_coor, "O": o_coor}
-                    backbone_coor_dict[(residue.resi[0], residue.chain[0].replace('"', ''))] = grouped_coords
+        for residue in self.structure.extract(f"resi {resi} and chain {chainid}"):
+            if residue.resn[0] != "HOH":
+                ca_coor = residue.extract("name", "CA").coor
+                c_coor = residue.extract("name", "C").coor
+                n_coor = residue.extract("name", "N").coor
+                o_coor = residue.extract("name", "O").coor
+                atom_coords = [ca_coor, c_coor, n_coor, o_coor]
+                atom_names = ["CA", "C", "N", "O"]
+                grouped_coords = {}
+                for i in range(len(atom_coords[0])):
+                    grouped_coords[i] = {name: coords[i] for name, coords in zip(atom_names, atom_coords)}
+                residue_chain_key = (residue.resi[0], residue.chain[0].replace('"', ''))
+                if residue_chain_key not in backbone_coor_dict:
+                    backbone_coor_dict[residue_chain_key] = {}
+                backbone_coor_dict[residue_chain_key] = grouped_coords
                     
         # Create a list of residues from single conformations of proteinaceous residues.
         # If we were to loop over all single_conformer_residues, then we end up adding HETATMs in two places


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.

----
If the input PDB has altlocs for C, CA, N, or O, it will run qFit residue starting from both conformations. This specifically will run sample_backbone x number of times determined by the number of backbone coordinates. This will then feed in both samplings into the coor_set for subsequent sampling. 

This is done by creating a dictionary in qfit_protein with the coordinates for all altlocs and the anisotropic matrix if applicable. 

This is still suffering from over-sampling with angle (and making it 2x or 3x worse), but is still returning the same conformations. 