### PR TITLE
Split QP step into two in sample sidechain

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1027,13 +1027,9 @@ class QFitRotamericResidue(_BaseQFit):
 
             if len(self._coor_set) > 15000:
                 logger.warning(
-                    f"[{self.identifier}] Too many conformers generated ({len(self._coor_set)}). "
-                    f"Reverting to a previous iteration of degrees of freedom: item 0. "
-                    f"n_coords: {[len(cs) for (cs) in iter_coor_set]}"
+                    f"[{self.identifier}] Too many conformers generated ({len(self._coor_set)}). Splitting QP scoring."
                 )
-                self._coor_set = iter_coor_set[0]
-                self._bs = iter_b_set[0]
-
+                
             if not self._coor_set:
                 msg = (
                     "No conformers could be generated. Check for initial "
@@ -1048,15 +1044,65 @@ class QFitRotamericResidue(_BaseQFit):
                 self._write_intermediate_conformers(
                     prefix=f"sample_sidechain_iter{iteration}"
                 )
+            
+            if len(self._coor_set) <= 15000:
+                # If <15000 conformers are generated, QP score conformer occupancy normally 
+                self._convert()
+                self._solve_qp()
+                self._update_conformers()
+                if self.options.write_intermediate_conformers:
+                    self._write_intermediate_conformers(
+                        prefix=f"sample_sidechain_iter{iteration}_qp"
+                    )
+            if len(self._coor_set) > 15000:
+                # If >15000 conformers are generated, split the QP conformer scoring into two
+                temp_coor_set = self._coor_set
+                temp_bs = self._bs
 
-            # QP score conformer occupancy
-            self._convert()
-            self._solve_qp()
-            self._update_conformers()
-            if self.options.write_intermediate_conformers:
-                self._write_intermediate_conformers(
-                    prefix=f"sample_sidechain_iter{iteration}_qp"
-                )
+                # Splitting the arrays into two sections
+                half_index = len(temp_coor_set) // 2  # Integer division for splitting
+                section_1_coor = temp_coor_set[:half_index]
+                section_1_bs = temp_bs[:half_index]
+                section_2_coor = temp_coor_set[half_index:]
+                section_2_bs = temp_bs[half_index:]
+
+                # Process the first section
+                self._coor_set = section_1_coor
+                self._bs = section_1_bs
+
+                # QP score the first section
+                self._convert()
+                self._solve_qp()
+                self._update_conformers()
+                if self.options.write_intermediate_conformers:
+                    self._write_intermediate_conformers(
+                        prefix=f"sample_sidechain_iter{iteration}_qp"
+                    )
+
+                # Save results from the first section
+                qp_temp_coor = self._coor_set
+                qp_temp_bs = self._bs
+
+                # Process the second section
+                self._coor_set = section_2_coor
+                self._bs = section_2_bs
+
+                # QP score the second section 
+                self._convert()
+                self._solve_qp()
+                self._update_conformers()
+                if self.options.write_intermediate_conformers:
+                    self._write_intermediate_conformers(
+                        prefix=f"sample_sidechain_iter{iteration}_qp"
+                    )
+
+                # Save results from the second section
+                qp_2_temp_coor = self._coor_set
+                qp_2_temp_bs = self._bs
+
+                # Concatenate the results from both sections
+                self._coor_set = np.concatenate((qp_temp_coor, qp_2_temp_coor), axis=0)
+                self._bs = np.concatenate((qp_temp_bs, qp_2_temp_bs), axis=0)
 
             # MIQP score conformer occupancy
             self.sample_b()


### PR DESCRIPTION
If too many conformers are generated during sidechain, split conformer array into two sections and score them separately

### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change
If too many conformers are generated during sample_sidechain(), split conformer array into two sections and score them separately. Concatenate after scoring both sections. This allows us to sample >15000 conformers without overloading QP. 

This is a temporary fix. Ideally, we want to reduce sampling as the time sampling is getting increasingly high for these residues. However, we believe we can do that more effectively with attention based sampling and so are leaving this patch in here for now. 


<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes
Split QP during sample_sidechain() in qfit.py
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
