### PR TITLE
Restraint creation file in loop

### DIFF
--- a/scripts/post/qfit_final_refine_xray.sh
+++ b/scripts/post/qfit_final_refine_xray.sh
@@ -94,8 +94,8 @@ rfreetypes="FREE R-free-flags"
 for field in ${rfreetypes}; do
   if grep -F -q -w $field <<< "${mtzmetadata}"; then
     gen_Rfree=False;
-    echo "Rfree column: ${field}";
-    echo "miller_array.labels.name=${field}" >> ${pdb_name}_refine.params
+    echo "Rfree column: ${rfield}";
+    echo "miller_array.labels.name=${rfield}" >> ${pdb_name}_refine.params
     break
   fi
 done
@@ -123,8 +123,6 @@ if [ -f "${multiconf}.f_modified.ligands.cif" ]; then
   echo "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" >> ${pdb_name}_refine.params
 fi
 
-create_restraints_file.py "${pdb_name}_002.pdb"
-
 #__________________________________COORDINATE REFINEMENT ONLY__________________________________
 # Write refinement parameters into parameters file
 echo "refinement.refine.strategy=*individual_sites"  >> ${pdb_name}_refine.params
@@ -142,10 +140,11 @@ phenix.refine  "${multiconf}.f_modified.updated.pdb" \
                "refinement.main.number_of_macro_cycles=5" \
                "refinement.main.nqh_flips=False" \
                "refinement.output.write_maps=False" \
-               "input.xray_data.label=$xray_data_labels" \
-               "xray_data.r_free_flags.generate=${gen_Rfree}" \
-               "miller_array.labels.name=R-free-flags" \
+               "input.xray_data.label=${xray_data_labels}" \
+               "xray_data.r_free_flags.generate=True" \
                --overwrite
+
+create_restraints_file.py "${pdb_name}_002.pdb"
 
 #__________________________________REFINE UNTIL OCCUPANCIES CONVERGE__________________________________
 # Write refinement parameters into parameters file
@@ -198,6 +197,7 @@ while [ $zeroes -gt 1 ]; do
     exit 1;
   else
     mv -v "${pdb_name}_003_norm.pdb" "${pdb_name}_002.pdb";
+    create_restraints_file.py "${pdb_name}_002.pdb"
   fi
 
   if [ $i -ge 50 ]; then


### PR DESCRIPTION
create_restraint file needs to be updated when changing occupancies

### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----
Not re-creating restraint file during loop is causing issues with occupancy iterative refinement loop. This change now incorporates this script within the loop rather than before the loop. 