### PR TITLE
remove BIC from side chain sampling

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.9
   - numpy>=1.20,<2
-  - scipy>=1.0
+  - scipy==9.1
   - cvxpy
   - pyscipopt
   - pandas>=1.2

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.9
   - numpy>=1.20,<2
-  - scipy==9.1
+  - scipy
   - cvxpy
   - pyscipopt
   - pandas>=1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = [
 	"setuptools_scm",
 	"numpy>=1.20,<2",
 	"cvxpy",
-	"pyscipopt",
+	"pyscipopt>=5.1.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def main():
         "numpy>=1.20,<2",
         "scipy>=1.0",
         "cvxpy",
-        "pyscipopt",
+        "pyscipopt>=5.1.1",
         "pandas>=1.2",
         "pyparsing>=2.2.0",
         "tqdm>=4.0.0",

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1187,7 +1187,7 @@ class QFitRotamericResidue(_BaseQFit):
 
                 if len(self._coor_set) <= 10000:
                     # If <15000 conformers are generated, QP score conformer occupancy normally
-                    self._convert(stride_, pool_size_)
+                    self._convert()
                     self._solve_qp()
                     self._update_conformers()
                     if self.options.write_intermediate_conformers:
@@ -1213,7 +1213,7 @@ class QFitRotamericResidue(_BaseQFit):
                     self._bs = section_1_bs
 
                     # QP score the first section
-                    self._convert(stride_, pool_size_)
+                    self._convert()
                     self._solve_qp()
                     self._update_conformers()
                     if self.options.write_intermediate_conformers:
@@ -1230,7 +1230,7 @@ class QFitRotamericResidue(_BaseQFit):
                     self._bs = section_2_bs
 
                     # QP score the second section
-                    self._convert(stride_, pool_size_)
+                    self._convert()
                     self._solve_qp()
                     self._update_conformers()
                     if self.options.write_intermediate_conformers:
@@ -1250,7 +1250,7 @@ class QFitRotamericResidue(_BaseQFit):
 
                 # MIQP score conformer occupancy
                 self.sample_b()
-                self._convert(stride_, pool_size_)
+                self._convert()
                 self._solve_miqp(
                     threshold=self.options.threshold,
                     cardinality=self.options.cardinality,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -327,7 +327,7 @@ class _BaseQFit:
         threshold,
         loop_range=[1.0, 0.5, 0.33, 0.25, 0.2],
         do_BIC_selection=None,
-        segment=None, intermediate=None
+        segment=None, terminal=True
     ):
         # set loop range differently for EM
         if self.options.em:
@@ -335,8 +335,9 @@ class _BaseQFit:
         # Set the default (from options) if it hasn't been passed as an argument
         if do_BIC_selection is None:
             do_BIC_selection = self.options.bic_threshold
-        if intermediate:
+        if terminal ==  False:
             loop_range = [0.2]
+            do_BIC_slection = False
 
         # Create solver
         logger.info("Solving MIQP")
@@ -1717,7 +1718,7 @@ class QFitLigand(_BaseQFit):
         if not self.options.ligand_bic:
             self._solve_miqp(
                 threshold=self.options.threshold,
-                cardinality=self.options._ligand_cardinality,
+                cardinality=self.options._ligand_cardinality, do_BIC_selection=False
             )
         self._update_conformers()
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -262,7 +262,7 @@ class _BaseQFit:
         # Subtract the density:
         self.xmap.array -= self._subtransformer.xmap.array
 
-    def _convert(self, stride=1, pool_size=1):  # default is to manipulate the maps
+    def _convert(self):  # default is to manipulate the maps
         """Convert structures to densities and extract relevant values for (MI)QP."""
         logger.info("Converting conformers to density")
         logger.debug("Masking")
@@ -276,38 +276,18 @@ class _BaseQFit:
         nvalues = mask.sum()
         self._target = self.xmap.array[mask]
 
-        # For a 1D array, we adjust our pooling approach
-        pooled_values = []
-        for i in range(0, len(self._target), stride):
-            # Extract the current window for pooling
-            current_window = self._target[i : i + pool_size]
-            # Perform max pooling on the current window and append the max value to pooled_values
-            if len(current_window) > 0:  # Ensure the window is not empty
-                pooled_values.append(np.max(current_window))
-
-        # Convert pooled_values back to a numpy array
-        self._target = np.array(pooled_values)
-
         logger.debug("Density")
         nmodels = len(self._coor_set)
-        maxpool_size = len(range(0, nvalues, stride))
-        self._models = np.zeros((nmodels, maxpool_size), float)
+        self._models = np.zeros((nmodels, nvalues), float)
         for n, coor in enumerate(self._coor_set):
             self.conformer.coor = coor
             self.conformer.b = self._bs[n]
             self._transformer.density()
             model = self._models[n]
-            # Apply maxpooling to the map similar to self._target
-            map_values = self._transformer.xmap.array[mask]
-            pooled_map_values = []
-            for i in range(0, len(map_values), stride):
-                current_window = map_values[i : i + pool_size]
-                if len(current_window) > 0:
-                    pooled_map_values.append(np.max(current_window))
-            model[:] = np.array(pooled_map_values)
+            model[:] = self._transformer.xmap.array[mask]
             np.maximum(model, self.options.bulk_solvent_level, out=model)
             self._transformer.reset(full=True)
-
+    
     def _solve_qp(self):
         # Create and run solver
         logger.info("Solving QP")

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -327,7 +327,7 @@ class _BaseQFit:
         threshold,
         loop_range=[1.0, 0.5, 0.33, 0.25, 0.2],
         do_BIC_selection=None,
-        segment=None,
+        segment=None, intermediate=None
     ):
         # set loop range differently for EM
         if self.options.em:
@@ -335,6 +335,8 @@ class _BaseQFit:
         # Set the default (from options) if it hasn't been passed as an argument
         if do_BIC_selection is None:
             do_BIC_selection = self.options.bic_threshold
+        if intermediate:
+            loop_range = [0.2]
 
         # Create solver
         logger.info("Solving MIQP")
@@ -1270,6 +1272,7 @@ class QFitRotamericResidue(_BaseQFit):
                 self._solve_miqp(
                     threshold=self.options.threshold,
                     cardinality=self.options.cardinality,
+                    terminal=False, do_BIC_selection=False
                 )
                 self._update_conformers()
                 if self.options.write_intermediate_conformers:

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -1032,8 +1032,8 @@ class QFitRotamericResidue(_BaseQFit):
         logger.debug(f"Bond angle sampling generated {len(self._coor_set)} conformers.")
         if self.options.write_intermediate_conformers:
             self._write_intermediate_conformers(prefix=f"sample_angle")
-
-   def _sample_sidechain(self, version=1):
+    
+    def _sample_sidechain(self, version=1):
         opt = self.options
         start_chi_index = 1
         


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----
There are two changes this PR is making:

1) It is eliminating us running through MIQP 5 times in the non-BIC scenario. We still use all 5 thresholds for MIQP, but then always save the last one (threshold =0.2). This changes MIQP to only use the 0.2 threshold UNLESS BIC is turned on. This should speed up the algorithm significantly.

2) This turns off BIC selection during intermediate (non-terminal) steps of side chains. While we want to eliminate options for subsequent rounds, we don't want to enforce parsimony as much until the final step.

Due to the line: 

if do_BIC_selection is None:
            do_BIC_selection = self.options.bic_threshold

BIC is always turned on when solving MIQP for intermediate steps during side chain.




This PR also prevents us from going through 5 MIQP rounds with different thresholds and only implements a threshold of 0.2 for non-terminal MIQP in the side chain sample. 