### PR TITLE
Making open OSQP solver default!

### DIFF
--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -338,8 +338,8 @@ def build_argparser():
         "--qp-solver",
         dest="qp_solver",
         choices=available_qp_solvers.keys(),
-        default=next(iter(available_qp_solvers.keys())),
-        help="Select the QP solver",
+        default='OSQPSolver',
+        help="Select the QP solver. Please chose between: 'CVXOPTSolver', 'CPLEXSolver', 'OSQPSolver'",
     )
     p.add_argument(
         "--miqp-solver",

--- a/src/qfit/qfit_protein.py
+++ b/src/qfit/qfit_protein.py
@@ -339,14 +339,14 @@ def build_argparser():
         dest="qp_solver",
         choices=available_qp_solvers.keys(),
         default='OSQPSolver',
-        help="Select the QP solver. Please chose between: 'CVXOPTSolver', 'CPLEXSolver', 'OSQPSolver'",
+        help="Select the QP solver. Please choose between: 'CVXOPTSolver', 'CPLEXSolver', 'OSQPSolver'",
     )
     p.add_argument(
         "--miqp-solver",
         dest="miqp_solver",
         choices=available_miqp_solvers.keys(),
-        default=next(iter(available_miqp_solvers.keys())),
-        help="Select the MIQP solver",
+        default='MIOSQPSolver',
+        help="Select the MIQP solver. Please choose between: 'CPLEXSolver', 'MIOSQPSolver'",
     )
 
     # qFit Segment options


### PR DESCRIPTION
### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [
[X] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
