### PR TITLE
Use deposited conformers if clashes

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1196,6 +1196,13 @@ class QFitRotamericResidue(_BaseQFit):
     def tofile(self):
         # Save the individual conformers
         conformers = self.get_conformers()
+        if len(conformers) == 0:
+            msg = "No conformers could be generated. " "Using Deposited conformer."
+            logger.warning(msg)
+            self._coor_set = [self.residue.coor]
+            self._bs = [self.residue.b]
+            self._occupancies = [1.0]
+            conformers = self.get_conformers()
         for n, conformer in enumerate(conformers, start=1):
             fname = os.path.join(self.directory_name, f"conformer_{n}.pdb")
             conformer.tofile(fname)
@@ -2238,11 +2245,11 @@ class QFitCovalentLigand(_BaseQFit):
                 self._bs = new_bs
 
             if not self._coor_set:
-                msg = (
-                    "No conformers could be generated. Check for initial "
-                    "clashes and density support."
+                logger.warning(
+                    "No conformers could be generated. Using deposited conformer."
                 )
-                raise RuntimeError(msg)
+                self._coor_set = [self.residue.coor]
+                self._bs = [self.residue.b]
             else:
                 logger.info(
                     f"Side chain sampling produced {len(self._coor_set)} conformers"


### PR DESCRIPTION
If qFit does not generate any conformers due to clashes, we will use the deposited conformer.

### Pull Request Checklist

- [X] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [X] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [X] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [X] Fill out the template below.



----

### Description of the Change

If qFit does not produce any conformers due to clashes, this used to result in conformer being returned. This was an issue for segment and refinement (& the model). Now it just returns the deposited conformer. 