### PR TITLE
qFit correctly models INS residues

### DIFF
--- a/src/qfit/command_line/qfit_ligand.py
+++ b/src/qfit/command_line/qfit_ligand.py
@@ -147,8 +147,11 @@ def prepare_qfit_ligand(options):
         structure = structure.extract("e", "H", "!=")
 
     chainid, resi = options.selection.split(",")
+    chainid = chainid.strip()
+    resi = resi.strip()
     if ":" in resi:
         resi, icode = resi.split(":")
+        icode = icode.strip()
         residue_id = (int(resi), icode)  # pylint: disable=unused-variable
     else:
         residue_id = int(resi)  # pylint: disable=unused-variable
@@ -161,12 +164,12 @@ def prepare_qfit_ligand(options):
         .extract("chain", chainid, "==")
         .extract("resi", resi_int, "==")
     )
-    if icode:
+    if icode != "":
         structure_ligand = structure_ligand.extract("icode", icode, "==")
 
     # Select everything that is not the ligand of interest.
     exclude_mask = (structure.chain == chainid) & (structure.resi == resi_int)
-    if icode:
+    if icode != "":
         exclude_mask &= (structure.icode == icode)
     receptor = structure.extract(np.flatnonzero(~exclude_mask))
 
@@ -185,7 +188,7 @@ def prepare_qfit_ligand(options):
                 & (structure_ligand.resi == resi_int)
                 & (structure_ligand.altloc == altloc)
             )
