### PR TITLE
Fix Cryo-EM input without symmetry

### DIFF
--- a/src/qfit/utils/mock_utils.py
+++ b/src/qfit/utils/mock_utils.py
@@ -89,16 +89,19 @@ SERINE_ALTERNATE_SYMMETRY = {
 
 
 def create_fmodel(pdb_file_name, high_resolution, output_file=None,
-                  em=False):
+                  em=False, reference_file=None):
     if output_file is None:
         output_file = tempfile.NamedTemporaryFile(suffix="-fmodel.mtz").name
     fmodel_args = [
         pdb_file_name,
-        f"high_resolution={high_resolution}",
         "r_free_flags_fraction=0.1",
         "output.label=FWT",
         f"output.file_name={output_file}",
     ]
+    if reference_file:
+        fmodel_args.append(reference_file)
+    else:
+        fmodel_args.append(f"high_resolution={high_resolution}")
     if em:
         fmodel_args.append("scattering_table=electron")
     # XXX the CLI implementation for mmtbx tools has changed - the old 'run'
@@ -164,8 +167,8 @@ class BaseTestRunner(unittest.TestCase):
             (space_group_symbol, unit_cell) = new_symmetry
             new_symmetry = symmetry(space_group_symbol=space_group_symbol,
                                     unit_cell=unit_cell)
-        suffix = "_newsymm.pdb"
         if not output_pdb_file:
+            suffix = "_newsymm.pdb"
             output_pdb_file = op.splitext(op.basename(pdb_file))[0] + suffix
         pdb_in = Structure.fromfile(pdb_file)
         pdb_in.crystal_symmetry = new_symmetry

--- a/src/qfit/xtal/transformer.py
+++ b/src/qfit/xtal/transformer.py
@@ -69,14 +69,19 @@ class CCTBXTransformer:
         # mmtbx.utils.extract_box_around_model_and_map.  in the future it
         # would be better to use that wrapper directly in qfit, in place
         # of the calls to xmap.extract()
-        xrs = self.structure.to_xray_structure(active_only=True)
+        symm = self.structure.crystal_symmetry
+        if not symm:
+            symm = self.xmap.get_p1_crystal_symmetry()
+        xrs = self.structure.to_xray_structure(
+            active_only=True,
+            crystal_symmetry=symm)
         if self.xmap.is_canonical_unit_cell():
             return xrs.expand_to_p1()
         origin = tuple(int(x) for x in self.xmap.grid_parameters.offset)
         uc_grid = tuple(int(x) for x in self.xmap.unit_cell_shape)
         n_real = self.xmap.n_real()
         #logger.debug(f"Computing mask with n_real={n_real} origin={origin} uc_grid={uc_grid}")
-        ucp = self.structure.crystal_symmetry.unit_cell().parameters()
+        ucp = symm.unit_cell().parameters()
         box_cell_abc = [ucp[i]*(n_real[i]/uc_grid[i]) for i in range(3)]
         uc_box = unit_cell(box_cell_abc + list(ucp)[3:])
         #logger.debug(f"New unit cell: {uc_box.parameters()}")

--- a/src/qfit/xtal/volume.py
+++ b/src/qfit/xtal/volume.py
@@ -9,7 +9,7 @@ from scipy.ndimage import map_coordinates
 from iotbx.reflection_file_reader import any_reflection_file
 import iotbx.ccp4_map
 import iotbx.mrcfile
-from cctbx import maptbx
+from cctbx import maptbx, crystal
 from scitbx.array_family import flex
 import boost_adaptbx.boost.python as bp
 asu_map_ext = bp.import_ext("cctbx_asymmetric_map_ext")
@@ -236,6 +236,10 @@ class XMap(_BaseVolume):
             int
         )
         return shape
+
+    def get_p1_crystal_symmetry(self):
+        return crystal.symmetry(unit_cell=self.unit_cell.to_cctbx(),
+                                space_group_symbol="P1")
 
     def _expand_to_p1(self):
         """

--- a/tests/unit/test_xtal_volume.py
+++ b/tests/unit/test_xtal_volume.py
@@ -32,6 +32,9 @@ class TestVolumeXmapIO(UnitBase):
             assert xmap.value_at(0, 0, 0) == pytest.approx(-0.719, abs=0.001)
             assert xmap.value_at(4, 5, 6) == pytest.approx(4.1893, abs=0.001)
             assert tuple(xmap.offset) == (0, 0, 0)
+            symm = xmap.get_p1_crystal_symmetry()
+            assert symm.unit_cell().parameters() == (4.0, 5.0, 6.0, 90, 90, 90)
+            assert str(symm.space_group_info()) == "P 1"
 
         MTZ = self.make_water_fmodel_mtz(d_min)
         print(f"MTZ: {MTZ}")


### PR DESCRIPTION
The transformer will now use the P1 unit cell defined by the map if the structure does not explicitly specify symmetry.  This change also tests the placeholder symmetry used by the PDB in CRYST1 records.