### PR TITLE
remove duplicate rotamer sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Electron density maps obtained from high-resolution X-ray diffraction data are a
    
 3) Create the Conda environment using the downloaded file:
 
-   conda env create -f enviornment.yml
+   conda env create -f environment.yml
 
 4) After creating the Conda environment, activate it:
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -358,7 +358,7 @@ class _BaseQFit:
                 model_params_per_atom = 3 + int(self.options.sample_bfactors)
                 k = (
                     model_params_per_atom * natoms * nconfs * 0.8
-                )  # hyperparameter 1.5 determined to be the best cut off between too many conformations and improving Rfree
+                )  # hyperparameter 0.8 determined to be the best cut off between too many conformations and improving Rfree
                 if segment is not None:
                     k = nconfs  # for segment, we only care about the number of conformations come out of MIQP. Considering atoms penalizes this too much
                 if self.options.ligand_bic:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -9,7 +9,6 @@ import subprocess
 import numpy as np
 import tqdm
 import timeit
-import time
 import concurrent.futures
 
 
@@ -1186,7 +1185,7 @@ class QFitRotamericResidue(_BaseQFit):
                 self._coor_set = new_coor_set
                 self._bs = new_bs
 
-            if len(self._coor_set) > 1500:
+            if len(self._coor_set) > 10000:
                 logger.warning(
                     f"[{self.identifier}] Too many conformers generated ({len(self._coor_set)}). Splitting QP scoring."
                 )
@@ -1206,8 +1205,8 @@ class QFitRotamericResidue(_BaseQFit):
                     prefix=f"sample_sidechain_iter{version}_{iteration}"
                 )
 
-            if len(self._coor_set) <= 1500:
-                # If <15000 conformers are generated, QP score conformer occupancy normally
+            if len(self._coor_set) <= 10000:
+                # If <10000 conformers are generated, QP score conformer occupancy normally
                 self._convert(stride_, pool_size_)
                 self._solve_qp()
                 self._update_conformers() #should this be more lenient?
@@ -1215,8 +1214,8 @@ class QFitRotamericResidue(_BaseQFit):
                     self._write_intermediate_conformers(
                         prefix=f"sample_sidechain_iter{version}_{iteration}_qp"
                     )
-            if len(self._coor_set) > 1500:
-                # If >15000 conformers are generated, split the QP conformer scoring into two
+            if len(self._coor_set) > 10000:
+                # If >10000 conformers are generated, split the QP conformer scoring into two
                 temp_coor_set = self._coor_set
                 temp_bs = self._bs
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