-            if icode:
+            if icode != "":
                 remove_mask &= (structure_ligand.icode == icode)
             structure_ligand = structure_ligand.extract(
                 np.flatnonzero(~remove_mask)
@@ -264,12 +267,12 @@ def main():
         fname = os.path.join(options.directory, f"conformer_{n}.{pdb_ext}")
         conformer.tofile(fname)
         conformer.altloc = altloc
-        if not multiconformer_ligand_bound:
+        if multiconformer_ligand_bound is None:
             multiconformer_ligand_bound = Structure.fromstructurelike(conformer.copy())
         else:
             multiconformer_ligand_bound = multiconformer_ligand_bound.combine(conformer)
 
-    if not multiconformer_ligand_bound:
+    if multiconformer_ligand_bound is None:
         logger.error("qFit-ligand failed to produce any valid conformers.")
         return 1
 
@@ -284,7 +287,7 @@ def main():
     fname = os.path.join(
         options.directory, f"{pdb_id}multiconformer_ligand_bound_with_protein.pdb"
     )
-    if icode:
+    if icode != "":
         fname = os.path.join(
             options.directory, f"{pdb_id}multiconformer_ligand_bound_with_protein.pdb"
         )

--- a/src/qfit/command_line/qfit_ligand.py
+++ b/src/qfit/command_line/qfit_ligand.py
@@ -153,18 +153,22 @@ def prepare_qfit_ligand(options):
     else:
         residue_id = int(resi)  # pylint: disable=unused-variable
         icode = ""
+    resi_int = int(resi)
 
-    # Extract the ligand:
-    structure_ligand = structure.extract(f"resi {resi} and chain {chainid}")
-
+    # Extract the ligand using attribute-based selection (handles icodes).
+    structure_ligand = (
+        structure
+        .extract("chain", chainid, "==")
+        .extract("resi", resi_int, "==")
+    )
     if icode:
-        structure_ligand = structure_ligand.extract("icode", icode)
-    sel_str = f"resi {resi} and chain {chainid}"
-    sel_str = f"not ({sel_str})"
+        structure_ligand = structure_ligand.extract("icode", icode, "==")
 
-    receptor = structure.extract(
-        sel_str
-    )  # selecting everything that is not the ligand of interest
+    # Select everything that is not the ligand of interest.
+    exclude_mask = (structure.chain == chainid) & (structure.resi == resi_int)
+    if icode:
+        exclude_mask &= (structure.icode == icode)
+    receptor = structure.extract(np.flatnonzero(~exclude_mask))
 
     # Check which altlocs are present in the ligand. If none, take the
     # A-conformer as default.
@@ -176,9 +180,16 @@ def prepare_qfit_ligand(options):
         except ValueError:
             pass
         for altloc in altlocs[1:]:
-            sel_str = f"resi {resi} and chain {chainid} and altloc {altloc}"
-            sel_str = f"not ({sel_str})"
-            structure_ligand = structure_ligand.extract(sel_str)
+            remove_mask = (
+                (structure_ligand.chain == chainid)
+                & (structure_ligand.resi == resi_int)
+                & (structure_ligand.altloc == altloc)
+            )
+            if icode:
+                remove_mask &= (structure_ligand.icode == icode)
+            structure_ligand = structure_ligand.extract(
+                np.flatnonzero(~remove_mask)
+            )
     altloc = structure_ligand.altloc[-1]
 
     ligand = Ligand.from_structure(structure_ligand, options.cif_file)

--- a/src/qfit/command_line/qfit_protein.py
+++ b/src/qfit/command_line/qfit_protein.py
@@ -275,8 +275,11 @@ class QFitProtein:
                 residue_id = int(resi)
                 icode = ""
             # Extract the residue:
+            resi_sel = f"resi {resi} and chain {chainid}"
+            if icode:
+                resi_sel += f" and icode {icode}"
             residues = list(
-                self.structure.extract(f"resi {resi} and chain {chainid}")
+                self.structure.extract(resi_sel)
                 .extract("resn", "HOH", "!=")
                 .single_conformer_residues
             )
@@ -292,17 +295,23 @@ class QFitProtein:
         for residue in residues:
             grouped_coords = {}
             grouped_u_matrices = {}
-            residue_chain_key = (residue.resi[0], residue.chain[0].replace('"', ""))
+            residue_chain_key = (
+                residue.chain[0].replace('"', ""),
+                residue.resi[0],
+                residue.id[1],
+            )
             if residue_chain_key not in backbone_coor_dict:
                 backbone_coor_dict[residue_chain_key] = {}
             for altloc in np.unique(
                 self.structure.extract("chain", residue.chain[0], "==")
                 .extract("resi", residue.resi[0], "==")
+                .extract("icode", residue.id[1], "==")
                 .altloc
             ):
                 grouped_coords[altloc] = (
                     self.structure.extract("chain", residue.chain[0], "==")
                     .extract("resi", residue.resi[0], "==")
+                    .extract("icode", residue.id[1], "==")
                     .extract("altloc", altloc)
                     .coor
                 )
@@ -313,6 +322,7 @@ class QFitProtein:
                 atom = (
                     self.structure.extract("chain", residue.chain[0], "==")
                     .extract("resi", residue.resi[0], "==")
+                    .extract("icode", residue.id[1], "==")
                     .extract("name", atom_name)
                     .extract("altloc", altloc)
                 )
@@ -580,24 +590,34 @@ def _run_qfit_residue(residue, structure, xmap, options, logqueue,
 
     # add multiple backbone positions
 
-    chain_resi_id = f"{resi}, '{chainid}'"
-    chain_resi_id = (resi, chainid)
+    chain_resi_id = (chainid, resi, icode)
+    if chain_resi_id not in backbone_coor_dict:
+        logger.warning(
+            f"[{residue.shortcode}] No backbone coordinates found for insertion; "
+            "falling back to base residue index."
+        )
+        chain_resi_id = (chainid, resi, "")
     options.backbone_coor_dict = backbone_coor_dict[chain_resi_id]
     # Exception handling in case qFit-residue fails:
-    qfit = QFitRotamericResidue(residue, structure_new, xmap, options)
+    qfit = None
     try:
+        qfit = QFitRotamericResidue(residue, structure_new, xmap, options)
         qfit.run()
     except RuntimeError as e:
         tb = "".join(traceback.format_exception(e.__class__, e, e.__traceback__))
+        identifier = getattr(qfit, "identifier", residue.shortcode)
         logger.warning(
-            f"[{qfit.identifier}] "
+            f"[{identifier}] "
             f"Unable to produce an alternate conformer. "
             f"Using deposited conformer A for this residue."
         )
         logger.info(
-            f"[{qfit.identifier}] This is a result of the following exception:\n"
+            f"[{identifier}] This is a result of the following exception:\n"
             f"{tb})"
         )
+        if qfit is None:
+            residue.tofile(fname)
+            return f"[{identifier}]: 1 conformer"
         qfit.reset_residue(residue, structure)
 
     # Save multiconformer_residue

--- a/src/qfit/command_line/qfit_protein.py
+++ b/src/qfit/command_line/qfit_protein.py
@@ -274,12 +274,16 @@ class QFitProtein:
             else:
                 residue_id = int(resi)
                 icode = ""
-            # Extract the residue:
-            resi_sel = f"resi {resi} and chain {chainid}"
+            # Extract the residue using attribute-based selection to handle icodes.
+            structure_resi = (
+                self.structure
+                .extract("chain", chainid, "==")
+                .extract("resi", int(resi), "==")
+            )
             if icode:
-                resi_sel += f" and icode {icode}"
+                structure_resi = structure_resi.extract("icode", icode, "==")
             residues = list(
-                self.structure.extract(resi_sel)
+                structure_resi
                 .extract("resn", "HOH", "!=")
                 .single_conformer_residues
             )
@@ -528,6 +532,22 @@ def _run_qfit_residue(residue, structure, xmap, options, logqueue,
     # Set up logger hierarchy in this subprocess
     poolworker_setup_logging(logqueue)
 
+    def _select_residue_structure(structure_obj, residue_obj, chainid, resi, icode):
+        """
+        Select the residue from structure_obj, handling insertion codes.
+        Falls back to atom serial selection if resi/icode filtering yields no atoms.
+        """
+        structure_resi = (
+            structure_obj
+            .extract("chain", chainid, "==")
+            .extract("resi", resi, "==")
+        )
+        if icode:
+            structure_resi = structure_resi.extract("icode", icode, "==")
+        if structure_resi.natoms == 0:
+            structure_resi = structure_obj.extract("atomid", residue_obj.atomid, "==")
+        return structure_resi
+
     # Exit early if we have already run qfit for this residue
     fname = os.path.join(options.directory,
                          residue.shortcode,
@@ -556,11 +576,10 @@ def _run_qfit_residue(residue, structure, xmap, options, logqueue,
             logger.info(
                 f"Residue {residue.shortcode}: Q-score is too low for this residue. Using deposited structure."
             )
-            resi_selstr = f"chain {chainid} and resi {resi}"
-            if icode:
-                resi_selstr += f" and icode {icode}"
             structure_new = structure
-            structure_resi = structure.extract(resi_selstr)
+            structure_resi = _select_residue_structure(
+                structure, residue, chainid, resi, icode
+            )
             chain = structure_resi[chainid]
             conformer = chain.conformers[0]
             residue = conformer[residue.id]
@@ -569,11 +588,10 @@ def _run_qfit_residue(residue, structure, xmap, options, logqueue,
 
     # Copy the structure
     (chainid, resi, icode) = residue.identifier_tuple
-    resi_selstr = f"chain {chainid} and resi {resi}"
-    if icode:
-        resi_selstr += f" and icode {icode}"
     structure_new = structure.copy()
-    structure_resi = structure_new.extract(resi_selstr)
+    structure_resi = _select_residue_structure(
+        structure_new, residue, chainid, resi, icode
+    )
     chain = structure_resi[chainid]
     conformer = chain.conformers[0]
     residue = conformer[residue.id]
@@ -584,9 +602,14 @@ def _run_qfit_residue(residue, structure, xmap, options, logqueue,
         except ValueError:
             pass
         for altloc in altlocs[1:]:
-            sel_str = f"resi {resi} and chain {chainid} and altloc {altloc}"
-            sel_str = f"not ({sel_str})"
-            structure_new = structure_new.extract(sel_str)
+            remove_mask = (
+                (structure_new.chain == chainid)
+                & (structure_new.resi == resi)
+                & (structure_new.altloc == altloc)
+            )
+            if icode:
+                remove_mask &= (structure_new.icode == icode)
+            structure_new = structure_new.extract(np.flatnonzero(~remove_mask))
 
     # add multiple backbone positions
 

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -316,10 +316,24 @@ class _BaseQFit(ABC):
         Optimized to pre-allocate memory and use efficient numpy operations.
         """
         logger.info("Converting conformers to density")
-        nmodels = len(self._coor_set)
+        if not self._coor_set:
+            logger.warning(
+                "No conformers available; falling back to input conformer."
+            )
+            coor_set = [self.conformer.coor]
+            b_set = [self.conformer.b]
+            occupancies = [self.conformer.q]
+        else:
+            coor_set = self._coor_set
+            b_set = self._bs
+            occupancies = self._occupancies
+        self._coor_set = coor_set
+        self._bs = b_set
+        self._occupancies = occupancies
+        nmodels = len(coor_set)
         
         # Get mask once for all conformers
-        mask = self._transformer.get_conformers_mask(self._coor_set, self._rmask)
+        mask = self._transformer.get_conformers_mask(coor_set, self._rmask)
         nvalues = mask.sum()
         logger.debug("%d grid points masked out of %s", nvalues, mask.size)
         
@@ -340,7 +354,7 @@ class _BaseQFit(ABC):
         # Process conformers - the transformer's get_conformers_densities is a generator
         # that yields densities one at a time to save memory
         for n, density in enumerate(self._transformer.get_conformers_densities(
-                                    self._coor_set, self._bs)):
+                                    coor_set, b_set)):
             if save_debug_maps_prefix:
                 self.xmap.save_masked_map(
                     mask,

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -239,9 +239,9 @@ class _BaseQFit(ABC):
         conformers = []
         for q, coor, b in zip(self._occupancies, self._coor_set, self._bs):
             conformer = self.conformer.copy()
-            conformer = conformer.extract(
-                f"resi {self.conformer.resi[0]} and " f"chain {self.conformer.chain[0]}"
-            )
+            if self.conformer.natoms:
+                # Use atom serial selection to avoid insertion-code issues.
+                conformer = conformer.extract("atomid", self.conformer.atomid, "==")
             conformer.q = q
             conformer.coor = coor
             conformer.b = b
@@ -944,10 +944,12 @@ class QFitRotamericResidue(_BaseQFit):
         resi, icode = residue.id
         chainid = self.segment.chain[0]
         if icode:
-            selection_str = f"not (resi {resi} and icode {icode} and chain {chainid})"
+            selection_str = (
+                f"not (resi {resi} and icode '{icode}' and chain '{chainid}')"
+            )
             receptor = self.structure.extract(selection_str)
         else:
-            sel_str = f"not (resi {resi} and chain {chainid})"
+            sel_str = f"not (resi {resi} and chain '{chainid}')"
             receptor = self.structure.extract(sel_str).copy()
 
         # Find symmetry mates of the receptor

--- a/src/qfit/qfit.py
+++ b/src/qfit/qfit.py
@@ -316,7 +316,7 @@ class _BaseQFit(ABC):
         Optimized to pre-allocate memory and use efficient numpy operations.
         """
         logger.info("Converting conformers to density")
-        if not self._coor_set:
+        if self._coor_set is None or len(self._coor_set) == 0:
             logger.warning(
                 "No conformers available; falling back to input conformer."
             )

--- a/src/qfit/structure/structure.py
+++ b/src/qfit/structure/structure.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import itertools
+import logging
 import os
 import iotbx.pdb.hierarchy
 
@@ -14,6 +15,8 @@ from .ligand import Ligand
 from .residue import Residue, RotamerResidue, residue_type
 from .rotamers import ROTAMERS
 from qfit.utils.normalize_to_precision import normalize_to_precision
+
+logger = logging.getLogger(__name__)
 
 
 class Structure(BaseStructure):
@@ -89,7 +92,7 @@ class Structure(BaseStructure):
             chain_id =chain.id
             for conformer in chain.conformers:
                 for residue in conformer.residues:
-                    key = (chain_id, residue.resi[0])
+                    key = (chain_id, residue.id)
                     if key in residues_d:
                       continue
                     residues_d.add(key)
@@ -113,7 +116,14 @@ class Structure(BaseStructure):
         # non-protein atoms separately, the internal grouping should be changed
         # to reflect that as well
         chains_d = defaultdict(list)
-        for iotbx_chain in hierarchy.only_model().chains():
+        models = list(hierarchy.models())
+        if len(models) != 1:
+            logger.warning(
+                "Multiple models detected (%d); using first model only.",
+                len(models),
+            )
+        model = models[0]
+        for iotbx_chain in model.chains():
             chains_d[iotbx_chain.id].append(iotbx_chain)
         sel_cache = hierarchy.atom_selection_cache()
         for chain_id, chains in chains_d.items():
@@ -156,6 +166,8 @@ class Structure(BaseStructure):
         sel_str = f"resi {resid} and chain {chainid}"
         conformers = self.extract(sel_str)
         altlocs = sorted(list(set(conformers.altloc)))
+        if len(altlocs) == 0:
+            return self.copy()
         altloc_keep = altlocs[0]
         altlocs_remove = altlocs[1:]
         if len(altlocs_remove) == 0:
@@ -244,16 +256,27 @@ class Structure(BaseStructure):
                         multiconformer.set_occupancies(1.0, mask.iselection())
                         altlocs.remove("")
                     conformers = []
+                    valid_altlocs = []
                     for altloc in altlocs:
                         sel_str = f"{base_sel_str} and altloc {altloc}"
-                        conformers.append(self.extract(sel_str))
+                        conf = self.extract(sel_str)
+                        if conf.q.size == 0:
+                            continue
+                        conformers.append(conf)
+                        valid_altlocs.append(altloc)
+                    if not conformers:
+                        continue
                     alt_sum = 0
                     for i in range(0, len(conformers)):
                         alt_sum += np.round(conformers[i].q[0], 2)
                         new_occ = np.append(new_occ, (np.round(conformers[i].q[0], 2)))
-                    if alt_sum != 1.0:  # we need to normalize
+                    if alt_sum == 0:
+                        new_occ = normalize_to_precision(
+                            np.full(len(conformers), 1.0 / len(conformers)), 2
+                        )
+                    elif alt_sum != 1.0:  # we need to normalize
                         new_occ = []
-                        for i in range(0, len(altlocs)):
+                        for i in range(0, len(valid_altlocs)):
                             new_occ = np.append(
                                 new_occ, ((np.round(conformers[i].q[0], 2)) / alt_sum)
                             )
@@ -261,7 +284,7 @@ class Structure(BaseStructure):
                             np.array(new_occ), 2
                         )  # deal with imprecision
                     for i in range(0, len(new_occ)):
-                        sel_str = f"{base_sel_str} and altloc {altlocs[i]}"
+                        sel_str = f"{base_sel_str} and altloc {valid_altlocs[i]}"
                         mask = self.get_atom_selection(sel_str)
                         multiconformer.set_occupancies(new_occ[i], mask.iselection())
         return multiconformer

--- a/src/qfit/xtal/legacy_transformer.py
+++ b/src/qfit/xtal/legacy_transformer.py
@@ -428,7 +428,11 @@ class Transformer:
         Get the combined map mask (as a numpy boolean array) for a series of
         coordinates for the current structure.
         """
-        assert len(coor_set) > 0
+        if len(coor_set) == 0:
+            logger.warning(
+                "No conformers provided for mask; using input conformer."
+            )
+            coor_set = [self.structure.coor]
         self.reset(full=True)
         logger.debug(f"Masking {len(coor_set)} conformations")
         for coor in coor_set:
@@ -444,7 +448,16 @@ class Transformer:
         B-factors and compute the density for each, without modifying the
         internal data structures.
         """
-        assert len(coor_set) == len(b_set) and len(coor_set) > 0
+        if len(coor_set) == 0:
+            logger.warning(
+                "No conformers provided for densities; using input conformer."
+            )
+            coor_set = [self.structure.coor]
+            b_set = [self.structure.b]
+        if len(coor_set) != len(b_set):
+            raise RuntimeError(
+                "Coordinate and B-factor sets have different lengths."
+            )
         for coor, b in zip(coor_set, b_set):
             self.structure.coor = coor
             self.structure.b = b

--- a/src/qfit/xtal/transformer.py
+++ b/src/qfit/xtal/transformer.py
@@ -266,7 +266,11 @@ class _BaseTransformer(ABC):
         Get the combined map mask (as a numpy boolean array) for a series of
         coordinates for the current structure.
         """
-        assert len(coor_set) > 0
+        if len(coor_set) == 0:
+            logger.warning(
+                "No conformers provided for mask; using input conformer."
+            )
+            coor_set = [self.structure.coor]
         self.reset(full=True)
         logger.debug(f"Masking {len(coor_set)} conformations")
         xrs, dxyz = self._get_xray_structure_in_box()
@@ -303,6 +307,16 @@ class Transformer(_BaseTransformer):
         B-factors and compute the density for each, without modifying the
         internal data structures.
         """
+        if len(coor_set) == 0:
+            logger.warning(
+                "No conformers provided for densities; using input conformer."
+            )
+            coor_set = [self.structure.coor]
+            b_set = [self.structure.b]
+        if len(coor_set) != len(b_set):
+            raise RuntimeError(
+                "Coordinate and B-factor sets have different lengths."
+            )
         xrs, dxyz = self._get_xray_structure_in_box()
         active_flag = self.structure.active
         for (coor, b) in zip(coor_set, b_set):


### PR DESCRIPTION
### Pull Request Checklist

- [x] Will your PR merge into the `dev` branch?  
    Exceptions will be made for _urgent_ bugfixes.
- [x] Have you **forked from `dev`**?  
    If not, please [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your PR [onto](https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce) the most recent `dev` tip.
- [x] Does your PR title succinctly describe the changes?  
    *Explain to a new user by completing the sentence: 'This PR will: ...'*
- [x] Fill out the template below.

----
qFit was ignoring any residues with INS codes (and not including them in output files). Selection strings throughout the pipeline now consider INS codes