### PR TITLE
missing import os breaks write in mmciffile.py

### DIFF
--- a/src/qfit/structure/mmciffile.py
+++ b/src/qfit/structure/mmciffile.py
@@ -11,6 +11,7 @@ with qFit Structures.
 import re
 import copy
 import itertools
+import os
 from collections import defaultdict
 from typing import Dict, List, Optional, Any, Tuple, Union, Iterator
 

--- a/src/qfit/structure/mmciffile.py
+++ b/src/qfit/structure/mmciffile.py
@@ -742,7 +742,7 @@ class mmCIFFile(list):
             symmetry = data_block.new_table("symmetry")
             symmetry.set_columns(["space_group_name_H-M"])
             row = symmetry.new_row()
-            row["space_group_name_H-M"] = structure.unit_cell.spg
+            row["space_group_name_H-M"] = structure.unit_cell.space_group
 
         # Add LINK records if available
         if structure.link_data and len(structure.link_data.get("record", [])) > 0:

--- a/src/qfit/structure/mmciffile.py
+++ b/src/qfit/structure/mmciffile.py
@@ -834,7 +834,7 @@ class mmCIFFile(list):
         column_map = {
             "group_PDB": "record",
             "id": "atomid",
-            "auth_atom_id": "name",
+            "label_atom_id": "name",
             "label_alt_id": "altloc",
             "label_comp_id": "resn",
             "label_asym_id": "chain",
@@ -852,6 +852,7 @@ class mmCIFFile(list):
         if self.use_auth:
             column_map.update({
                 "auth_atom_id": "name",
+                "auth_alt_id": "altloc",
                 "auth_comp_id": "resn",
                 "auth_asym_id": "chain",
                 "auth_seq_id": "resi",


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change
Bugfix as mmciffile.py write used os, and it was not imported. Additionally, the writer was trying to use a non-existent attribute in unit_cell, my mistake as I got confused about cryst info vs unit_cell.
<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes
mmciffile.py writer fixes
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
