### PR TITLE
add write-intermediate-conformers to ligand sampling

### DIFF
--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -483,8 +483,12 @@ class _BaseQFit:
 
         logger.debug(f"Remaining valid conformations: {len(self._coor_set)}")
 
-    def _write_intermediate_conformers(self, prefix="conformer"):
-        for n, coor in enumerate(self._coor_set):
+    def _write_intermediate_conformers(self, prefix="conformer", coord_array=None):
+        # Use coord_array if provided, otherwise use self._coor_set
+        if coord_array is None:
+            coord_array = self._coor_set
+
+        for n, coor in enumerate(coord_array):
             self.conformer.coor = coor
             fname = os.path.join(self.directory_name, f"{prefix}_{n}.pdb")
 
@@ -1686,7 +1690,8 @@ class QFitLigand(_BaseQFit):
         self._convert()
         logger.info("Solving QP within run.")
         self._solve_qp()
-        # self._write_intermediate_conformers(prefix="pre_qp")
+        if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers(prefix="pre_qp")
         logger.debug("Updating conformers within run.")
         self._update_conformers()
 
@@ -1740,7 +1745,6 @@ class QFitLigand(_BaseQFit):
 
         if self.options.write_intermediate_conformers:
             self._write_intermediate_conformers(prefix="miqp_solution")
-        # self._write_intermediate_conformers(prefix="miqp_solution")
 
         logger.info(f"Number of final conformers: {len(self._coor_set)}")
 
@@ -1841,7 +1845,10 @@ class QFitLigand(_BaseQFit):
                         new_idx_set.append(idx)
                         new_coor_set.append(conf)
                         new_bs.append(b[0])
-
+            
+            if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("unconstrained_sol", new_coor_set)
+                
             # Save new conformers to self
             merged_arr = np.concatenate((self._coor_set, new_coor_set), axis=0)
             merged_bs = np.concatenate((self._bs, new_bs), axis=0)
@@ -1978,6 +1985,9 @@ class QFitLigand(_BaseQFit):
                         new_coor_set.append(conf)
                         new_bs.append(b[0])
 
+            if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("terminal_atoms", new_coor_set)
+                
             # Save new conformers to self
             merged_arr = np.concatenate((self._coor_set, new_coor_set), axis=0)
             merged_bs = np.concatenate((self._bs, new_bs), axis=0)
@@ -2124,6 +2134,9 @@ class QFitLigand(_BaseQFit):
                         new_coor_set.append(conf)
                         new_bs.append(b[0])
 
+            if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("blob", new_coor_set)
+                
             # Save new conformers to self
             merged_arr = np.concatenate((self._coor_set, new_coor_set), axis=0)
             merged_bs = np.concatenate((self._bs, new_bs), axis=0)
@@ -2265,6 +2278,9 @@ class QFitLigand(_BaseQFit):
                         new_coor_set.append(conf)
                         new_bs.append(b[0])
 
+            if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("branching", new_coor_set)
+                
             # Save new conformers to self
             merged_arr = np.concatenate((self._coor_set, new_coor_set), axis=0)
             merged_bs = np.concatenate((self._bs, new_bs), axis=0)
@@ -2382,6 +2398,9 @@ class QFitLigand(_BaseQFit):
                         new_coor_set.append(conf)
                         new_bs.append(b[0])
 
+            if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("long_chain", new_coor_set)
+                
             # Save new conformers to self
             merged_arr = np.concatenate((self._coor_set, new_coor_set), axis=0)
             merged_bs = np.concatenate((self._bs, new_bs), axis=0)
@@ -2449,7 +2468,10 @@ class QFitLigand(_BaseQFit):
         # Make sure b-factor array is the same length as coordinate array
         if len(self._bs) != len(self._coor_set):
             self._bs = np.tile(self._bs[0], (len(self._coor_set), 1))
-
+            
+        if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers(prefix="trans_rot_sol")
+            
         self._convert()
         logger.info("Solving QP after trans and rot search.")
         self._solve_qp()
@@ -2535,6 +2557,9 @@ class QFitLigand(_BaseQFit):
 
         logger.info(f"Generated {len(new_coor)} flipped conformers")
 
+        if self.options.write_intermediate_conformers:
+                self._write_intermediate_conformers("flip_180", new_coor)
+            
         self._coor_set = np.array(new_coor)
         self._bs = np.array(new_bs)
 


### PR DESCRIPTION
make sure _write_intermediate_conformers works for running ligand. I had to make a slight change to the _write_intermediate_conformers function to include an optional argument for inputting a coordinate array. This was necessary in order to write out the conformers for the different ligand sampling functions separately. The function can still be used without this argument, and will just write out confs stored in self._coor_set, as it already does

### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change
make sure _write_intermediate_conformers works for running ligand. I had to make a slight change to the _write_intermediate_conformers function to include an optional argument for inputting a coordinate array. This was necessary in order to write out the conformers for the different ligand sampling functions separately. The function can still be used without this argument, and will just write out confs stored in self._coor_set, as it already does

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes
add write-intermediate-conformers to ligand sampling
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
