### PR TITLE
README cleanups and qFit version reporting library change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@
 ![](https://github.com/ExcitedStates/qfit-3.0/workflows/tests/badge.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-qFit is a collection of programs for modeling multi-conformer protein structures. 
+qFit is a collection of programs for modeling multiconformer protein structures. 
 
-Electron density maps obtained from high-resolution X-ray diffraction data are a spatial and temporal average of all conformations within the crystal. qFit evaluates an extremely large number of combinations of sidechain conformers, backbone fragments and small-molecule ligands to locally explain the electron density.
+Electron density maps obtained from high-resolution X-ray diffraction data are a spatial and temporal average of all conformations within the crystal. 
+qFit evaluates an extremely large number of combinations of sidechain conformers, backbone fragments, and small-molecule ligand conformations to locally explain the electron density.
 
 
 If you use this software, please cite: 
-- [Wankowicz SA, Ravikumar A, Sharma S, Riley BT, Raju A, Hogan DW, van den Bedem H, Keedy DA, & Fraser JS. Uncovering Protein Ensembles: Automated Multiconformer Model Building for X-ray Crystallography and Cryo-EM. eLife. (2024).](https://www.biorxiv.org/content/10.1101/2023.06.28.546963v2.abstract)
-- [Riley BT, Wankowicz SA, et al. qFit 3: Protein and ligand multiconformer modeling for X-ray crystallographic and single-particle cryo-EM density maps. Protein Sci. 30, 270–285 (2021)](https://dx.doi.org/10.1002/pro.4001)
-- [Keedy, D. A., Fraser, J. S. & van den Bedem, H. Exposing Hidden Alternative Backbone Conformations in X-ray Crystallography Using qFit. PLoS Comput. Biol. 11, e1004507 (2015)](https://dx.doi.org/10.1371/journal.pcbi.1004507)
+- [Wankowicz SA, Ravikumar A, Sharma S, Riley BT, Raju A, Hogan DW, van den Bedem H, Keedy DA, & Fraser JS. Uncovering Protein Ensembles: Automated Multiconformer Model Building for X-ray Crystallography and Cryo-EM. eLife. (2024)](https://doi.org/10.7554/eLife.90606.3)
+- [Riley BT, Wankowicz SA, de Oliveira SHP, van Zundert GCP, Hogan DW, Fraser JS, Keedy DA, van den Bedem H. qFit 3: Protein and ligand multiconformer modeling for X-ray crystallographic and single-particle cryo-EM density maps. Protein Sci. 30, 270–285 (2021)](https://dx.doi.org/10.1002/pro.4001)
+- [Keedy DA, Fraser JS, & van den Bedem H. Exposing Hidden Alternative Backbone Conformations in X-ray Crystallography Using qFit. PLoS Comput. Biol. 11, e1004507 (2015)](https://dx.doi.org/10.1371/journal.pcbi.1004507)
 
 qFit-ligand:
-- [Flowers J, Echols N, Correy G, Jaishankar P, Togo T, Renslo A, van den Bedem H,, Fraser J, Wankowicz SA.* (2024) Expanding Automated Multiconformer Ligand Modeling to Macrocycles and Fragments. BioRxiv.](https://www.biorxiv.org/content/10.1101/2024.09.20.613996v1)
-- [van Zundert, G. C. P. et al. qFit-ligand Reveals Widespread Conformational Heterogeneity of Drug-Like Molecules in X-Ray Electron Density Maps. J. Med. Chem. 61, 11183–11198 (2018)](https://dx.doi.org/10.1021/acs.jmedchem.8b01292)
+- [Flowers J, Echols N, Correy G, Jaishankar P, Togo T, Renslo A, van den Bedem H, Fraser J, Wankowicz SA. (2024) Expanding Automated Multiconformer Ligand Modeling to Macrocycles and Fragments. bioRxiv.](https://www.biorxiv.org/content/10.1101/2024.09.20.613996)
+- [van Zundert GCP, Hudson BM, de Oliveira SHP, Keedy DA, Fonseca R, Heliou A, Suresh P, Borrelli K, Day T, Fraser JS, van den Bedem H. qFit-ligand Reveals Widespread Conformational Heterogeneity of Drug-Like Molecules in X-Ray Electron Density Maps. J. Med. Chem. 61, 11183–11198 (2018)](https://dx.doi.org/10.1021/acs.jmedchem.8b01292)
 
 As this software relies on CVXPY, please also cite:
 - [Agrawal, Verschueren, Diamond, & Boyd. A Rewriting System for Convex Optimization Problems. Journal of Control and Decision. (2018).](https://arxiv.org/abs/1709.04494)
@@ -47,6 +48,7 @@ We recommend using the _conda_ package manager to install _qFit_.
      conda activate qfit
 
 6. Install qFit
+
    pip install .
    
 
@@ -70,26 +72,27 @@ is most suited for your task. Please refer below for a basic usage example. More
 are shown in [example](example/README.md) directory.
 
 To remove single-conformer model bias, qFit should be used with a composite omit
-map. One way of generating such map is using the [Phenix software suite](https://www.phenix-online.org/):
+map. One way of generating such a map is using the [Phenix software suite](https://www.phenix-online.org/):
 
 `phenix.composite_omit_map input.mtz model.pdb omit-type=refine`
 
-An example test case (1G8A) can be found in the [qfit protein example](example/qfit_protein_example/) directory. Additionally, you can find the [cyroEM protein example](example/qfit_cryoem_example/)(PDB: 7A4M) and the [ligand example](example/qfit_ligand_example/) qFit-ligand example (PDB: 4MS6) in the *example* directory. 
+An example test case (PDB: 1G8A) can be found in the [qFit protein example](example/qfit_protein_example/) directory. Additionally, you can find the [cryo-EM qFit protein example](example/qfit_cryoem_example/) (PDB: 7A4M) 
+and the [qFit ligand example](example/qfit_ligand_example/) (PDB: 4MS6) in the [example](example/README.md) directory. 
 
 
 ### Recommended settings
 
-To model alternate conformers for all residues in a *X-ray crystallography* model using qFit,
+To model alternate conformers for all residues in an *X-ray crystallography* model using qFit,
 the following command should be used:
 
 `qfit_protein [COMPOSITE_OMIT_MAP_FILE] -l [LABELS] [PDB_FILE] -p [# OF THREADS]`
 
 This command will produce a multiconformer model that spans the entirety of the
-input target protein. The final model, with consistent labeling of multiple conformers
+input target protein. The final model, with consistent labeling of multiple conformers,
 is output into *multiconformer_model2.pdb*. This file should then
-be used as input to the post-qFit refinement script provided in [scripts](scripts/post) folder. 
+be used as input to the post-qFit refinement script provided in the [scripts](scripts/post) directory. 
 
-qFit can be run on a single thread, but speeds up significantly with multiple threads. Do to this, use the *-p* flag.
+qFit can be run on a single thread, but speeds up significantly with multiple threads. To do this, use the *-p* flag.
 
 If you wish to specify a different directory for the output, this can be done
 using the flag *-d*.
@@ -105,7 +108,7 @@ After *multiconformer_model2.pdb* has been generated, refine this model using:
 
 `qfit_final_refine_xray.sh example/qfit_protein_example/18GA.mtz example/qfit_protein_example/multiconformer_model2.pdb`
 
-Additionally, the qFit_occupancy.params file must exist in the folder (this is an output of qFit protein).
+Additionally, the qFit_occupancy.params file must exist in the directory (this is an output of qFit protein).
 
 Bear in mind that this final step currently depends on an existing installation
 of the Phenix software suite. This script is currently written to work with version Phenix 1.21.
@@ -120,9 +123,9 @@ After *multiconformer_model2.pdb* has been generated, refine this model using:
 
 `qfit_final_refine_cryoEM.sh example/qfit_cryoem_example/7A4M_box.ccp4 example/qfit_cryoem_example/multiconformer_model2.pdb example/qfit_cryoem_example/7A4M_box.pdb`
 
-More advanced features of qFit (modeling single residue, more advanced options, and further explainations) are explained in [TUTORIAL](example/README.md).
+More advanced features of qFit (modeling single residue, more advanced options, and further explainations) are explained in the [example](example/README.md) directory.
 
-To model alternate conformations of ligands using qFit, we recommend running composite omit map excluding bulk solvent with the following command:
+To model alternate conformations of ligands using qFit, we recommend generating a composite omit map excluding bulk solvent with the following command:
 
 `phenix.composite_omit_map input.mtz model.pdb omit-type=refine exclude_bulk_solvent=True`
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note: If you encounter difficulties installing on an M1 Mac, you may try the fol
 
 If you prefer to manage your environments using other methods, qFit has the following prerequisites:
 
-* [Python 3.6+](https://python.org)
+* [Python 3.9+](https://python.org)
 * [numpy](https://numpy.org)
 * [scipy](https://scipy.org)
 * [cvxpy](https://www.cvxpy.org)

--- a/README.md
+++ b/README.md
@@ -24,32 +24,33 @@ As this software relies on CVXPY, please also cite:
 - [Diamond & Boyd. CVXPY: A Python-Embedded Modeling Language for Convex Optimization. Journal of Machine Learning Research. (2016)](https://www.jmlr.org/papers/volume17/15-408/15-408.pdf)
 
 
-## Installation (conda recommended)
+## Installation
 
-We recommend using the _conda_ package manager to install _qFit_.
+We recommend using the _mamba_ package manager to install _qFit_.
 
-1. Clone the latest release of the qFit source, and install to your conda env
+1. Clone the latest release of the qFit source:
 
-   git clone -b main https://github.com/ExcitedStates/qfit-3.0.git
+`git clone -b main https://github.com/ExcitedStates/qfit-3.0.git`
    
-   cd qfit-3.0
+`cd qfit-3.0`
    
-3. Create the Conda environment using the downloaded file:
+2. Create the mamba environment using the downloaded file:
 
-   mamba env create -f environment.yml
+`mamba env create -f environment.yml`
 
-4. After creating the Conda environment, activate it:
+3. Activate the new mamba environment:
 
-   conda activate qfit
+`mamba activate qfit`
 
-5. If you installing on M1 Mac:
+Note: If you encounter difficulties installing on an M1 Mac, you may try the following:
    
-     conda activate qfit; conda env config vars set CONDA_SUBDIR=osx-64; conda deactivate
-     conda activate qfit
+`conda activate qfit; conda env config vars set CONDA_SUBDIR=osx-64; conda deactivate`
 
-6. Install qFit
+`conda activate qfit`
 
-   pip install .
+4. Install qFit into the mamba environment:
+
+   `pip install .`
    
 
 ### Advanced

--- a/src/qfit/logtools.py
+++ b/src/qfit/logtools.py
@@ -1,12 +1,13 @@
 import sys
 import os
-import pkg_resources
 import time
 import logging
 import logging.handlers
 import multiprocessing as mp
 import numpy as np
 import threading
+#import pkg_resources  # deprecated
+from importlib.metadata import version, PackageNotFoundError
 
 from . import LOGGER as MODULELOGGER
 
@@ -57,9 +58,15 @@ def log_run_info(options, logger):
         options (_BaseQFitOptions): A QFitOptions object for this run.
         logger (logging.Logger): The logger that will log the messages.
     """
-    version = pkg_resources.require("qfit")[0].version
+    
+    #version = pkg_resources.require("qfit")[0].version  # deprecated
+    try:
+        qfit_version = version("qfit")
+    except PackageNotFoundError:
+        qfit_version = "unknown"
+
     cmd = " ".join(sys.argv)
-    logger.info(f"===== qFit version: {version} =====")
+    logger.info(f"===== qFit version: {qfit_version} =====")
     logger.info(time.strftime("%c %Z"))
     logger.info(f"{cmd}")
     logger.info(f"===== qFit parameters: =====")


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----

### Description of the Change

Reporting of the qFit version had used the pkg_resources library, but that is set to be deprecated soon, so we have now changed to importlib.

The README had recommended conda, but we now prefer mamba. This has now been changed.

The README had several minor formatting issues and typos. These are now fixed.

### Release Notes

- Fixed typos in README.
- Changed from conda to mamba in README.
- Switched from deprecated library for reporting qFit version.