### PR TITLE
Add import iotbx.pdb.hierarchy to structure.py

### DIFF
--- a/scripts/post/qfit_final_refine_ligand.sh
+++ b/scripts/post/qfit_final_refine_ligand.sh
@@ -52,7 +52,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Display relevant file information
-echo "whats up"
 echo "mapfile              : ${mapfile} $([[ -f ${mapfile} ]] || echo '[NOT FOUND]')";
 echo "qfit unrefined model : ${multiconf} $([[ -f ${multiconf} ]] || echo '[NOT FOUND]')";
 echo "qfit unrefined ligand model : ${multiconf_lig} $([[ -f ${multiconf_lig} ]] || echo '[NOT FOUND]')";

--- a/scripts/post/qfit_final_refine_ligand.sh
+++ b/scripts/post/qfit_final_refine_ligand.sh
@@ -11,6 +11,14 @@ qfit_usage() {
 }
 
 #___________________________SOURCE__________________________________
+# Check that Phenix is loaded
+if [ -z "${PHENIX}" ]; then
+  echo >&2 "I require PHENIX but it's not loaded.";
+  echo >&2 "Please \`source phenix_env.sh\` from where it is installed.";
+  exit 1;
+else
+  export PHENIX_OVERWRITE_ALL=true;
+fi
 
 # Check that qFit is loaded.
 command -v remove_duplicates >/dev/null 2>&1 || {
@@ -130,7 +138,7 @@ if [ -z "${xray_data_labels}" ]; then
 else
   echo "data labels: ${xray_data_labels}"
   # Start writing refinement parameters into a parameter file
-  echo "data_manager.miller_array.labels.name=${xray_data_labels}" > ${pdb_name}_refine.params
+  echo "refinement.input.xray_data.labels=$xray_data_labels" > ${pdb_name}_refine.params
 fi
 
 #_____________________________DETERMINE R FREE FLAGS______________________________
@@ -144,14 +152,14 @@ for field in ${rfreetypes}; do
     break
   fi
 done
-echo "data_manager.fmodel.xray_data.r_free_flags.generate=${gen_Rfree}" >> ${pdb_name}_refine.params
+echo "refinement.input.xray_data.r_free_flags.generate=${gen_Rfree}" >> ${pdb_name}_refine.params
 
 #__________________________________REMOVE DUPLICATE HET ATOMS__________________________________
 remove_duplicates "${multiconf}"
 
 #__________________________________NORMALIZE OCCUPANCIES________________________________________
 echo "Normalizing occupancies, before refinement "
-echo "${multiconf}.fixed"
+
 redistribute_cull_low_occupancies -occ 0.09 "${multiconf}.fixed"
 mv -v "${multiconf}.f_norm.pdb" "${multiconf}.fixed"
 
@@ -198,14 +206,13 @@ phenix.refine  "${multiconf}.f_modified.pdb" \
                "output.serial=2" \
                "refinement.main.number_of_macro_cycles=5" \
                "refinement.main.nqh_flips=True" \
-               "data_manager.fmodel.xray_data.r_free_flags.generate=true" \
+               "xray_data.r_free_flags.generate=True" \
                "refinement.refine.${adp}" \
                "refinement.hydrogens.refine=riding" \
                "refinement.main.ordered_solvent=True" \
                "refinement.target_weights.optimize_xyz_weight=true" \
                "refinement.target_weights.optimize_adp_weight=true" \
                "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" \
-               "data_manager.miller_array.labels.name=${xray_data_labels}" \
                 --overwrite
 
 #________________________________CHECK FOR REDUCE ERRORS______________________________
@@ -232,18 +239,17 @@ phenix.refine  "${multiconf}.f_modified.pdb" \
                "output.serial=2" \
                "refinement.main.number_of_macro_cycles=5" \
                "refinement.main.nqh_flips=False" \
-               "data_manager.fmodel.xray_data.r_free_flags.generate=true" \
+               "xray_data.r_free_flags.generate=True" \
                "refinement.refine.${adp}" \
                "refinement.hydrogens.refine=riding" \
                "refinement.main.ordered_solvent=True" \
                "refinement.target_weights.optimize_xyz_weight=true" \
                "refinement.target_weights.optimize_adp_weight=true" \
                "refinement.input.monomers.file_name='${multiconf}.f_modified.ligands.cif'" \
-               "data_manager.miller_array.labels.name='${xray_data_labels}'" \
+               "refinement.input.xray_data.labels=${xray_data_labels}" \
                --overwrite
 
 fi
-
 
 #______________________________REMOVE AND REDISTRIBUTE LOW OCC_____________________
 redistribute_cull_low_occupancies -occ 0.09 "${pdb_name}_002.pdb"

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import itertools
 import os
+import iotbx.pdb.hierarchy
 
 from scitbx.array_family import flex
 import numpy as np


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
Yes
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
Yes
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
Yes
- [x] Fill out the template below.

----

### Description of the Change

<!--

If you are fixing a bug, link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

--> https://github.com/ExcitedStates/qfit-3.0/issues/517

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

--> Structure.split_models() calls a module that is not imported. This PR adds that import

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in qFit's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

--> Fixes a bug that causes a fatal error in structure.split_models()

----

<!-- ht: This template borrows significantly from the [Atom project](https://github.com/atom/atom/blob/master/PULL_REQUEST_TEMPLATE.md). -->
